### PR TITLE
APIT-2632: Release confluent_certificate_authority, confluent_certificate pool as GA

### DIFF
--- a/docs/data-sources/confluent_certificate_authority.md
+++ b/docs/data-sources/confluent_certificate_authority.md
@@ -8,7 +8,7 @@ description: |-
 
 # confluent_certificate_authority Data Source
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
 
 `confluent_certificate_authority` describes a Certificate Authority data source.
 

--- a/docs/data-sources/confluent_certificate_pool.md
+++ b/docs/data-sources/confluent_certificate_pool.md
@@ -8,7 +8,7 @@ description: |-
 
 # confluent_certificate_pool Data Source
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
 
 `confluent_certificate_pool` describes a Certificate Pool data source.
 

--- a/docs/resources/confluent_certificate_authority.md
+++ b/docs/resources/confluent_certificate_authority.md
@@ -8,7 +8,7 @@ description: |-
 
 # confluent_certificate_authority Resource
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
 
 `confluent_certificate_authority` provides a Certificate Authority resource that enables creating, editing, and deleting Certificate Authorities on Confluent Cloud.
 

--- a/docs/resources/confluent_certificate_pool.md
+++ b/docs/resources/confluent_certificate_pool.md
@@ -8,7 +8,7 @@ description: |-
 
 # confluent_certificate_pool Resource
 
-[![Limited Availability](https://img.shields.io/badge/Lifecycle%20Stage-Limited%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
 
 `confluent_certificate_pool` provides a Certificate Pool resource that enables creating, editing, and deleting Certificate Pools on Confluent Cloud.
 


### PR DESCRIPTION
### What
This PR updates the TF docs to match corresponding APIs:

* https://docs.confluent.io/cloud/current/api.html#tag/Certificate-Authorities-(iamv2)
* https://docs.confluent.io/cloud/current/api.html#tag/Certificate-Identity-Pools-(iamv2)
