### PR TITLE
API-2397: Update timeout for confluent_statement

### DIFF
--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/http"
 	"regexp"
+	"time"
 )
 
 const (
@@ -38,8 +39,7 @@ const (
 	statePending   = "PENDING"
 	stateFailing   = "FAILING"
 
-	// exampleFlinkRestEndpoint = "https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/1111aaaa-11aa-11aa-11aa-111111aaaaaa/environments/env-abc123"
-	exampleFlinkRestEndpoint = "https://flink.us-east-1.aws.confluent.cloud"
+	statementsAPICreateTimeout = 6 * time.Hour
 )
 
 func flinkStatementResource() *schema.Resource {
@@ -91,6 +91,9 @@ func flinkStatementResource() *schema.Resource {
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^http"), "the REST endpoint must start with 'https://'"),
 			},
 			paramCredentials: credentialsSchema(),
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(statementsAPICreateTimeout),
 		},
 	}
 }

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -249,11 +249,10 @@ func waitForNetworkToProvision(ctx context.Context, c *Client, environmentId, ne
 func waitForFlinkStatementToProvision(ctx context.Context, c *FlinkRestClient, statementName string, isAcceptanceTestMode bool) error {
 	delay, pollInterval := getDelayAndPollInterval(5*time.Second, 10*time.Second, isAcceptanceTestMode)
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{statePending},
-		Target:  []string{stateRunning, stateCompleted},
-		Refresh: flinkStatementProvisionStatus(c.apiContext(ctx), c, statementName),
-		// Default timeout
-		Timeout:      20 * time.Minute,
+		Pending:      []string{statePending},
+		Target:       []string{stateRunning, stateCompleted},
+		Refresh:      flinkStatementProvisionStatus(c.apiContext(ctx), c, statementName),
+		Timeout:      statementsAPICreateTimeout,
 		Delay:        delay,
 		PollInterval: pollInterval,
 	}


### PR DESCRIPTION
### What
This PR updates the timeout for `confluent_flink_statement` provisioning to 6 hours to resolve timeout issues.