### PR TITLE
Fix "error waiting for Flink Statement: ... : is an unexpected state "STOPPING" 

### DIFF
--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -1175,7 +1175,7 @@ func flinkStatementUpdatingStatus(ctx context.Context, c *FlinkRestClient, state
 		}
 
 		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q provisioning status to become %q: current status is %q", statementName, targetStatusMessage, statement.Status.GetPhase()), map[string]interface{}{flinkStatementLoggingKey: statementName})
-		if statement.Status.GetPhase() == statePending || statement.Status.GetPhase() == stateRunning || statement.Status.GetPhase() == stateCompleted || statement.Status.GetPhase() == stateStopped {
+		if statement.Status.GetPhase() == statePending || statement.Status.GetPhase() == stateRunning || statement.Status.GetPhase() == stateCompleted || statement.Status.GetPhase() == stateStopped  || statement.Status.GetPhase() == stateStopping {
 			return statement, statement.Status.GetPhase(), nil
 		} else if statement.Status.GetPhase() == stateFailed || statement.Status.GetPhase() == stateFailing {
 			return nil, stateFailed, fmt.Errorf("flink Statement %q provisioning status is %q", statementName, statement.Status.GetPhase())


### PR DESCRIPTION
### What
When working on a relevant task, I ran into an issue with stopping Flink statements:
```
  ~ update in-place

Terraform will perform the following actions:

  # confluent_flink_statement.insert-into-table will be updated in-place
  ~ resource "confluent_flink_statement" "insert-into-table" {
        id                       = "env-devcg1gy1r/lfcp-devc2g87dm/tf-2024-10-14-175011-47aef93e-a292-446e-9970-21e5d47805af"
      ~ stopped                  = false -> true
        # (5 unchanged attributes hidden)
    }


confluent_flink_statement.insert-into-table: Refreshing state... [id=env-devcg1gy1r/lfcp-devc2g87dm/tf-2024-10-14-175011-47aef93e-a292-446e-9970-21e5d47805af]
confluent_flink_statement.insert-into-table: Modifying... [id=env-devcg1gy1r/lfcp-devc2g87dm/tf-2024-10-14-175011-47aef93e-a292-446e-9970-21e5d47805af]

Error: error waiting for Flink Statement "tf-2024-10-14-175011-47aef93e-a292-446e-9970-21e5d47805af" to update: flink Statement "tf-2024-10-14-175011-47aef93e-a292-446e-9970-21e5d47805af" is an unexpected state "STOPPING"
```

It seems like there was a typo where we didn't process all pending / target states in `flinkStatementUpdatingStatus` from `waitForFlinkStatementToBeUpdated`.

### Testing
* <REDACTED>