### PR TITLE
[APIT-2280] Rebase the airlock branch to avoid conflict in the master…

### DIFF
--- a/examples/configurations/provider-integration-aws/main.tf
+++ b/examples/configurations/provider-integration-aws/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    confluent = {
+      source  = "confluentinc/confluent"
+      version = "2.2.0"
+    }
+  }
+}
+
+provider "confluent" {
+  cloud_api_key    = var.confluent_cloud_api_key
+  cloud_api_secret = var.confluent_cloud_api_secret
+}
+
+resource "confluent_environment" "staging" {
+  display_name = "Staging"
+
+  stream_governance {
+    package = "ESSENTIALS"
+  }
+}
+
+resource "confluent_provider_integration" "main" {
+  environment {
+    id = confluent_environment.staging.id
+  }
+  aws {
+    customer_role_arn = var.customer_role_arn
+  }
+  display_name = "provider_integration_main"
+}

--- a/examples/configurations/provider-integration-aws/variables.tf
+++ b/examples/configurations/provider-integration-aws/variables.tf
@@ -1,0 +1,15 @@
+variable "confluent_cloud_api_key" {
+  description = "Confluent Cloud API Key (also referred as Cloud API ID)"
+  type        = string
+}
+
+variable "confluent_cloud_api_secret" {
+  description = "Confluent Cloud API Secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "customer_role_arn" {
+  description = "The AWS customer's IAM role ARN."
+  type        = string
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-ip v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0
+	github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0
 	github.com/confluentinc/ccloud-sdk-go-v2/schema-registry v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0 h1:3nm/8K
 github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink v0.2.0/go.mod h1:uj/ybBJPQbmuuBdSoznMiMGEwW3z/g0Uko8uKWg36I8=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0 h1:FtaqHX0kBTK7fCQK+9SJcOso+XpWCWzY2roT3gBQGfw=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.9.0/go.mod h1:X0uaTYPp+mr19W1R/Z1LuB1ePZJZrH7kxnQckDx6zoc=
+github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0 h1:a6GlDTUoeX5zRlIPVToH3Aa779QA2Ajj/LYyJC5UQN8=
+github.com/confluentinc/ccloud-sdk-go-v2/provider-integration v0.1.0/go.mod h1:aNAIuiIUbfvqtQrl4yp1f7dMdUInXs+PDrHLvKCr0PE=
 github.com/confluentinc/ccloud-sdk-go-v2/schema-registry v0.4.0 h1:fBki9LEIQOy82oArfbMJxAh5vGPFg9WvHG3HSnZubyk=
 github.com/confluentinc/ccloud-sdk-go-v2/schema-registry v0.4.0/go.mod h1:uTE8K5/jg75ubJY1Flh6TfBIwVFVOchkLWqVsamwLYc=
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.0 h1:BFab+P8PHLsmmPfg/K7eguW1wE9mlL1sLYlvZxVzWH8=

--- a/internal/provider/data_source_provider_integration.go
+++ b/internal/provider/data_source_provider_integration.go
@@ -1,0 +1,197 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
+)
+
+func providerIntegrationDataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: providerIntegrationDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			paramId: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				// A user should provide a value for either "id" or "display_name" attribute, not both
+				ExactlyOneOf: []string{paramId, paramDisplayName},
+				Description:  "The ID for provider integration.",
+			},
+			paramDisplayName: {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				// A user should provide a value for either "id" or "display_name" attribute, not both
+				ExactlyOneOf: []string{paramId, paramDisplayName},
+				Description:  "The display name of provider integration.",
+			},
+			paramAws: awsProviderIntegrationDataSourceConfigSchema(),
+			paramUsages: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The usages of provider integration.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			paramEnvironment: environmentDataSourceSchema(),
+		},
+	}
+}
+
+func awsProviderIntegrationDataSourceConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				paramIamRoleUrn: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "IAM role ARN.",
+				},
+				paramExternalId: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "External ID for the AWS role.",
+				},
+				paramCustomerRoleArn: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The AWS customer's IAM role ARN.",
+				},
+			},
+		},
+		Computed:    true,
+		Description: "Config objects represent AWS cloud provider specific configs.",
+	}
+}
+
+func providerIntegrationDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	pimId := d.Get(paramId).(string)
+	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
+	displayName := d.Get(paramDisplayName).(string)
+
+	if pimId != "" {
+		return providerIntegrationDataSourceReadUsingId(ctx, d, meta, environmentId, pimId)
+	} else if displayName != "" {
+		return providerIntegrationDataSourceReadUsingDisplayName(ctx, d, meta, environmentId, displayName)
+	} else {
+		return diag.Errorf("error reading provider integration: exactly one of %q or %q must be specified but they're both empty", paramId, paramDisplayName)
+	}
+}
+
+func providerIntegrationDataSourceReadUsingId(ctx context.Context, d *schema.ResourceData, meta interface{}, environmentId, pimId string) diag.Diagnostics {
+	tflog.Debug(ctx, fmt.Sprintf("Reading provider integration data source using Id %q", pimId), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+	c := meta.(*Client)
+	pim, _, err := executeProviderIntegrationRead(c.piApiContext(ctx), c, environmentId, pimId)
+
+	if err != nil {
+		return diag.Errorf("error reading provider integration data source using Id %q: %s", pimId, createDescriptiveError(err))
+	}
+	pimJson, err := json.Marshal(pim)
+	if err != nil {
+		return diag.Errorf("error reading provider integration %q: error marshaling %#v to json: %s", pimId, pim, createDescriptiveError(err))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Fetched provider integration %q: %s", pimId, pimJson), map[string]interface{}{providerIntegrationLoggingKey: pimId})
+
+	if _, err := setProviderIntegrationAttributes(d, pim); err != nil {
+		return diag.FromErr(createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Finished reading provider integration %q", pimId), map[string]interface{}{providerIntegrationLoggingKey: pimId})
+	return nil
+}
+
+func providerIntegrationDataSourceReadUsingDisplayName(ctx context.Context, d *schema.ResourceData, meta interface{}, environmentId, displayName string) diag.Diagnostics {
+	tflog.Debug(ctx, fmt.Sprintf("Reading provider integration data source using display name %q", displayName))
+	c := meta.(*Client)
+	providerIntegrations, err := loadProviderIntegrations(ctx, c, environmentId)
+
+	if err != nil {
+		return diag.Errorf("error reading provider integration data source using display name %q: %s", displayName, createDescriptiveError(err))
+	}
+	if orgHasMultipleProviderIntegrationsWithTargetDisplayName(providerIntegrations, displayName) {
+		return diag.Errorf("error reading provider integration: there are multiple provider integrations with %q=%q", paramDisplayName, displayName)
+	}
+
+	for _, providerIntegration := range providerIntegrations {
+		if providerIntegration.GetDisplayName() == displayName {
+			pimJson, err := json.Marshal(providerIntegration)
+			if err != nil {
+				return diag.Errorf("error reading provider integration using display name %q: error marshaling %#v to json: %s", displayName, providerIntegration, createDescriptiveError(err))
+			}
+
+			if _, err := setProviderIntegrationAttributes(d, providerIntegration); err != nil {
+				tflog.Debug(ctx, fmt.Sprintf("Fetched provider integration using display name %q: %s", displayName, pimJson))
+				return diag.FromErr(createDescriptiveError(err))
+			}
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func loadProviderIntegrations(ctx context.Context, c *Client, environmentId string) ([]pi.PimV1Integration, error) {
+	providerIntegrations := make([]pi.PimV1Integration, 0)
+	done := false
+	pageToken := ""
+
+	for !done {
+		providerIntegrationsPageList, _, err := executeListProviderIntegrations(ctx, c, environmentId, pageToken)
+		if err != nil {
+			return nil, fmt.Errorf("error reading provider integrations list: %s", createDescriptiveError(err))
+		}
+		providerIntegrations = append(providerIntegrations, providerIntegrationsPageList.GetData()...)
+
+		// nextPageUrlStringNullable is nil for the last page
+		nextPageUrlStringNullable := providerIntegrationsPageList.GetMetadata().Next
+
+		if nextPageUrlStringNullable.IsSet() {
+			nextPageUrlString := *nextPageUrlStringNullable.Get()
+			if nextPageUrlString == "" {
+				done = true
+			} else {
+				pageToken, err = extractPageToken(nextPageUrlString)
+				if err != nil {
+					return nil, fmt.Errorf("error reading provider integration list: %s", createDescriptiveError(err))
+				}
+			}
+		} else {
+			done = true
+		}
+	}
+
+	return providerIntegrations, nil
+}
+
+func orgHasMultipleProviderIntegrationsWithTargetDisplayName(providerIntegrations []pi.PimV1Integration, displayName string) bool {
+	var counter = 0
+	for _, providerIntegration := range providerIntegrations {
+		if providerIntegration.GetDisplayName() == displayName {
+			counter += 1
+		}
+	}
+	return counter > 1
+}

--- a/internal/provider/data_source_provider_integration_aws_test.go
+++ b/internal/provider/data_source_provider_integration_aws_test.go
@@ -1,0 +1,143 @@
+// Copyright 2022 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/walkerus/go-wiremock"
+)
+
+const (
+	dataSourceProviderIntegrationScenarioName = "confluent_provider_integration Data Source Lifecycle"
+)
+
+func TestAccDataSourceProviderIntegration(t *testing.T) {
+	ctx := context.Background()
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	// Mock the GET of a provider integration
+	readResponse, _ := ioutil.ReadFile("../testdata/provider_integration/read_created_aws_provider_integration.json")
+	readStub := wiremock.Get(wiremock.URLPathEqualTo(fmt.Sprintf("/pim/v1/integrations/%s", providerIntegrationId))).
+		InScenario(dataSourceProviderIntegrationScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(providerIntegrationEnvironmentId)).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(readResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		)
+	_ = wiremockClient.StubFor(readStub)
+
+	// Mock the LIST of the provider integrations
+	listResponse, _ := ioutil.ReadFile("../testdata/provider_integration/read_aws_provider_integrations.json")
+	listStub := wiremock.Get(wiremock.URLPathEqualTo(fmt.Sprintf("/pim/v1/integrations"))).
+		InScenario(dataSourceProviderIntegrationScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(providerIntegrationEnvironmentId)).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(listResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		)
+	_ = wiremockClient.StubFor(listStub)
+
+	dataSourceLabel := "test"
+	fullLabel := fmt.Sprintf("data.confluent_provider_integration.%s", dataSourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDataSourceProviderIntegrationWithIdSet(mockServerUrl, dataSourceLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderIntegrationExists(fullLabel),
+					resource.TestCheckResourceAttr(fullLabel, paramId, providerIntegrationId),
+					resource.TestCheckResourceAttr(fullLabel, paramDisplayName, providerIntegrationDisplayName),
+					resource.TestCheckResourceAttr(fullLabel, "aws.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.customer_role_arn", providerIntegrationCustomerRoleARN),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.iam_role_arn", providerIntegrationIamRoleArn),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.external_id", providerIntegrationExternalId),
+					resource.TestCheckResourceAttr(fullLabel, "usages.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "usages.0", providerIntegrationUsage),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.#", paramEnvironment), "1"),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.0.%s", paramEnvironment, paramId), providerIntegrationEnvironmentId),
+				),
+			},
+			{
+				Config: testAccCheckDataSourceProviderIntegrationWithDisplayNameSet(mockServerUrl, dataSourceLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderIntegrationExists(fullLabel),
+					resource.TestCheckResourceAttr(fullLabel, paramId, providerIntegrationId),
+					resource.TestCheckResourceAttr(fullLabel, paramDisplayName, providerIntegrationDisplayName),
+					resource.TestCheckResourceAttr(fullLabel, "aws.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.customer_role_arn", providerIntegrationCustomerRoleARN),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.iam_role_arn", providerIntegrationIamRoleArn),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.external_id", providerIntegrationExternalId),
+					resource.TestCheckResourceAttr(fullLabel, "usages.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "usages.0", providerIntegrationUsage),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.#", paramEnvironment), "1"),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.0.%s", paramEnvironment, paramId), providerIntegrationEnvironmentId),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceProviderIntegrationWithIdSet(mockServerUrl, dataSourceLabel string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint = "%s"
+	}
+	data "confluent_provider_integration" "%s" {
+		environment {
+    		id = "%s"
+  		}
+		id = "%s"
+	}
+	`, mockServerUrl, dataSourceLabel, providerIntegrationEnvironmentId, providerIntegrationId)
+}
+
+func testAccCheckDataSourceProviderIntegrationWithDisplayNameSet(mockServerUrl, dataSourceLabel string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint = "%s"
+	}
+	data "confluent_provider_integration" "%s" {
+		environment {
+    		id = "%s"
+  		}
+		display_name = "%s"
+	}
+	`, mockServerUrl, dataSourceLabel, providerIntegrationEnvironmentId, providerIntegrationDisplayName)
+}

--- a/internal/provider/resource_provider_integration.go
+++ b/internal/provider/resource_provider_integration.go
@@ -60,6 +60,7 @@ func providerIntegrationResource() *schema.Resource {
 			paramDisplayName: {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				Description:  "The display name of provider integration.",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},

--- a/internal/provider/resource_provider_integration.go
+++ b/internal/provider/resource_provider_integration.go
@@ -1,0 +1,293 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
+)
+
+const (
+	paramIamRoleUrn          = "iam_role_arn"
+	paramExternalId          = "external_id"
+	paramCustomerRoleArn     = "customer_role_arn"
+	paramUsages              = "usages"
+	AwsIntegrationConfigKind = "AwsIntegrationConfig"
+)
+
+const (
+	listProviderIntegrationsPageSize = 99
+)
+
+var acceptedProviderIntegrationConfig = []string{paramAws}
+
+func providerIntegrationResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: providerIntegrationCreate,
+		ReadContext:   providerIntegrationRead,
+		DeleteContext: providerIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: providerIntegrationImport,
+		},
+		Schema: map[string]*schema.Schema{
+			paramId: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID for provider integration.",
+			},
+			paramDisplayName: {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The display name of provider integration.",
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			paramAws: awsProviderIntegrationConfigSchema(),
+			paramUsages: {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The usages of provider integration.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			paramEnvironment: environmentSchema(),
+		},
+	}
+}
+
+func awsProviderIntegrationConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				paramIamRoleUrn: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "IAM role ARN.",
+				},
+				paramExternalId: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "External ID for the AWS role.",
+				},
+				paramCustomerRoleArn: {
+					Type:        schema.TypeString,
+					Required:    true,
+					ForceNew:    true,
+					Description: "The AWS customer's IAM role ARN.",
+				},
+			},
+		},
+		Optional:     true,
+		MinItems:     1,
+		MaxItems:     1,
+		ForceNew:     true,
+		ExactlyOneOf: acceptedProviderIntegrationConfig,
+		Description:  "Config objects represent AWS cloud provider specific configs.",
+	}
+}
+
+func providerIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*Client)
+
+	displayName := d.Get(paramDisplayName).(string)
+	config := pi.PimV1IntegrationConfigOneOf{}
+	var cloud string
+	isAwsConfigs := len(d.Get(paramAws).([]interface{})) > 0
+
+	if isAwsConfigs {
+		cloud = "aws"
+		config.PimV1AwsIntegrationConfig = &pi.PimV1AwsIntegrationConfig{
+			Kind:               AwsIntegrationConfigKind,
+			CustomerIamRoleArn: pi.PtrString(extractStringValueFromBlock(d, paramAws, paramCustomerRoleArn)),
+		}
+	} else {
+		return diag.Errorf("None of %q block was provided for confluent_provider_integration resource", paramAws)
+	}
+
+	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
+
+	// Create the provider integration request
+	createPimRequest := pi.PimV1Integration{}
+	createPimRequest.SetDisplayName(displayName)
+	createPimRequest.SetProvider(cloud)
+	createPimRequest.SetConfig(config)
+	createPimRequest.SetEnvironment(pi.GlobalObjectReference{Id: environmentId})
+	createPimRequestRequestJson, err := json.Marshal(createPimRequest)
+
+	if err != nil {
+		return diag.Errorf("error creating provider integration resource: error marshaling %#v to json: %s", createPimRequest, createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Creating new provider integration resource: %s", createPimRequestRequestJson))
+	createdPimResponse, _, err := executeProviderIntegrationCreate(c.piApiContext(ctx), c, &createPimRequest)
+	if err != nil {
+		return diag.Errorf("error creating provider integration: %s", createDescriptiveError(err))
+	}
+
+	d.SetId(createdPimResponse.GetId())
+	createdPimResponseJson, err := json.Marshal(createdPimResponse)
+
+	if err != nil {
+		return diag.Errorf("error creating provider integration: error marshaling %#v to json: %s", createdPimResponseJson, createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Finished creating provider integration %q: %s", d.Id(), createdPimResponseJson), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+	return providerIntegrationRead(ctx, d, meta)
+}
+
+func providerIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	pimId := d.Get(paramId).(string)
+	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
+	tflog.Debug(ctx, fmt.Sprintf("Reading provider integration resource %q", pimId), map[string]interface{}{providerIntegrationLoggingKey: pimId})
+
+	if _, err := readProviderIntegrationAndSetAttributes(ctx, d, meta, environmentId, pimId); err != nil {
+		return diag.FromErr(fmt.Errorf("error reading provider integration %q: %s", pimId, createDescriptiveError(err)))
+	}
+
+	return nil
+}
+
+func providerIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, fmt.Sprintf("Deleting provider integration %q", d.Id()), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+	c := meta.(*Client)
+	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
+
+	_, err := executeProviderIntegrationDelete(ctx, c, environmentId, d.Id())
+	if err != nil {
+		return diag.Errorf("error deleting provider integration %q: %s", d.Id(), createDescriptiveError(err))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Finished deleting provider integration %q", d.Id()), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+
+	return nil
+}
+
+func providerIntegrationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tflog.Debug(ctx, fmt.Sprintf("Importing provider integration %q", d.Id()), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+
+	envIDAndComputePoolId := d.Id()
+	parts := strings.Split(envIDAndComputePoolId, "/")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("error importing provider integration: invalid format: expected '<env ID>/<provider integration ID>'")
+	}
+
+	environmentId := parts[0]
+	providerIntegrationId := parts[1]
+	d.SetId(providerIntegrationId)
+
+	// Mark resource as new to avoid d.Set("") when getting 404
+	d.MarkNewResource()
+	if _, err := readProviderIntegrationAndSetAttributes(ctx, d, meta, environmentId, providerIntegrationId); err != nil {
+		return nil, fmt.Errorf("error importing provider integration %q: %s", d.Id(), err)
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Finished importing provider integration %q", d.Id()), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+	return []*schema.ResourceData{d}, nil
+}
+
+func readProviderIntegrationAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}, environmentId, id string) ([]*schema.ResourceData, error) {
+	c := meta.(*Client)
+	pim, resp, err := executeProviderIntegrationRead(c.piApiContext(ctx), c, environmentId, id)
+
+	if err != nil {
+		tflog.Warn(ctx, fmt.Sprintf("Error reading provider integration %q: %s", id, createDescriptiveError(err)), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+		isResourceNotFound := isNonKafkaRestApiResourceNotFound(resp)
+		if isResourceNotFound && !d.IsNewResource() {
+			tflog.Warn(ctx, fmt.Sprintf("Removing provider integration %q in TF state because provider integration could not be found on the server", d.Id()), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+			d.SetId("")
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	pimJson, err := json.Marshal(pim)
+	if err != nil {
+		return nil, fmt.Errorf("error reading provider integration %q: error marshaling %#v to json: %s", id, pim, createDescriptiveError(err))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Fetched provider integration %q: %s", d.Id(), pimJson), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+
+	if _, err := setProviderIntegrationAttributes(d, pim); err != nil {
+		return nil, createDescriptiveError(err)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Finished reading provider integration %q", id), map[string]interface{}{providerIntegrationLoggingKey: d.Id()})
+	return []*schema.ResourceData{d}, nil
+}
+
+func executeProviderIntegrationCreate(ctx context.Context, c *Client, createPimRequest *pi.PimV1Integration) (pi.PimV1Integration, *http.Response, error) {
+	req := c.piClient.IntegrationsPimV1Api.CreatePimV1Integration(c.piApiContext(ctx)).PimV1Integration(*createPimRequest)
+	return req.Execute()
+}
+
+func executeProviderIntegrationRead(ctx context.Context, c *Client, environmentId string, id string) (pi.PimV1Integration, *http.Response, error) {
+	req := c.piClient.IntegrationsPimV1Api.GetPimV1Integration(c.piApiContext(ctx), id).Environment(environmentId)
+	return req.Execute()
+}
+
+func executeProviderIntegrationDelete(ctx context.Context, c *Client, environmentId string, pimId string) (*http.Response, error) {
+	req := c.piClient.IntegrationsPimV1Api.DeletePimV1Integration(c.piApiContext(ctx), pimId).Environment(environmentId)
+	return req.Execute()
+}
+
+func executeListProviderIntegrations(ctx context.Context, c *Client, environmentId, pageToken string) (pi.PimV1IntegrationList, *http.Response, error) {
+	if pageToken != "" {
+		return c.piClient.IntegrationsPimV1Api.ListPimV1Integrations(c.piApiContext(ctx)).Environment(environmentId).PageSize(listProviderIntegrationsPageSize).PageToken(pageToken).Execute()
+	} else {
+		return c.piClient.IntegrationsPimV1Api.ListPimV1Integrations(c.piApiContext(ctx)).Environment(environmentId).PageSize(listProviderIntegrationsPageSize).Execute()
+	}
+}
+
+func setProviderIntegrationAttributes(d *schema.ResourceData, pim pi.PimV1Integration) (*schema.ResourceData, error) {
+	if err := d.Set(paramDisplayName, pim.GetDisplayName()); err != nil {
+		return nil, err
+	}
+	if err := setProviderIntegrationConfigAttributes(d, pim.GetConfig()); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramUsages, pim.GetUsages()); err != nil {
+		return nil, err
+	}
+	if err := setStringAttributeInListBlockOfSizeOne(paramEnvironment, paramId, pim.Environment.GetId(), d); err != nil {
+		return nil, err
+	}
+
+	d.SetId(pim.GetId())
+	return d, nil
+}
+
+func setProviderIntegrationConfigAttributes(d *schema.ResourceData, config pi.PimV1IntegrationConfigOneOf) error {
+	if config.PimV1AwsIntegrationConfig != nil {
+		if err := d.Set(paramAws, []interface{}{map[string]interface{}{
+			paramIamRoleUrn:      config.PimV1AwsIntegrationConfig.GetIamRoleArn(),
+			paramExternalId:      config.PimV1AwsIntegrationConfig.GetExternalId(),
+			paramCustomerRoleArn: config.PimV1AwsIntegrationConfig.GetCustomerIamRoleArn(),
+		}}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/resource_provider_integration_aws_test.go
+++ b/internal/provider/resource_provider_integration_aws_test.go
@@ -1,0 +1,204 @@
+// Copyright 2022 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/walkerus/go-wiremock"
+)
+
+const (
+	providerIntegrationScenarioName                = "confluent_provider_integration Resource Lifecycle"
+	scenarioStateProviderIntegrationHasBeenCreated = "The new provider_integration has been just created"
+	scenarioStateProviderIntegrationHasBeenDeleted = "The provider_integration has been deleted"
+	providerIntegrationId                          = "dlz-f3a90de"
+	providerIntegrationDisplayName                 = "s3_provider_integration"
+	providerIntegrationEnvironmentId               = "env-00000"
+	providerIntegrationIamRoleArn                  = "arn:aws:iam::000000000000:role/my-test-aws-role"
+	providerIntegrationExternalId                  = "95c35493-41aa-44f8-9154-5a25cbbc1865"
+	providerIntegrationCustomerRoleARN             = "arn:aws:iam::000000000000:role/my-test-aws-role"
+	providerIntegrationUsage                       = "crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-456xy/cloud-cluster=lkc-123abc/connector=my_datagen_connector"
+)
+
+func TestAccProviderIntegration(t *testing.T) {
+	ctx := context.Background()
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	// Mock the POST of a provider integration
+	createResponse, _ := ioutil.ReadFile("../testdata/provider_integration/create_aws_provider_integration.json")
+	createStub := wiremock.Post(wiremock.URLPathEqualTo("/pim/v1/integrations")).
+		InScenario(providerIntegrationScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateProviderIntegrationHasBeenCreated).
+		WillReturn(
+			string(createResponse),
+			contentTypeJSONHeader,
+			http.StatusCreated,
+		)
+	_ = wiremockClient.StubFor(createStub)
+
+	// Mock the GET of a provider integration
+	readResponse, _ := ioutil.ReadFile("../testdata/provider_integration/read_created_aws_provider_integration.json")
+	readStub := wiremock.Get(wiremock.URLPathEqualTo(fmt.Sprintf("/pim/v1/integrations/%s", providerIntegrationId))).
+		InScenario(providerIntegrationScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(providerIntegrationEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateProviderIntegrationHasBeenCreated).
+		WillReturn(
+			string(readResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		)
+	_ = wiremockClient.StubFor(readStub)
+
+	// Mock the DELETE of a provider integration
+	deleteStub := wiremock.Delete(wiremock.URLPathEqualTo(fmt.Sprintf("/pim/v1/integrations/%s", providerIntegrationId))).
+		InScenario(providerIntegrationScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(providerIntegrationEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateProviderIntegrationHasBeenCreated).
+		WillSetStateTo(scenarioStateProviderIntegrationHasBeenDeleted).
+		WillReturn(
+			"",
+			contentTypeJSONHeader,
+			http.StatusNoContent,
+		)
+	_ = wiremockClient.StubFor(deleteStub)
+
+	// Mock the GET of a deleted provider integration during terraform destroy
+	readDeletedResponse, _ := ioutil.ReadFile("../testdata/provider_integration/read_deleted_aws_provider_integration.json")
+	readDeletedStub := wiremock.Get(wiremock.URLPathEqualTo(fmt.Sprintf("/pim/v1/integrations/%s", providerIntegrationId))).
+		InScenario(providerIntegrationScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(providerIntegrationEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateProviderIntegrationHasBeenDeleted).
+		WillReturn(
+			string(readDeletedResponse),
+			contentTypeJSONHeader,
+			http.StatusNotFound,
+		)
+	_ = wiremockClient.StubFor(readDeletedStub)
+
+	resourceLabel := "test"
+	fullLabel := fmt.Sprintf("confluent_provider_integration.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckProviderIntegrationConfig(mockServerUrl, resourceLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProviderIntegrationExists(fullLabel),
+					resource.TestCheckResourceAttr(fullLabel, paramId, providerIntegrationId),
+					resource.TestCheckResourceAttr(fullLabel, paramDisplayName, providerIntegrationDisplayName),
+					resource.TestCheckResourceAttr(fullLabel, "aws.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.customer_role_arn", providerIntegrationCustomerRoleARN),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.iam_role_arn", providerIntegrationIamRoleArn),
+					resource.TestCheckResourceAttr(fullLabel, "aws.0.external_id", providerIntegrationExternalId),
+					resource.TestCheckResourceAttr(fullLabel, "usages.#", "1"),
+					resource.TestCheckResourceAttr(fullLabel, "usages.0", providerIntegrationUsage),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.#", paramEnvironment), "1"),
+					resource.TestCheckResourceAttr(fullLabel, fmt.Sprintf("%s.0.%s", paramEnvironment, paramId), providerIntegrationEnvironmentId),
+				),
+			},
+			{
+				// https://www.terraform.io/docs/extend/resources/import.html
+				ResourceName:      fullLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					pimId := resources[fullLabel].Primary.ID
+					environmentId := resources[fullLabel].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + pimId, nil
+				},
+			},
+		},
+		CheckDestroy: testAccCheckProviderIntegrationDestroy,
+	})
+}
+
+func testAccCheckProviderIntegrationDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*Client)
+	// Loop through the resources in state, verifying each provider integration is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "confluent_provider_integration" {
+			continue
+		}
+		deletedProviderIntegrationId := rs.Primary.ID
+		req := c.piClient.IntegrationsPimV1Api.GetPimV1Integration(c.netApiContext(context.Background()), deletedProviderIntegrationId).Environment(providerIntegrationEnvironmentId)
+		deletedProviderIntegration, response, err := req.Execute()
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return nil
+		} else if err == nil && deletedProviderIntegration.Id != nil {
+			// Otherwise return the error
+			if *deletedProviderIntegration.Id == rs.Primary.ID {
+				return fmt.Errorf("provider integration (%s) still exists", rs.Primary.ID)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func testAccCheckProviderIntegrationConfig(mockServerUrl, resourceLabel string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint = "%s"
+	}
+	resource "confluent_provider_integration" "%s" {
+		environment {
+    		id = "%s"
+  		}
+		display_name = "%s"
+		aws {
+    		customer_role_arn = "%s"
+  		}
+	}
+	`, mockServerUrl, resourceLabel, providerIntegrationEnvironmentId, providerIntegrationDisplayName, providerIntegrationCustomerRoleARN)
+}
+
+func testAccCheckProviderIntegrationExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("%s provider integration has not been found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID has not been set for %s provider integration", n)
+		}
+
+		return nil
+	}
+}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -39,6 +39,7 @@ import (
 	netpl "github.com/confluentinc/ccloud-sdk-go-v2/networking-privatelink/v1"
 	net "github.com/confluentinc/ccloud-sdk-go-v2/networking/v1"
 	org "github.com/confluentinc/ccloud-sdk-go-v2/org/v2"
+	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
 	schemaregistry "github.com/confluentinc/ccloud-sdk-go-v2/schema-registry/v1"
 	srcm "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v3"
 	"github.com/confluentinc/ccloud-sdk-go-v2/sso/v2"
@@ -115,6 +116,7 @@ const (
 	schemaRegistryKekKey                      = "kek_id"
 	schemaRegistryDekKey                      = "dek_id"
 	entityAttributesLoggingKey                = "entity_attributes_id"
+	providerIntegrationLoggingKey             = "provider_integration_id"
 )
 
 func (c *Client) apiKeysApiContext(ctx context.Context) context.Context {
@@ -186,6 +188,17 @@ func (c *Client) iamApiContext(ctx context.Context) context.Context {
 func (c *Client) ssoApiContext(ctx context.Context) context.Context {
 	if c.cloudApiKey != "" && c.cloudApiSecret != "" {
 		return context.WithValue(context.Background(), sso.ContextBasicAuth, sso.BasicAuth{
+			UserName: c.cloudApiKey,
+			Password: c.cloudApiSecret,
+		})
+	}
+	tflog.Warn(ctx, "Could not find Cloud API Key")
+	return ctx
+}
+
+func (c *Client) piApiContext(ctx context.Context) context.Context {
+	if c.cloudApiKey != "" && c.cloudApiSecret != "" {
+		return context.WithValue(context.Background(), pi.ContextBasicAuth, pi.BasicAuth{
 			UserName: c.cloudApiKey,
 			Password: c.cloudApiSecret,
 		})

--- a/internal/testdata/provider_integration/create_aws_provider_integration.json
+++ b/internal/testdata/provider_integration/create_aws_provider_integration.json
@@ -1,0 +1,19 @@
+{
+  "api_version": "pim/v1",
+  "kind": "Integration",
+  "id": "dlz-f3a90de",
+  "display_name": "s3_provider_integration",
+  "provider": "AWS",
+  "config": {
+    "iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+    "external_id": "95c35493-41aa-44f8-9154-5a25cbbc1865",
+    "customer_iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+    "kind": "AwsIntegrationConfig"
+  },
+  "usages": [],
+  "environment": {
+    "id": "env-00000",
+    "related": "https://api.confluent.cloud/v2/environments/env-00000",
+    "resource_name": "https://api.confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-00000"
+  }
+}

--- a/internal/testdata/provider_integration/read_aws_provider_integrations.json
+++ b/internal/testdata/provider_integration/read_aws_provider_integrations.json
@@ -1,0 +1,28 @@
+{
+  "api_version": "pim/v1",
+  "kind": "IntegrationList",
+  "metadata": {},
+  "data": [
+    {
+      "api_version": "pim/v1",
+      "kind": "Integration",
+      "id": "dlz-f3a90de",
+      "display_name": "s3_provider_integration",
+      "provider": "AWS",
+      "config": {
+        "iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+        "external_id": "95c35493-41aa-44f8-9154-5a25cbbc1865",
+        "customer_iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+        "kind": "AwsIntegrationConfig"
+      },
+      "usages": [
+        "crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-456xy/cloud-cluster=lkc-123abc/connector=my_datagen_connector"
+      ],
+      "environment": {
+        "id": "env-00000",
+        "related": "https://api.confluent.cloud/v2/environments/env-00000",
+        "resource_name": "https://api.confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-00000"
+      }
+    }
+  ]
+}

--- a/internal/testdata/provider_integration/read_created_aws_provider_integration.json
+++ b/internal/testdata/provider_integration/read_created_aws_provider_integration.json
@@ -1,0 +1,21 @@
+{
+  "api_version": "pim/v1",
+  "kind": "Integration",
+  "id": "dlz-f3a90de",
+  "display_name": "s3_provider_integration",
+  "provider": "AWS",
+  "config": {
+    "iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+    "external_id": "95c35493-41aa-44f8-9154-5a25cbbc1865",
+    "customer_iam_role_arn": "arn:aws:iam::000000000000:role/my-test-aws-role",
+    "kind": "AwsIntegrationConfig"
+  },
+  "usages": [
+    "crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-456xy/cloud-cluster=lkc-123abc/connector=my_datagen_connector"
+  ],
+  "environment": {
+    "id": "env-00000",
+    "related": "https://api.confluent.cloud/v2/environments/env-00000",
+    "resource_name": "https://api.confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/environment=env-00000"
+  }
+}

--- a/internal/testdata/provider_integration/read_deleted_aws_provider_integration.json
+++ b/internal/testdata/provider_integration/read_deleted_aws_provider_integration.json
@@ -1,0 +1,4 @@
+{
+  "error_code": 404,
+  "message": "Provider Integration dlz-f3a90de not found"
+}


### PR DESCRIPTION
### Summary:

The provider integration feature from [APIT-2280](https://confluentinc.atlassian.net/browse/APIT-2280).

Adding the fundamental CRUD operation and associated acceptance tests for both resource and data source.

### Supported operations:

- Create a provider integration
- Describe a provider integration
- List provider integrations, optionally filtered by cloud provider, supporting pagination.
- Delete a provider integration.
- Update a provider is not supported.

### Test done:

Acceptance tests are successful for the newly added `TestAccProviderIntegration` and `TestAccDataSourceProviderIntegration`.

The manually `terraform plan/apply/delete` output files will be available shortly.

### References

https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3291517621/Provider+Integration+Resource+APIs+and+RBAC

[APIT-2280]: https://confluentinc.atlassian.net/browse/APIT-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