### PR TITLE
[APIT-884] Support for Flink statement resume feature (#40)

### DIFF
--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -108,7 +108,11 @@ The following arguments are supported:
     - `name` - (Required String) The setting name, for example, `sql.local-time-zone`.
     - `value` - (Required String) The setting value, for example, `GMT-08:00`.
 
-- `stopped` - (Optional Boolean) The boolean flag to control whether the running Flink Statement should be stopped. Defaults to `false`. Update it to `true` to stop the statement.
+- `stopped` - (Optional Boolean) The boolean flag to control whether the running Flink Statement should be stopped. Defaults to `false`. Update it to `true` to stop the statement. Subsequently, update it to `false` to resume the statement.
+
+!> **Note:** To stop a running statement or resume a stopped statement, no other argument can be updated except `stopped`.
+
+!> **Note:** Currently, only 3 Flink statements support the resuming feature, namely: `CREATE TABLE AS`, `INSERT INTO`, and `EXECUTE STATEMENT SET`.
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_flink_statement` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/data-catalog v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
-	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.10.0
+	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0
 	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/data-catalog v0.2.0 h1:ySx0jYNGK0XLcSkg
 github.com/confluentinc/ccloud-sdk-go-v2/data-catalog v0.2.0/go.mod h1:27GwI+j82LDFydahgmKVroqw6oFxzbvIj+ZOnksaKGw=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0 h1:QqtIFEB5E3CIyGMJd7NQBEtc/k3K11PX7f4Fj7sPFdo=
 github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0/go.mod h1:GPj4sfR85OyiFQUMNEq1DtPOjYVAuE222Z6Mcapwa48=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.10.0 h1:KQVHoct3guckqY2dbzmNouJRwtUfESAKCOjSfbNOuKU=
-github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.10.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0 h1:fra7uBCCtYkUFtHb6ununxMWqYuVonG52t1mV9o7qRE=
+github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.12.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0 h1:AV0bGk01bGfKzNq5IVqRi2iEc6YTeBbl//IYvQ/j8ag=
 github.com/confluentinc/ccloud-sdk-go-v2/iam v0.10.0/go.mod h1:2Lm82ly9Yh5LLhp8OTnUGqjz4JdIXAZ5a0/u9T+rGGU=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=

--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -38,6 +38,8 @@ const (
 	stateCompleted = "COMPLETED"
 	statePending   = "PENDING"
 	stateFailing   = "FAILING"
+	stateResuming  = "RESUMING"
+	stateStopping  = "STOPPING"
 
 	statementsAPICreateTimeout = 6 * time.Hour
 )
@@ -215,38 +217,51 @@ func flinkStatementRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func flinkStatementUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Make sure we only have a paramStopped update,
+	// Updating anything else is not supported at this moment
+	// stopped: false -> true to trigger flinkStatementStop
+	// stopped: true -> false to trigger flinkStatementResume
 	if d.HasChangeExcept(paramStopped) {
-		return diag.Errorf("error updating Flink Statement %q: only %q attribute can be updated for Flink Statement", d.Id(), paramStopped)
-	}
-	updatedStopped := d.Get(paramStopped).(bool)
-	if updatedStopped == false {
-		return diag.Errorf("error updating Flink Statement %q: Flink Statement cannot be resumed. Only "+
-			"%s=false -> %s=true updates are supported.", d.Id(), paramStopped, paramStopped)
+		return diag.Errorf(`error updating Flink Statement %q: only %q attribute can be updated for Flink Statement, "true" -> "false" to trigger resuming, "false" -> "true" to trigger stopping`, d.Id(), paramStopped)
 	}
 
+	if d.Get(paramStopped).(bool) == false {
+		return flinkStatementUpdateWithFlag(ctx, d, meta, false)
+	}
+
+	return flinkStatementUpdateWithFlag(ctx, d, meta, true)
+}
+
+// On entering this function, it's guaranteed that `stopped` has a change
+// boolean flag `toStop` = true indicates a stop, false indicates a resume
+func flinkStatementUpdateWithFlag(ctx context.Context, d *schema.ResourceData, meta interface{}, toStop bool) diag.Diagnostics {
+	message := "stopping"
+	if toStop == false {
+		message = "resuming"
+	}
 	restEndpoint, err := extractFlinkRestEndpoint(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	organizationId, err := extractFlinkOrganizationId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	environmentId, err := extractFlinkEnvironmentId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	computePoolId, err := extractFlinkComputePoolId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	principalId, err := extractFlinkPrincipalId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	flinkApiKey, flinkApiSecret, err := extractFlinkApiKeyAndApiSecret(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
 	}
 	flinkRestClient := meta.(*Client).flinkRestClientFactory.CreateFlinkRestClient(restEndpoint, organizationId, environmentId, computePoolId, principalId, flinkApiKey, flinkApiSecret, meta.(*Client).isFlinkMetadataSet)
 
@@ -256,30 +271,38 @@ func flinkStatementUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	statement, _, err := req.Execute()
 
 	if err != nil {
-		return diag.Errorf("error updating Flink Statement: error fetching Flink Statement: %s", createDescriptiveError(err))
+		return diag.Errorf("error %s Flink Statement: error fetching Flink Statement: %s", message, createDescriptiveError(err))
 	}
 
 	// The statement could be automatically stopped if no client has consumed the results for 5 minutes or more.
-	// Therefore, we need to double-check whether the backend has already stopped the statement.
-	shouldSendUpdateRequest := !statement.Spec.GetStopped()
+	// Therefore, we need to double-check whether the backend has already stopped/resumed the statement.
+	var shouldSendUpdateRequest bool
+	if toStop {
+		// When trying to stop the statement, current statement `stopped` status should be false
+		shouldSendUpdateRequest = !statement.Spec.GetStopped()
+	} else {
+		// When trying to resume the statement, current statement `stopped` status should be true
+		shouldSendUpdateRequest = statement.Spec.GetStopped()
+	}
+
 	if shouldSendUpdateRequest {
-		statement.Spec.SetStopped(true)
+		statement.Spec.SetStopped(toStop)
 		updateFlinkStatementRequestJson, err := json.Marshal(statement)
 		if err != nil {
-			return diag.Errorf("error updating Flink Statement %q: error marshaling %#v to json: %s", statementName, statement, createDescriptiveError(err))
+			return diag.Errorf("error %s Flink Statement %q: error marshaling %#v to json: %s", message, statementName, statement, createDescriptiveError(err))
 		}
-		tflog.Debug(ctx, fmt.Sprintf("Updating Flink Statement %q: %s", statementName, updateFlinkStatementRequestJson), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+		tflog.Debug(ctx, fmt.Sprintf("%s Flink Statement %q: %s", message, statementName, updateFlinkStatementRequestJson), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
 		req := flinkRestClient.apiClient.StatementsSqlV1Api.UpdateSqlv1Statement(flinkRestClient.apiContext(ctx), organizationId, environmentId, statementName).SqlV1Statement(statement)
 		_, err = req.Execute()
 		if err != nil {
-			return diag.Errorf("error updating Flink Statement 123 %q: %s", statementName, createDescriptiveError(err))
+			return diag.Errorf("error %s Flink Statement 123 %q: %s", message, statementName, createDescriptiveError(err))
 		}
-		if err := waitForFlinkStatementToBeStopped(flinkRestClient.apiContext(ctx), flinkRestClient, statementName, meta.(*Client).isAcceptanceTestMode); err != nil {
-			return diag.Errorf("error waiting for Flink Statement %q to be stopped: %s", statementName, createDescriptiveError(err))
+		if err := waitForFlinkStatementToBeUpdated(flinkRestClient.apiContext(ctx), flinkRestClient, statementName, meta.(*Client).isAcceptanceTestMode, toStop); err != nil {
+			return diag.Errorf("error waiting for Flink Statement %q to update: %s", statementName, createDescriptiveError(err))
 		}
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished updating Flink Statement %q", statementName), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished %s Flink Statement %q", message, statementName), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
 	return flinkStatementRead(ctx, d, meta)
 }
 

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -724,19 +724,32 @@ func waitForFlinkStatementToBeDeleted(ctx context.Context, c *FlinkRestClient, s
 	return nil
 }
 
-func waitForFlinkStatementToBeStopped(ctx context.Context, c *FlinkRestClient, statementName string, isAcceptanceTestMode bool) error {
+func waitForFlinkStatementToBeUpdated(ctx context.Context, c *FlinkRestClient, statementName string, isAcceptanceTestMode bool, toStop bool) error {
 	delay, pollInterval := getDelayAndPollInterval(5*time.Second, 10*time.Second, isAcceptanceTestMode)
+	var pendingStates, targetStates []string
+	var targetStatusMessage string
+
+	if toStop {
+		pendingStates = []string{statePending, stateRunning, stateCompleted, stateStopping}
+		targetStates = []string{stateStopped}
+		targetStatusMessage = stateStopped
+	} else {
+		pendingStates = []string{stateStopped, stateResuming}
+		targetStates = []string{statePending, stateRunning, stateCompleted}
+		targetStatusMessage = fmt.Sprintf("%s, %s or %s", statePending, stateRunning, stateCompleted)
+	}
+
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{statePending, stateRunning, stateCompleted},
-		Target:  []string{stateStopped},
-		Refresh: flinkStatementStoppingStatus(c.apiContext(ctx), c, statementName),
+		Pending: pendingStates,
+		Target:  targetStates,
+		Refresh: flinkStatementUpdatingStatus(c.apiContext(ctx), c, statementName, targetStatusMessage),
 		// Default timeout
 		Timeout:      20 * time.Minute,
 		Delay:        delay,
 		PollInterval: pollInterval,
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q stopping status to become %q", statementName, stateStopped), map[string]interface{}{flinkStatementLoggingKey: statementName})
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q stopped status to become %q", statementName, targetStatusMessage), map[string]interface{}{flinkStatementLoggingKey: statementName})
 	if _, err := stateConf.WaitForStateContext(c.apiContext(ctx)); err != nil {
 		return err
 	}
@@ -1153,7 +1166,7 @@ func flinkStatementProvisionStatus(ctx context.Context, c *FlinkRestClient, stat
 	}
 }
 
-func flinkStatementStoppingStatus(ctx context.Context, c *FlinkRestClient, statementName string) resource.StateRefreshFunc {
+func flinkStatementUpdatingStatus(ctx context.Context, c *FlinkRestClient, statementName, targetStatusMessage string) resource.StateRefreshFunc {
 	return func() (result interface{}, s string, err error) {
 		statement, _, err := executeFlinkStatementRead(c.apiContext(ctx), c, statementName)
 		if err != nil {
@@ -1161,7 +1174,7 @@ func flinkStatementStoppingStatus(ctx context.Context, c *FlinkRestClient, state
 			return nil, stateUnknown, err
 		}
 
-		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q provisioning status to become %q: current status is %q", statementName, stateStopped, statement.Status.GetPhase()), map[string]interface{}{flinkStatementLoggingKey: statementName})
+		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q provisioning status to become %q: current status is %q", statementName, targetStatusMessage, statement.Status.GetPhase()), map[string]interface{}{flinkStatementLoggingKey: statementName})
 		if statement.Status.GetPhase() == statePending || statement.Status.GetPhase() == stateRunning || statement.Status.GetPhase() == stateCompleted || statement.Status.GetPhase() == stateStopped {
 			return statement, statement.Status.GetPhase(), nil
 		} else if statement.Status.GetPhase() == stateFailed || statement.Status.GetPhase() == stateFailing {

--- a/internal/testdata/flink_statement/read_resumed_flink_statement.json
+++ b/internal/testdata/flink_statement/read_resumed_flink_statement.json
@@ -1,0 +1,39 @@
+{
+  "api_version": "sql/v1",
+  "environment_id": "env-abc123",
+  "kind": "Statement",
+  "metadata": {
+    "created_at": "2023-11-15T08:34:12Z",
+    "resource_version": "1",
+    "self": "https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/1111aaaa-11aa-11aa-11aa-111111aaaaaa/environments/env-abc123/statements/workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9",
+    "uid": "8b9c49bb-7351-416d-98d5-d5f29f6de980",
+    "updated_at": "2023-11-15T08:35:20Z"
+  },
+  "name": "workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "spec": {
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "properties": {
+      "sql.local-time-zone": "GMT-08:00"
+    },
+    "statement": "SELECT CURRENT_TIMESTAMP;",
+    "stopped": false
+  },
+  "status": {
+    "detail": "",
+    "phase": "PENDING",
+    "result_schema": {
+      "columns": [
+        {
+          "name": "CURRENT_TIMESTAMP",
+          "type": {
+            "nullable": false,
+            "precision": 3,
+            "type": "TIMESTAMP_WITH_LOCAL_TIME_ZONE"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Support for Flink statement resume feature:

1. Differentiate the `flinkStatementUpdate` function into `flinkStatementResume` and `flinkStatementStop`.
2. Allow the Flink statement to be resumed from `stopped` = true -> false scenario.
3. Update all ACC test cases with additional scenario to resume the Flink statement.

The successfully test step-by-step TF procedure with real infrastructure can be found here (Confluent Only):
https://docs.google.com/document/d/163ffPHucuITuUWV3ptDKMDTJzrWKs9BHdKHcIeNNan0/edit#heading=h.a96w50hs5wqs