### PR TITLE
[DP-12820] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -20,7 +20,6 @@ blocks:
           - checkout
           - . vault-setup
           # GitHub token is required for running GoReleaser
-          - . vault-sem-get-secret semaphore-secrets-global
           - . vault-sem-get-secret v1/ci/kv/apif/signing_key
           # Import GPG private key
           - echo -e "${GPG_PRIVATE_KEY}" | gpg --import --batch --no-tty


### PR DESCRIPTION
## Background
This is a followup to DP-12820 to clean up semaphore pipelines. This change removes some secrets that have been
deactivated as well as removes some commands that are set automatically by the semaphore agent, and replaces
two lines make install-vault and mk-include/bin/vault-setup with . vault-setup.

The same [change](https://github.com/confluentinc/cc-service-bot/pull/471/files) was made for managed semaphore pipelines, this automated PR
should match the changes made in the managed semaphore pipelines.

## Actions
This should not affect your pipelines. If the commands match what was made in the managed semaphore pipelines,
and the pr build passes, please merge this change.
