### PR TITLE
#minor: prepare for v2.4.0 minor release (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.4.0 (October 1st, 2024)
+
+[Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.3.0...v2.4.0)
+
+**New features:**
+* Added support for `confluent_flink_statement` [resource](docs/resources/confluent_flink_statement.md) resume feature.
+
+**Bug fixes:**
+* Updated docs for `confluent_kafka_client_quota` [resource](docs/resources/confluent_kafka_client_quota.md) and [data-source](docs/data-sources/confluent_kafka_client_quota.md).
+
 ## 2.3.0 (September 20th, 2024)
 
 [Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.2.0...v2.3.0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/azure-key-vault/main.tf
+++ b/examples/configurations/azure-key-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/basic-kafka-acls-with-alias/main.tf
+++ b/examples/configurations/basic-kafka-acls-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/basic-kafka-acls/main.tf
+++ b/examples/configurations/basic-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/cloud-importer/main.tf
+++ b/examples/configurations/cloud-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
+++ b/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
 
     aws = {

--- a/examples/configurations/connectors/custom-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/custom-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
+++ b/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/managed-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/managed-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-source-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/s3-sink-connector/main.tf
+++ b/examples/configurations/connectors/s3-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/snowflake-sink-connector/main.tf
+++ b/examples/configurations/connectors/snowflake-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
+++ b/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
 
     aws = {

--- a/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
 
     azurerm = {

--- a/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
 
     google = {

--- a/examples/configurations/dedicated-public-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-public-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-public-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
 
     azurerm = {

--- a/examples/configurations/flink-quickstart-2/main.tf
+++ b/examples/configurations/flink-quickstart-2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/flink-quickstart/main.tf
+++ b/examples/configurations/flink-quickstart/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/hashicorp-vault/main.tf
+++ b/examples/configurations/hashicorp-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/examples/configurations/kafka-importer/main.tf
+++ b/examples/configurations/kafka-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/ksql-acls/main.tf
+++ b/examples/configurations/ksql-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/ksql-rbac/main.tf
+++ b/examples/configurations/ksql-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
+++ b/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/managing-single-kafka-cluster/main.tf
+++ b/examples/configurations/managing-single-kafka-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/managing-single-schema-registry-cluster/main.tf
+++ b/examples/configurations/managing-single-schema-registry-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-avro-schema/main.tf
+++ b/examples/configurations/multiple-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-proto-schema/main.tf
+++ b/examples/configurations/multiple-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/provider-integration-aws/main.tf
+++ b/examples/configurations/provider-integration-aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/schema-linking/main.tf
+++ b/examples/configurations/schema-linking/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/schema-registry-importer/main.tf
+++ b/examples/configurations/schema-registry-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-avro-schema/main.tf
+++ b/examples/configurations/single-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
+++ b/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema/main.tf
+++ b/examples/configurations/single-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/source-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/source-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-acls/main.tf
+++ b/examples/configurations/standard-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-rbac/main.tf
+++ b/examples/configurations/standard-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/stream-catalog/main.tf
+++ b/examples/configurations/stream-catalog/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
+++ b/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.3.0"
+      version = "2.4.0"
     }
   }
 }

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -589,7 +589,7 @@ func createHclFileWithHeader(mode ImporterMode) *hclwrite.File {
 	requiredProvidersBlock := tfBlock.Body().AppendNewBlock("required_providers", nil)
 	requiredProvidersBlock.Body().SetAttributeValue("confluent", zclCty.ObjectVal(map[string]zclCty.Value{
 		"source":  zclCty.StringVal("confluentinc/confluent"),
-		"version": zclCty.StringVal("2.3.0"),
+		"version": zclCty.StringVal("2.4.0"),
 	}))
 
 	providerBlock := body.AppendNewBlock("provider", []string{"confluent"})


### PR DESCRIPTION
## 2.4.0 (October 1st, 2024)

[Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.3.0...v2.4.0)

**New features:**
* Added support for `confluent_flink_statement` [resource](docs/resources/confluent_flink_statement.md) resume feature.

**Bug fixes:**
* Updated docs for `confluent_kafka_client_quota` [resource](docs/resources/confluent_kafka_client_quota.md) and [data-source](docs/data-sources/confluent_kafka_client_quota.md).