### PR TITLE
fix #177: validate inputs length on identity pool and service account resources

### DIFF
--- a/internal/provider/resource_identity_pool.go
+++ b/internal/provider/resource_identity_pool.go
@@ -48,13 +48,19 @@ func identityPoolResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "A name for the Identity Pool.",
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringLenBetween(0, 64)
+				),
 			},
 			paramDescription: {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "A description of the Identity Pool.",
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringLenBetween(0, 128)
+				),
 			},
 			paramIdentityClaim: {
 				Type:         schema.TypeString,
@@ -66,7 +72,10 @@ func identityPoolResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "A filter expression that must be evaluated to be true to use this identity pool.",
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringLenBetween(0, 300)
+				),
 			},
 		},
 	}

--- a/internal/provider/resource_service_account.go
+++ b/internal/provider/resource_service_account.go
@@ -57,6 +57,10 @@ func serviceAccountResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A free-form description of the Service Account.",
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringLenBetween(0, 128)
+				),
 			},
 		},
 	}


### PR DESCRIPTION
Added validation of input lengths that I know of.
These are listed in https://github.com/confluentinc/terraform-provider-confluent/issues/177