### PR TITLE
Fix SR exporter provisioning issues

### DIFF
--- a/internal/provider/resource_schema_exporter.go
+++ b/internal/provider/resource_schema_exporter.go
@@ -45,7 +45,7 @@ const (
 	schemaRegistryUrlConfig               = "schema.registry.url"
 	basicAuthUserInfoConfig               = "basic.auth.user.info"
 
-	schemaExporterAPICreateTimeout = 24 * time.Hour
+	schemaExporterAPICreateTimeout = 4 * time.Hour
 )
 
 var standardConfigs = []string{basicAuthUserInfoConfig, schemaRegistryUrlConfig, basicAuthCredentialsSourceConfig}

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -528,7 +528,7 @@ func waitForSchemaExporterToProvision(ctx context.Context, c *SchemaRegistryRest
 		Pending:      []string{stateProvisioning},
 		Target:       []string{stateReady},
 		Refresh:      schemaExporterProvisionStatus(c.apiContext(ctx), c, id, name),
-		Timeout:      dataCatalogExporterTimeout,
+		Timeout:      schemaExporterAPICreateTimeout,
 		PollInterval: 30 * time.Second,
 	}
 
@@ -1175,7 +1175,7 @@ func flinkStatementUpdatingStatus(ctx context.Context, c *FlinkRestClient, state
 		}
 
 		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Statement %q provisioning status to become %q: current status is %q", statementName, targetStatusMessage, statement.Status.GetPhase()), map[string]interface{}{flinkStatementLoggingKey: statementName})
-		if statement.Status.GetPhase() == statePending || statement.Status.GetPhase() == stateRunning || statement.Status.GetPhase() == stateCompleted || statement.Status.GetPhase() == stateStopped  || statement.Status.GetPhase() == stateStopping {
+		if statement.Status.GetPhase() == statePending || statement.Status.GetPhase() == stateRunning || statement.Status.GetPhase() == stateCompleted || statement.Status.GetPhase() == stateStopped || statement.Status.GetPhase() == stateStopping {
 			return statement, statement.Status.GetPhase(), nil
 		} else if statement.Status.GetPhase() == stateFailed || statement.Status.GetPhase() == stateFailing {
 			return nil, stateFailed, fmt.Errorf("flink Statement %q provisioning status is %q", statementName, statement.Status.GetPhase())


### PR DESCRIPTION
### What
This PR is a follow up to #462 where I forgot to update internal provisioning function of SR exporter. It
* Starts using schemaExporterAPICreateTimeout in the internal provisioning function, which is the component that actually triggers the error (timeout after 10 minutes).
* Reduces the schemaExporterAPICreateTimeout from 24 hours to 4 hours, as 4 hours should be sufficient even for huge users with 20k+ schemas (assuming it takes 40 minutes to export 4k schemas).