### PR TITLE
Remove all quotes from incoming env variables

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -580,6 +580,9 @@ func apiKeyImport(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return nil, fmt.Errorf("error importing API Key %q: API_KEY_SECRET environment variable is empty but it must be set", d.Id())
 	}
 
+	// Trim outer quotes from the retrieved value.
+	apiKeySecret = strings.Trim(apiKeySecret, "\"")
+
 	envIdAndClusterAPIKeyId := d.Id()
 	parts := strings.Split(envIdAndClusterAPIKeyId, "/")
 	if len(parts) == 1 {

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -808,30 +808,54 @@ func extractKafkaClusterRestAndBootstrapEndpoints(restEndpointEnvVar, bootstrapE
 	restEndpoint := getEnv(restEndpointEnvVar, "")
 	bootstrapEndpoint := getEnv(bootstrapEndpointEnvVar, "")
 
+	// Trim outer quotes from the retrieved values.
+	restEndpoint = strings.Trim(restEndpoint, "\"")
+	bootstrapEndpoint = strings.Trim(bootstrapEndpoint, "\"")
+
 	return restEndpoint, bootstrapEndpoint
 }
 
 func extractSourceClusterApiKeyAndApiSecret() (string, string) {
 	clusterApiKey := getEnv("IMPORT_SOURCE_KAFKA_API_KEY", "")
 	clusterApiSecret := getEnv("IMPORT_SOURCE_KAFKA_API_SECRET", "")
+
+	// Trim outer quotes from the retrieved values.
+	clusterApiKey = strings.Trim(clusterApiKey, "\"")
+	clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 	return clusterApiKey, clusterApiSecret
 }
 
 func extractDestinationClusterApiKeyAndApiSecret() (string, string) {
 	clusterApiKey := getEnv("IMPORT_DESTINATION_KAFKA_API_KEY", "")
 	clusterApiSecret := getEnv("IMPORT_DESTINATION_KAFKA_API_SECRET", "")
+
+	// Trim outer quotes from the retrieved values.
+	clusterApiKey = strings.Trim(clusterApiKey, "\"")
+	clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 	return clusterApiKey, clusterApiSecret
 }
 
 func extractLocalClusterApiKeyAndApiSecret() (string, string) {
 	clusterApiKey := getEnv("IMPORT_LOCAL_KAFKA_API_KEY", "")
 	clusterApiSecret := getEnv("IMPORT_LOCAL_KAFKA_API_SECRET", "")
+
+	// Trim outer quotes from the retrieved values.
+	clusterApiKey = strings.Trim(clusterApiKey, "\"")
+	clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 	return clusterApiKey, clusterApiSecret
 }
 
 func extractRemoteClusterApiKeyAndApiSecret() (string, string) {
 	clusterApiKey := getEnv("IMPORT_REMOTE_KAFKA_API_KEY", "")
 	clusterApiSecret := getEnv("IMPORT_REMOTE_KAFKA_API_SECRET", "")
+
+	// Trim outer quotes from the retrieved values.
+	clusterApiKey = strings.Trim(clusterApiKey, "\"")
+	clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 	return clusterApiKey, clusterApiSecret
 }
 

--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -407,6 +408,10 @@ func extractFlinkRestEndpoint(client *Client, d *schema.ResourceData, isImportOp
 	}
 	if isImportOperation {
 		restEndpoint := getEnv("IMPORT_FLINK_REST_ENDPOINT", "")
+
+		// Trim outer quotes from the retrieved values.
+		restEndpoint = strings.Trim(restEndpoint, "\"")
+
 		if restEndpoint != "" {
 			return restEndpoint, nil
 		} else {
@@ -427,6 +432,11 @@ func extractFlinkApiKeyAndApiSecret(client *Client, d *schema.ResourceData, isIm
 	if isImportOperation {
 		clusterApiKey := getEnv("IMPORT_FLINK_API_KEY", "")
 		clusterApiSecret := getEnv("IMPORT_FLINK_API_SECRET", "")
+
+		// Trim outer quotes from the retrieved values.
+		clusterApiKey = strings.Trim(clusterApiKey, "\"")
+		clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 		if clusterApiKey != "" && clusterApiSecret != "" {
 			return clusterApiKey, clusterApiSecret, nil
 		} else {

--- a/internal/provider/resource_kafka_topic.go
+++ b/internal/provider/resource_kafka_topic.go
@@ -156,6 +156,10 @@ func extractRestEndpoint(client *Client, d *schema.ResourceData, isImportOperati
 	}
 	if isImportOperation {
 		restEndpoint := getEnv("IMPORT_KAFKA_REST_ENDPOINT", "")
+
+		// Trim outer quotes from the retrieved values.
+		restEndpoint = strings.Trim(restEndpoint, "\"")
+
 		if restEndpoint != "" {
 			return restEndpoint, nil
 		} else {
@@ -176,6 +180,11 @@ func extractClusterApiKeyAndApiSecret(client *Client, d *schema.ResourceData, is
 	if isImportOperation {
 		clusterApiKey := getEnv("IMPORT_KAFKA_API_KEY", "")
 		clusterApiSecret := getEnv("IMPORT_KAFKA_API_SECRET", "")
+
+		// Trim outer quotes from the retrieved values.
+		clusterApiKey = strings.Trim(clusterApiKey, "\"")
+		clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 		if clusterApiKey != "" && clusterApiSecret != "" {
 			return clusterApiKey, clusterApiSecret, nil
 		} else {

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -787,6 +787,10 @@ func extractSchemaRegistryRestEndpoint(client *Client, d *schema.ResourceData, i
 	}
 	if isImportOperation {
 		restEndpoint := getEnv("IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT", "")
+
+		// Trim outer quotes from the retrieved values.
+		restEndpoint = strings.Trim(restEndpoint, "\"")
+
 		if restEndpoint != "" {
 			return restEndpoint, nil
 		} else {
@@ -807,6 +811,11 @@ func extractSchemaRegistryClusterApiKeyAndApiSecret(client *Client, d *schema.Re
 	if isImportOperation {
 		clusterApiKey := getEnv("IMPORT_SCHEMA_REGISTRY_API_KEY", "")
 		clusterApiSecret := getEnv("IMPORT_SCHEMA_REGISTRY_API_SECRET", "")
+
+		// Trim outer quotes from the retrieved values.
+		clusterApiKey = strings.Trim(clusterApiKey, "\"")
+		clusterApiSecret = strings.Trim(clusterApiSecret, "\"")
+
 		if clusterApiKey != "" && clusterApiSecret != "" {
 			return clusterApiKey, clusterApiSecret, nil
 		} else {


### PR DESCRIPTION
After a lot of testing, it seems that having quotes `"` in any of your KAFKA_ or IMPORT_ environment variables, the provider shows some really unexpected behavior.

This PR adds trimming of those `"`'s from all (I hope) incoming Environment Variables.