### PR TITLE
Fix minor naming confusion

### DIFF
--- a/examples/configurations/standard-kafka-rbac/main.tf
+++ b/examples/configurations/standard-kafka-rbac/main.tf
@@ -170,7 +170,7 @@ resource "confluent_role_binding" "app-consumer-developer-read-from-topic" {
   crn_pattern = "${confluent_kafka_cluster.standard.rbac_crn}/kafka=${confluent_kafka_cluster.standard.id}/topic=${confluent_kafka_topic.orders.topic_name}"
 }
 
-resource "confluent_role_binding" "app-producer-developer-read-from-group" {
+resource "confluent_role_binding" "app-consumer-developer-read-from-group" {
   principal = "User:${confluent_service_account.app-consumer.id}"
   role_name = "DeveloperRead"
   // The existing value of crn_pattern's suffix (group=confluent_cli_consumer_*) are set up to match Confluent CLI's default consumer group ID ("confluent_cli_consumer_<uuid>").


### PR DESCRIPTION
One of the `role_binding` resources is named as if it configures a producer while it configures a consumer. In this commit, I've adapted the resource naming accordingly.