### PR TITLE
#major: Prepare for 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.0.0 (August 14th, 2024)
+
+[Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v1.83.0...v2.0.0)
+
+**New features:**
+* Removed deprecated `confluent_schema_registry_region` [data source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_schema_registry_region)
+and `confluent_schema_registry_cluster` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_schema_registry_cluster). Refer to the [Upgrade Guide](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/version-2-upgrade) for more details.
+
+**Bug fixes:**
+* Update Terraform configuration examples note for [dedicated-vnet-peering-azure-kafka-acls](examples/configurations/dedicated-vnet-peering-azure-kafka-acls/README.md).
+* Update Terraform configuration examples note for [dedicated-vnet-peering-azure-kafka-rbac](examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/README.md).
+
 ## 1.83.0 (August 7th, 2024)
 
 [Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v1.82.0...v1.83.0)

--- a/docs/guides/version-2-upgrade.md
+++ b/docs/guides/version-2-upgrade.md
@@ -3,8 +3,8 @@ page_title: "Confluent Provider 2.0.0: Upgrade Guide"
 ---
 # Confluent Provider 2.0.0: Upgrade Guide
 
-!> **Warning:** Version `2.0.0` of Confluent Provider hasn't been released yet and this guide describes how to resolve `Warning: Deprecated Resource` for deprecated `confluent_schema_registry_cluster` [resource](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/resources/confluent_schema_registry_cluster) and
-deprecated `confluent_schema_registry_region` [data source](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/data-sources/confluent_schema_registry_region) as the warning message references this guide.
+!> **Warning:** Version `2.0.0` of Confluent Provider has been released and this guide describes how to resolve `Warning: Deprecated Resource` for deprecated `confluent_schema_registry_cluster` [resource](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/resources/confluent_schema_registry_cluster)  and
+deprecated `confluent_schema_registry_region` [data source](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/data-sources/confluent_schema_registry_region) as the warning message references this guide, please resolve these warnings before upgrading to major version `2.0.0`.
 
 ## Provider Version Configuration
 
@@ -45,7 +45,7 @@ Terraform has compared your real infrastructure against your configuration and f
 ### Changes to `confluent_schema_registry_cluster` resource
 
 Deprecated `confluent_schema_registry_cluster`
-[resource](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/resources/confluent_schema_registry_cluster) will be removed in version `2.0.0`.
+[resource](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/resources/confluent_schema_registry_cluster) has been removed in version `2.0.0`.
 
 Use the `confluent_schema_registry_cluster` data source instead to avoid `Warning: Deprecated Resource` messages.
 
@@ -98,7 +98,7 @@ Successfully removed 1 resource instance(s).
 ### Changes to `confluent_schema_registry_region` data source
 
 Deprecated `confluent_schema_registry_region`
-[data source](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/data-sources/confluent_schema_registry_region) will be removed in version `2.0.0`.
+[data source](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/data-sources/confluent_schema_registry_region) has been removed in version `2.0.0`.
 
 Remove the `confluent_schema_registry_region`
 [data source](https://registry.terraform.io/providers/confluentinc/confluent/1.83.0/docs/data-sources/confluent_schema_registry_region) only from TF configuration (as data sources are not stored in the TF state) instead

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/azure-key-vault/main.tf
+++ b/examples/configurations/azure-key-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/basic-kafka-acls-with-alias/main.tf
+++ b/examples/configurations/basic-kafka-acls-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/basic-kafka-acls/main.tf
+++ b/examples/configurations/basic-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/cloud-importer/main.tf
+++ b/examples/configurations/cloud-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
+++ b/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
 
     aws = {

--- a/examples/configurations/connectors/custom-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/custom-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
+++ b/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/managed-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/managed-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-source-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/s3-sink-connector/main.tf
+++ b/examples/configurations/connectors/s3-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/snowflake-sink-connector/main.tf
+++ b/examples/configurations/connectors/snowflake-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
+++ b/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
 
     aws = {

--- a/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
 
     azurerm = {

--- a/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
 
     google = {

--- a/examples/configurations/dedicated-public-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-public-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-public-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
 
     azurerm = {

--- a/examples/configurations/flink-quickstart-2/main.tf
+++ b/examples/configurations/flink-quickstart-2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/flink-quickstart/main.tf
+++ b/examples/configurations/flink-quickstart/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/hashicorp-vault/main.tf
+++ b/examples/configurations/hashicorp-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/examples/configurations/kafka-importer/main.tf
+++ b/examples/configurations/kafka-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/ksql-acls/main.tf
+++ b/examples/configurations/ksql-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/ksql-rbac/main.tf
+++ b/examples/configurations/ksql-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
+++ b/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/managing-single-kafka-cluster/main.tf
+++ b/examples/configurations/managing-single-kafka-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/managing-single-schema-registry-cluster/main.tf
+++ b/examples/configurations/managing-single-schema-registry-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-avro-schema/main.tf
+++ b/examples/configurations/multiple-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-proto-schema/main.tf
+++ b/examples/configurations/multiple-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/schema-linking/main.tf
+++ b/examples/configurations/schema-linking/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/schema-registry-importer/main.tf
+++ b/examples/configurations/schema-registry-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-avro-schema/main.tf
+++ b/examples/configurations/single-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
+++ b/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema/main.tf
+++ b/examples/configurations/single-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/source-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/source-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-acls/main.tf
+++ b/examples/configurations/standard-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-rbac/main.tf
+++ b/examples/configurations/standard-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/stream-catalog/main.tf
+++ b/examples/configurations/stream-catalog/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
+++ b/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.83.0"
+      version = "2.0.0"
     }
   }
 }

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -589,7 +589,7 @@ func createHclFileWithHeader(mode ImporterMode) *hclwrite.File {
 	requiredProvidersBlock := tfBlock.Body().AppendNewBlock("required_providers", nil)
 	requiredProvidersBlock.Body().SetAttributeValue("confluent", zclCty.ObjectVal(map[string]zclCty.Value{
 		"source":  zclCty.StringVal("confluentinc/confluent"),
-		"version": zclCty.StringVal("1.83.0"),
+		"version": zclCty.StringVal("2.0.0"),
 	}))
 
 	providerBlock := body.AppendNewBlock("provider", []string{"confluent"})


### PR DESCRIPTION
#major: Prepare for 2.0.0 release.

**New features:**

- Major version release with [Upgrade Guide](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/version-2-upgrade).
- Remove confluent_schema_registry_cluster resource, use confluent_schema_registry_cluster data source instead.
- Remove confluent_schema_registry_region data source.
- Update the API library version from srcm/v2 to srcm/v3.
- Update the [confluent_api_key resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_api_key) diff logic to ensure - `srcm/v2` -> `srcm/v3` api version change won't cause Terraform plan drift.

**Bug fixes:**

- Update Terraform configuration examples note for `dedicated-vnet-peering-azure-kafka-acls`.
- Update Terraform configuration examples note for `dedicated-vnet-peering-azure-kafka-rbac`.