### PR TITLE
fix: Update state when refreshing schema #318 #293

### DIFF
--- a/docs/resources/confluent_schema.md
+++ b/docs/resources/confluent_schema.md
@@ -102,8 +102,6 @@ In addition to the preceding arguments, the following attributes are exported:
 
 ## Import
 
--> **Note:** You must set the `SCHEMA_CONTENT` (`schema`) environment variable before importing a Schema.
-
 You can import a Schema by using the Schema Registry cluster ID, Subject name, and unique identifier (or `latest` when `recreate_on_update = false`) of the Schema in the format `<Schema Registry cluster ID>/<Subject name>/<Schema identifier>`, for example:
 
 ```shell
@@ -111,14 +109,12 @@ You can import a Schema by using the Schema Registry cluster ID, Subject name, a
 $ export IMPORT_SCHEMA_REGISTRY_API_KEY="<schema_registry_api_key>"
 $ export IMPORT_SCHEMA_REGISTRY_API_SECRET="<schema_registry_api_secret>"
 $ export IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT="<schema_registry_rest_endpoint>"
-$ export SCHEMA_CONTENT="<schema_content>" # for example, export SCHEMA_CONTENT=$(cat schemas/proto/purchase.proto)
 $ terraform import confluent_schema.my_schema_1 lsrc-abc123/test-subject/latest
 
 # Option B: recreate_on_update = true
 $ export IMPORT_SCHEMA_REGISTRY_API_KEY="<schema_registry_api_key>"
 $ export IMPORT_SCHEMA_REGISTRY_API_SECRET="<schema_registry_api_secret>"
 $ export IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT="<schema_registry_rest_endpoint>"
-$ export SCHEMA_CONTENT="<schema_content>" # for example, export SCHEMA_CONTENT=$(cat schemas/proto/purchase.proto)
 $ terraform import confluent_schema.my_schema_1 lsrc-abc123/test-subject/100003
 ```
 

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -17,12 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"regexp"
-	"strconv"
 )
 
 func schemaDataSource() *schema.Resource {
@@ -127,13 +128,7 @@ func schemaDataSourceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if _, err := readSchemaRegistryConfigAndSetAttributes(ctx, d, schemaRegistryRestClient, subjectName, strconv.Itoa(schemaIdentifier)); err != nil {
 		return diag.Errorf("error reading Schema: %s", createDescriptiveError(err))
 	}
-	srSchema, _, err := loadSchema(ctx, d, schemaRegistryRestClient, subjectName, strconv.Itoa(schemaIdentifier))
-	if err != nil {
-		return diag.Errorf("error reading Schema: %s", createDescriptiveError(err))
-	}
-	if err := d.Set(paramSchema, srSchema.GetSchema()); err != nil {
-		return diag.Errorf("error reading Schema: %s", createDescriptiveError(err))
-	}
+
 	tflog.Debug(ctx, fmt.Sprintf("Finished reading Schema %q", d.Id()), map[string]interface{}{schemaLoggingKey: d.Id()})
 
 	return nil

--- a/internal/provider/resource_schema_latest_provider_block_test.go
+++ b/internal/provider/resource_schema_latest_provider_block_test.go
@@ -17,13 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/walkerus/go-wiremock"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/walkerus/go-wiremock"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -119,12 +119,6 @@ func TestAccLatestSchemaWithEnhancedProviderBlock(t *testing.T) {
 			contentTypeJSONHeader,
 			http.StatusOK,
 		))
