### PR TITLE
Fix "syntax error: package statement must be first"

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -20,7 +20,7 @@ blocks:
             - git clone --branch go$(cat terraform-provider-confluent*/.go-version)-1-openssl-fips --depth 1 https://github.com/golang-fips/go.git go-openssl
             - cd go
             - brew install gpatch
-            - cat ../go-openssl/patches/*.patch | patch -p1
+            - cat ../go-openssl/patches/*.patch | gpatch -p1
             - sed -i '' 's/linux/darwin/' src/crypto/internal/backend/nobackend.go
             - sed -i '' 's/linux/darwin/' src/crypto/internal/backend/openssl.go
             - sed -i '' 's/"libcrypto.so.%s"/"libcrypto.%s.dylib"/' src/crypto/internal/backend/openssl.go


### PR DESCRIPTION
### Context
This PR should solve the error in `goreleaser-darwin-fips` job.

The root cause is our previous CI builds used gpatch--2.7.6.arm64_ventura.bottle.tar.gz, while the most recent (failed) one used gpatch--2.7.6.arm64_ventura.bottle.1.tar.gz. This indicates that there’s a slight difference in the bottles (likely a minor patch or metadata update).

Based on the output, the key differences between the two installations of `gpatch` seem to be:

**Different Bottle Versions**:
   - The first installation used `gpatch--2.7.6.arm64_ventura.bottle.tar.gz`, while the second used `gpatch--2.7.6.arm64_ventura.bottle.1.tar.gz`. This indicates that there’s a slight difference in the bottles (likely a minor patch or metadata update).
   

In the second installation, there’s an additional message in the [output](https://semaphore.ci.confluent.io/jobs/481cbce2-28d2-4204-a675-f6e4a5a005da):
```
######################################################################## 100.0%
[34m==>[0m [1mPouring gpatch--2.7.6.arm64_ventura.bottle.1.tar.gz[0m
[34m==>[0m [1mCaveats[0m
GNU "patch" has been installed as "gpatch".
If you need to use it as "patch", you can add a "gnubin" directory
to your PATH from your bashrc like:

    PATH="/opt/homebrew/opt/gpatch/libexec/gnubin:$PATH"
```

about setting up `gpatch` as the default `patch`.

This suggests that the installed `gpatch` version is not symlinked as `patch` by default. If this is missing, scripts expecting `patch` might fail if they cannot find `gpatch`.

### Testing
* <REDACTED>