### PR TITLE
feat: remove up state

### DIFF
--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -90,9 +90,8 @@ func waitForKafkaClusterToProvision(ctx context.Context, c *Client, environmentI
 
 func waitForKsqlClusterToProvision(ctx context.Context, c *Client, environmentId, clusterId string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{stateProvisioning},
-		// TODO: KSQL-1235: Remove stateUp when cc-scheduler is updated
-		Target:       []string{stateUp, stateProvisioned},
+		Pending:      []string{stateProvisioning},
+		Target:       []string{stateProvisioned},
 		Refresh:      ksqlClusterProvisionStatus(c.ksqlApiContext(ctx), c, environmentId, clusterId),
 		Timeout:      ksqlCreateTimeout,
 		Delay:        5 * time.Second,


### PR DESCRIPTION
[KFS-152](https://confluentinc.atlassian.net/browse/KFS-152)

## What
Previously, the public KSQL API was returning `UP` instead of `Provisioned` as agreed upon in the minispec. Therefore, we needed to include the `UP` state in the TF provider. Now that that is fixed and in prod (see [this](https://github.com/confluentinc/cc-scheduler-service/pull/4115) PR) we are removing the `UP` state from the provider. 

## Testing
made sure unit tests run 