-
-	// Set fake values for schema content since it's required for importing
-	_ = os.Setenv("SCHEMA_CONTENT", testSchemaContent)
-	defer func() {
-		_ = os.Unsetenv("SCHEMA_CONTENT")
-	}()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/resource_schema_latest_refresh_test.go
+++ b/internal/provider/resource_schema_latest_refresh_test.go
@@ -1,0 +1,275 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/walkerus/go-wiremock"
+)
+
+const (
+	scenarioStateSchemaTest1Part2 = "In Test 1 part 2"
+	scenarioStateSchemaTest2      = "In test 2 part 1"
+)
+
+//
+// This is a new test to check specific functionality whereby a schema is updated between Terraform runs.
+// It's actually more to do with ensuring the state is refreshed - see issue #318
+// The provider would compare the new schema with the old value in the new state.
+// In the second step, this test returns updated version of the schema and ensures that Terraform creates a plan against it's initial schema.
+// In the third step, this test returns updated version of the schema and ensures that Terraform does not create a plan against an updated schema.
+//
+
+func TestAccLatestRefreshSchema(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockSchemaTestServerUrl := wiremockContainer.URI
+	confluentCloudBaseUrl := ""
+	wiremockClient := wiremock.NewClient(mockSchemaTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	// Schema has not yet been created. Used for test step 1.
+
+	validateSchemaResponse, _ := os.ReadFile("../testdata/schema_registry_schema/validate_schema.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(validateSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(validateSchemaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	createSchemaResponse, _ := os.ReadFile("../testdata/schema_registry_schema/create_schema.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(createSchemaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readLatestSchemaResponse, _ := os.ReadFile("../testdata/schema_registry_schema/read_latest_schema.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readLatestSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(readLatestSchemaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readSchemasResponse, _ := os.ReadFile("../testdata/schema_registry_schema/read_schemas.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSchemasPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateSchemaTest1Part2).
+		WillReturn(
+			string(readSchemasResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	// Created schema but still in test 1, we now have a plan to respond to.
+	// We need to have an intermediate state so we know when we move on to the next tests.
+
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readLatestSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaTest1Part2).
+		WillReturn(
+			string(readLatestSchemaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSchemasPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaTest1Part2).
+		WillSetStateTo(scenarioStateSchemaTest2).
+		WillReturn(
+			string(readSchemasResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	// On to test step 2 and 3. On refresh, we will return that something has changed compared to step 1.
+	// Planning only o we do not need to create a schema but we do need to validate in step 2.
+
+	readLatestSchemaResponseUpdated, _ := os.ReadFile("../testdata/schema_registry_schema/read_latest_schema_updated.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readLatestSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaTest2).
+		WillReturn(
+			string(readLatestSchemaResponseUpdated),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readSchemasResponseUpdated, _ := os.ReadFile("../testdata/schema_registry_schema/read_schemas_updated.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSchemasPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaTest2).
+		WillReturn(
+			string(readSchemasResponseUpdated),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(validateSchemaPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaTest2).
+		WillReturn(
+			string(validateSchemaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	// Test 2 and 3 done. The delete path is unique so we don't need to worry about the state.
+
+	deleteSchemaStub := wiremock.Delete(wiremock.URLPathEqualTo(deleteSchemaPathUpdated)).
+		InScenario(schemaScenarioName).
+		WillSetStateTo(scenarioStateSchemaHasBeenDeleted).
+		WillReturn(
+			"",
+			contentTypeJSONHeader,
+			http.StatusNoContent,
+		)
+	_ = wiremockClient.StubFor(deleteSchemaStub)
+
+	readDeletedSaResponse, _ := os.ReadFile("../testdata/schema_registry_schema/read_schemas_after_delete.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSchemasPath)).
+		InScenario(schemaScenarioName).
+		WhenScenarioStateIs(scenarioStateSchemaHasBeenDeleted).
+		WillReturn(
+			string(readDeletedSaResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckSchemaDestroy(s, mockSchemaTestServerUrl)
+		},
+		// https://www.terraform.io/docs/extend/testing/acceptance-tests/teststep.html
+		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckLatestRefreshSchemaConfig(confluentCloudBaseUrl, mockSchemaTestServerUrl, testSchemaContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSchemaExists(fullSchemaResourceLabel),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "id", fmt.Sprintf("%s/%s/%s", testStreamGovernanceClusterId, testSubjectName, latestSchemaVersionAndPlaceholderForSchemaIdentifier)),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_registry_cluster.#", "1"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_registry_cluster.0.%", "1"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_registry_cluster.0.id", testStreamGovernanceClusterId),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "rest_endpoint", mockSchemaTestServerUrl),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "credentials.#", "1"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "credentials.0.%", "2"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "credentials.0.key", testSchemaRegistryKey),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "credentials.0.secret", testSchemaRegistrySecret),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "subject_name", testSubjectName),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "format", testFormat),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema", testSchemaContent),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "version", strconv.Itoa(testSchemaVersion)),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_identifier", strconv.Itoa(testSchemaIdentifier)),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "hard_delete", testHardDelete),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "recreate_on_update", testRecreateOnUpdateFalse),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.#", "2"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.0.%", "3"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.0.name", testFirstSchemaReferenceDisplayName),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.0.subject_name", testFirstSchemaReferenceSubject),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.0.version", strconv.Itoa(testFirstSchemaReferenceVersion)),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.%", "3"),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.name", testSecondSchemaReferenceDisplayName),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.subject_name", testSecondSchemaReferenceSubject),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.version", strconv.Itoa(testSecondSchemaReferenceVersion)),
+					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "%", strconv.Itoa(testNumberOfSchemaRegistrySchemaResourceAttributes)),
+				),
+			},
+			{
+				// For step 2 wiremock will send back an updated schema, which should cause Terraform to create a plan.
+				Config:             testAccCheckLatestRefreshSchemaConfig(confluentCloudBaseUrl, mockSchemaTestServerUrl, testSchemaContent),
+				PlanOnly:           true, // The plan is only checked if this is set!
+				ExpectNonEmptyPlan: true,
+			}, {
+				// For step 3 wiremock will send back an updated schema, which should not cause Terraform to create a plan against the updated schema.
+				Config:             testAccCheckLatestRefreshSchemaConfig(confluentCloudBaseUrl, mockSchemaTestServerUrl, testSchemaContentUpdated),
+				PlanOnly:           true, // The plan is only checked if this is set and any other Check is ignored!
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+
+	checkStubCount(t, wiremockClient, deleteSchemaStub, fmt.Sprintf("DELETE %s", readSchemasPath), expectedCountOne)
+}
+
+func testAccCheckLatestRefreshSchemaConfig(confluentCloudBaseUrl, mockServerUrl string, schemaContent string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+      endpoint = "%s"
+    }
+	resource "confluent_schema" "%s" {
+	  schema_registry_cluster {
+        id = "%s"
+      }
+      rest_endpoint = "%s"
+      credentials {
+        key = "%s"
+        secret = "%s"
+	  }
+	
+	  subject_name = "%s"
+	  format = "%s"
+      schema = "%s"
+
+      hard_delete = "%s"
+	  
+      schema_reference {
+        name = "%s"
+        subject_name = "%s"
+        version = %d
+      }
+
+      schema_reference {
+        name = "%s"
+        subject_name = "%s"
+        version = %d
+      }
+	}
+	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryKey, testSchemaRegistrySecret, testSubjectName, testFormat, schemaContent,
+		testHardDelete,
+		testFirstSchemaReferenceDisplayName, testFirstSchemaReferenceSubject, testFirstSchemaReferenceVersion,
+		testSecondSchemaReferenceDisplayName, testSecondSchemaReferenceSubject, testSecondSchemaReferenceVersion)
+}

--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -124,12 +124,10 @@ func TestAccLatestSchema(t *testing.T) {
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_KEY", testSchemaRegistryUpdatedKey)
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_SECRET", testSchemaRegistryUpdatedSecret)
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT", mockSchemaTestServerUrl)
-	_ = os.Setenv("SCHEMA_CONTENT", testSchemaContent)
 	defer func() {
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_API_KEY")
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_API_SECRET")
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT")
-		_ = os.Unsetenv("SCHEMA_CONTENT")
 	}()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_schema_versioned_provider_block_test.go
+++ b/internal/provider/resource_schema_versioned_provider_block_test.go
@@ -17,13 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/walkerus/go-wiremock"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/walkerus/go-wiremock"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -109,12 +109,6 @@ func TestAccVersionedSchemaWithEnhancedProviderBlock(t *testing.T) {
 			contentTypeJSONHeader,
 			http.StatusOK,
 		))
-
-	// Set fake values for schema content since it's required for importing
-	_ = os.Setenv("SCHEMA_CONTENT", testSchemaContent)
-	defer func() {
-		_ = os.Unsetenv("SCHEMA_CONTENT")
-	}()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/resource_schema_versioned_test.go
+++ b/internal/provider/resource_schema_versioned_test.go
@@ -17,12 +17,13 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/walkerus/go-wiremock"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/walkerus/go-wiremock"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -155,12 +156,10 @@ func TestAccVersionedSchema(t *testing.T) {
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_KEY", testSchemaRegistryUpdatedKey)
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_SECRET", testSchemaRegistryUpdatedSecret)
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT", mockSchemaTestServerUrl)
-	_ = os.Setenv("SCHEMA_CONTENT", testSchemaContent)
 	defer func() {
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_API_KEY")
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_API_SECRET")
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT")
-		_ = os.Unsetenv("SCHEMA_CONTENT")
 	}()
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_schema_versioned_test.go
+++ b/internal/provider/resource_schema_versioned_test.go
@@ -40,6 +40,7 @@ const (
 	testFormat                    = "AVRO"
 	testStreamGovernanceClusterId = "lsrc-abc123"
 	testSchemaContent             = "foobar"
+	testSchemaContentUpdated      = "foobar2"
 	testSchemaResourceLabel       = "test_schema_resource_label"
 
 	testFirstSchemaReferenceDisplayName = "sampleRecord"
@@ -69,6 +70,7 @@ var createSchemaPath = fmt.Sprintf("/subjects/%s/versions", testSubjectName)
 var readSchemasPath = fmt.Sprintf("/schemas")
 var readLatestSchemaPath = fmt.Sprintf("/subjects/%s/versions/latest", testSubjectName)
 var deleteSchemaPath = fmt.Sprintf("/subjects/%s/versions/%s", testSubjectName, strconv.Itoa(testSchemaVersion))
+var deleteSchemaPathUpdated = fmt.Sprintf("/subjects/%s/versions/%s", testSubjectName, strconv.Itoa(testSchemaVersion+1))
 
 func TestAccVersionedSchema(t *testing.T) {
 	ctx := context.Background()

--- a/internal/testdata/schema_registry_schema/read_latest_schema_updated.json
+++ b/internal/testdata/schema_registry_schema/read_latest_schema_updated.json
@@ -1,0 +1,18 @@
+{
+  "subject": "test2",
+  "version": 9,
+  "id": 100002,
+  "schema": "foobar2",
+  "references": [
+    {
+      "name": "sampleRecord",
+      "subject": "test2",
+      "version": 9
+    },
+    {
+      "name": "sampleRecord2",
+      "subject": "test3",
+      "version":  3
+    }
+  ]
+}

--- a/internal/testdata/schema_registry_schema/read_schemas_updated.json
+++ b/internal/testdata/schema_registry_schema/read_schemas_updated.json
@@ -1,0 +1,38 @@
+[
+  {
+    "subject": "test2",
+    "version": 8,
+    "id": 100001,
+    "schema": "foobar",
+    "references": [
+      {
+        "name": "sampleRecord",
+        "subject": "test2",
+        "version": 9
+      },
+      {
+        "name": "sampleRecord2",
+        "subject": "test3",
+        "version":  3
+      }
+    ]
+  },
+  {
+    "subject": "test2",
+    "version": 9,
+    "id": 100002,
+    "schema": "foobar2",
+    "references": [
+      {
+        "name": "sampleRecord",
+        "subject": "test2",
+        "version": 9
+      },
+      {
+        "name": "sampleRecord2",
+        "subject": "test3",
+        "version":  3
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Gets and sets the schema within readSchemaRegistryConfigAndSetAttributes so it will be consistently actioned. This ensures that when the resource is refreshed the state file is updated (for #318). Removed corrsponding code from immediately after other calls (for import and data resource). As a result of this the use of SCHEMA_CONTENT during import is removed, which I cannot fathom a use for as imho an import should always be from the actual resource and not a local data file (#293). 

I have used the provider in dev mode to make updates (driven by the fixed refresh), perform an import and verify the data resource. The existing tests all run without apparant issue.

Grateful for review, comments and assistance with modifying the acceptance tests.