### PR TITLE
[CIAM-3066] Add group prefix check for identity pools

### DIFF
--- a/internal/provider/resource_kafka_acl.go
+++ b/internal/provider/resource_kafka_acl.go
@@ -99,7 +99,7 @@ func kafkaAclResource() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				Description:  "The principal for the ACL.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^User:(\\*)$|^User:(sa|u|pool)-"), "the principal must start with 'User:sa-' or 'User:u-' or 'User:pool-' or 'User:*'."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^User:(\\*)$|^User:(sa|u|pool|group)-"), "the principal must start with 'User:sa-' or 'User:u-' or 'User:pool-' or 'User:group-' or 'User:*'."),
 			},
 			paramHost: {
 				Type:        schema.TypeString,
@@ -488,9 +488,9 @@ func createAclInstanceName(acl Acl) string {
 // APIF-2043: TEMPORARY METHOD
 // Converts principal with an integer ID (User:6789) to principal with a resourceID (User:sa-01234)
 func principalWithIntegerIdToPrincipalWithResourceId(principalIdMap map[int32]string, principalWithIntegerId string) (string, error) {
-	// There's input validation that principal attribute must start with "User:sa-" or "User:u-" or "User:pool-"  or "User:*"
+	// There's input validation that principal attribute must start with "User:sa-" or "User:u-" or "User:pool-" or "User:group-" or "User:*"
 
-	if principalWithIntegerId == "User:*" || strings.HasPrefix(principalWithIntegerId, "User:sa-") || strings.HasPrefix(principalWithIntegerId, "User:u-") || strings.HasPrefix(principalWithIntegerId, "User:pool-") {
+	if principalWithIntegerId == "User:*" || strings.HasPrefix(principalWithIntegerId, "User:sa-") || strings.HasPrefix(principalWithIntegerId, "User:u-") || strings.HasPrefix(principalWithIntegerId, "User:pool-" || strings.HasPrefix(principalWithIntegerId, "User:group-") {
 		return principalWithIntegerId, nil
 	}
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -437,7 +437,7 @@ func isNonKafkaRestApiResourceNotFound(response *http.Response) bool {
 // APIF-2043: TEMPORARY METHOD
 // Converts principal with a resourceID (User:sa-01234) to principal with an integer ID (User:6789)
 func principalWithResourceIdToPrincipalWithIntegerId(c *Client, principalWithResourceId string) (string, error) {
-	// There's input validation that principal attribute must start with "User:sa-" or "User:u-" or "User:pool-"  or "User:*"
+	// There's input validation that principal attribute must start with "User:sa-" or "User:u-" or "User:pool-"  or "User:group-" or "User:*"
 
 	if principalWithResourceId == "User:*" {
 		return principalWithResourceId, nil
@@ -457,10 +457,10 @@ func principalWithResourceIdToPrincipalWithIntegerId(c *Client, principalWithRes
 			return "", err
 		}
 		return fmt.Sprintf("%s%d", principalPrefix, integerId), nil
-	} else if strings.HasPrefix(principalWithResourceId, "User:pool-") {
+	} else if strings.HasPrefix(principalWithResourceId, "User:pool-") || strings.HasPrefix(principalWithResourceId, "User:group-") {
 		return principalWithResourceId, nil
 	}
-	return "", fmt.Errorf("the principal must start with 'User:sa-' or 'User:u-' or 'User:pool-' or 'User:*'")
+	return "", fmt.Errorf("the principal must start with 'User:sa-' or 'User:u-' or 'User:pool-' or 'User:group-' or 'User:*'")
 }
 
 // APIF-2043: TEMPORARY METHOD


### PR DESCRIPTION
As part of AUPM, we introduced a new subset of identity pools with the prefix of "group-". We need to update instances where we filter based on prefix to also account for these new pools.

