### PR TITLE
Fix confluent_kafka_topic notes about attributes

### DIFF
--- a/docs/resources/confluent_kafka_topic.md
+++ b/docs/resources/confluent_kafka_topic.md
@@ -63,7 +63,7 @@ The following arguments are supported:
     - `key` - (Required String) The Kafka API Key.
     - `secret` - (Required String, Sensitive) The Kafka API Secret.
 
--> **Note:** Omit the `rest_endpoint` attribute and `credentials` block if the `kafka_rest_endpoint`, `kafka_rest_endpoint`, and `kafka_rest_endpoint` attributes are all set in a `provider` block (see [option #2](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#example-usage)).
+-> **Note:** Omit the `rest_endpoint` attribute and `credentials` block if the `kafka_rest_endpoint`, `kafka_api_key`, and `kafka_api_secret` attributes are all set in a `provider` block (see [option #2](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#example-usage)).
 
 -> **Note:** A Kafka API key consists of a key and a secret. Kafka API keys are required to interact with Kafka clusters in Confluent Cloud. Each Kafka API key is valid for one specific Kafka cluster.
 


### PR DESCRIPTION
`kafka_rest_endpoint` is repeated in the notes.
seems it should be `kafka_rest_endpoint` , `kafka_api_key`, and `kafka_api_secret` instead based on the doc https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#example-usage