### PR TITLE
APIT-2468: Resolve "Error: unexpected API Key "... resource" when creating SR confluent_api_key 

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -507,7 +507,9 @@ func isKafkaApiKey(apiKey apikeys.IamV2ApiKey) bool {
 
 func isSchemaRegistryApiKey(apiKey apikeys.IamV2ApiKey) bool {
 	// At the moment, API Key Mgmt API temporarily returns schemaRegistryKind instead of clusterKind
-	return (apiKey.Spec.Resource.GetKind() == clusterKind || apiKey.Spec.Resource.GetKind() == schemaRegistryKind) && apiKey.Spec.Resource.GetApiVersion() == srcmV3ApiVersion
+	// and api_version="srcm/v2"
+	return (apiKey.Spec.Resource.GetKind() == clusterKind || apiKey.Spec.Resource.GetKind() == schemaRegistryKind) &&
+		(apiKey.Spec.Resource.GetApiVersion() == srcmV3ApiVersion || apiKey.Spec.Resource.GetApiVersion() == srcmV2ApiVersion)
 }
 
 func isFlinkApiKey(apiKey apikeys.IamV2ApiKey) bool {

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	apikeys "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 )
 
 func testKafkaClusterBlockStateDataV0() map[string]interface{} {
@@ -157,6 +159,71 @@ func TestCanUpdateEntityName(t *testing.T) {
 			result := canUpdateEntityName(tt.entityType, tt.oldEntityName, tt.newEntityName)
 			if result != tt.expected {
 				t.Errorf("canUpdateEntityName(%s, %s, %s) = %v; want %v", tt.entityType, tt.oldEntityName, tt.newEntityName, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsSchemaRegistryApiKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   apikeys.IamV2ApiKey
+		expected bool
+	}{
+		{
+			name: "SR API Key with api_version=srcm/v3",
+			apiKey: apikeys.IamV2ApiKey{
+				Spec: &apikeys.IamV2ApiKeySpec{
+					Resource: &apikeys.ObjectReference{
+						Kind:       apikeys.PtrString(schemaRegistryKind),
+						ApiVersion: apikeys.PtrString(srcmV3ApiVersion),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "SR API Key with api_version=srcm/v2",
+			apiKey: apikeys.IamV2ApiKey{
+				Spec: &apikeys.IamV2ApiKeySpec{
+					Resource: &apikeys.ObjectReference{
+						Kind:       apikeys.PtrString(schemaRegistryKind),
+						ApiVersion: apikeys.PtrString(srcmV2ApiVersion),
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Kafka API Key",
+			apiKey: apikeys.IamV2ApiKey{
+				Spec: &apikeys.IamV2ApiKeySpec{
+					Resource: &apikeys.ObjectReference{
+						Kind:       apikeys.PtrString(schemaRegistryKind),
+						ApiVersion: apikeys.PtrString(cmkApiVersion),
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Cloud API Key",
+			apiKey: apikeys.IamV2ApiKey{
+				Spec: &apikeys.IamV2ApiKeySpec{
+					Resource: &apikeys.ObjectReference{
+						Kind:       apikeys.PtrString("Cloud"),
+						ApiVersion: apikeys.PtrString(iamApiVersion),
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSchemaRegistryApiKey(tt.apiKey)
+			if result != tt.expected {
+				t.Errorf("%s: isSchemaRegistryApiKey() = %v; want %v", tt.name, result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
### What
This PR resolves https://github.com/confluentinc/terraform-provider-confluent/issues/418.

### Note
In short, the issue is `isSchemaRegistryApiKey()` was only expecting for `srcm/v3` API version instead of any of `srcm/v2` or `srcm/v3`.

The API Keys Mgmt API doesn't require `api_version` in the request and it does return `resource.api_version=srcm/v2` by default:
```
➜  ✗ curl --request POST \
  --url https://api.confluent.cloud/iam/v2/api-keys \
  --header 'Authorization: Basic ...' \
  --header 'content-type: application/json' \
  --data '{"spec":{"display_name":"test2","owner":{"id":"sa-6zzw98"},"resource":{"id":"lsrc-kkg0rg","kind":"SchemaRegistry"}}}'
{
  "api_version": "iam/v2",
  "id": "OZSKBWUZFIF6QHUM",
  "kind": "ApiKey",
  "metadata": {
    "created_at": "2024-08-23T14:15:30.4238Z",
    "resource_name": "crn://api.confluent.cloud/organization=cc2d2db8-b889-4d72-8948-9d7cb37c6a9c/service-account=sa-6zzw98/api-key=OZSKBWUZFIF6QHUM",
    "self": "https://api.confluent.cloud/iam/v2/api-keys/OZSKBWUZFIF6QHUM",
    "updated_at": "2024-08-23T14:15:30.4238Z"
  },
  "spec": {
    "description": "",
    "display_name": "test2",
    "owner": {
      "api_version": "iam/v2",
      "id": "sa-6zzw98",
      "kind": "ServiceAccount",
      "related": "https://api.confluent.cloud/iam/v2/service-accounts/sa-6zzw98",
      "resource_name": "crn://api.confluent.cloud/organization=cc2d2db8-b889-4d72-8948-9d7cb37c6a9c/service-account=sa-6zzw98"
    },
    "resource": {
      "api_version": "srcm/v2", <------------
      "environment": "env-0j5orp",
      "id": "lsrc-kkg0rg",
      "kind": "SchemaRegistry",
      "related": "https://api.confluent.cloud/srcm/v2/schema-registries/lsrc-kkg0rg",
      "resource_name": "crn://api.confluent.cloud/organization=cc2d2db8-b889-4d72-8948-9d7cb37c6a9c/schema-registry=lsrc-kkg0rg"
    },
    "secret": "<REDACTED>"
  }
}
```

FWIW we can expect customers to hardcode the value for `api_version` from previous TF Provider versions as well so 

1. We definitely need to accept both `srcm/v2` and `srcm/v3`.
2. We can't hardcode `srcm/v3` in TF state and `DiffSurpressFunc` will help us to resolve a potential TF drift: https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/provider/resource_api_key.go#L417-L423 (`srcm/v2` / `srcm/v3` in TF config but `srcm/v2` / `srcm/v3` in TF state).