### PR TITLE
[CLI-3313] Resume Flink statement along with principal and/or compute_pool ID update

### DIFF
--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -108,11 +108,13 @@ The following arguments are supported:
     - `name` - (Required String) The setting name, for example, `sql.local-time-zone`.
     - `value` - (Required String) The setting value, for example, `GMT-08:00`.
 
-- `stopped` - (Optional Boolean) The boolean flag to control whether the running Flink Statement should be stopped. Defaults to `false`. Update it to `true` to stop the statement. Subsequently, update it to `false` to resume the statement.
+- `stopped` - (Optional Boolean) The boolean flag to indicate statement running status and control whether the Flink Statement should be stopped or resumed. Defaults to `false`. Update it to `true` to stop the statement. Subsequently update it to `false` to resume the statement.
 
-!> **Note:** To stop a running statement or resume a stopped statement, no other argument can be updated except `stopped`.
+!> **Note:** To stop a running statement, no other argument can be updated except `stopped`.
 
-!> **Note:** Currently, only 3 Flink statements support the resuming feature, namely: `CREATE TABLE AS`, `INSERT INTO`, and `EXECUTE STATEMENT SET`.
+!> **Note:** To resume a stopped statement, `principal.id` and/or `compute_pool.id` can be updated in additional to `stopped` to resume the original statement under different principal (must have proper role assignment) and/or Flink compute pool (must use the same Flink region as original).
+
+!> **Note:** Currently, only 3 Flink statements support the resume feature, namely: `CREATE TABLE AS`, `INSERT INTO`, and `EXECUTE STATEMENT SET`.
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_flink_statement` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 

--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -108,11 +108,11 @@ The following arguments are supported:
     - `name` - (Required String) The setting name, for example, `sql.local-time-zone`.
     - `value` - (Required String) The setting value, for example, `GMT-08:00`.
 
-- `stopped` - (Optional Boolean) The boolean flag to indicate statement running status and control whether the Flink Statement should be stopped or resumed. Defaults to `false`. Update it to `true` to stop the statement. Subsequently update it to `false` to resume the statement.
+- `stopped` - (Optional Boolean) The boolean flag is used to indicate the statement's running status and to control whether the Flink Statement should be stopped or resumed. Defaults to `false`. Update it to `true` to stop the statement. Subsequently update it to `false` to resume the statement.
 
 !> **Note:** To stop a running statement, no other argument can be updated except `stopped`.
 
-!> **Note:** To resume a stopped statement, `principal.id` and/or `compute_pool.id` can be updated in additional to `stopped` to resume the original statement under different principal (must have proper role assignment) and/or Flink compute pool (must use the same Flink region as original).
+!> **Note:** When resuming a stopped statement, you can update `principal.id` and/or `compute_pool.id` in addition to `stopped` attribute. This enables the statement to run under a different principal (with the appropriate role assignment) or a different Flink compute pool (as long as it is in the same Flink region as the original).
 
 !> **Note:** Currently, only 3 Flink statements support the resume feature, namely: `CREATE TABLE AS`, `INSERT INTO`, and `EXECUTE STATEMENT SET`.
 

--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -40,8 +40,10 @@ const (
 	stateCompleted = "COMPLETED"
 	statePending   = "PENDING"
 	stateFailing   = "FAILING"
-	stateResuming  = "RESUMING"
 	stateStopping  = "STOPPING"
+
+	stopFlinkStatementErrorFormat   = "error stopping Flink Statement: %s"
+	resumeFlinkStatementErrorFormat = "error resuming Flink Statement: %s"
 
 	statementsAPICreateTimeout = 6 * time.Hour
 )
@@ -235,51 +237,53 @@ func flinkStatementRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func flinkStatementUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Make sure we only have a paramStopped update,
-	// Updating anything else is not supported at this moment
-	// stopped: false -> true to trigger flinkStatementStop
-	// stopped: true -> false to trigger flinkStatementResume
-	if d.HasChangeExcept(paramStopped) {
-		return diag.Errorf(`error updating Flink Statement %q: only %q attribute can be updated for Flink Statement, "true" -> "false" to trigger resuming, "false" -> "true" to trigger stopping`, d.Id(), paramStopped)
+	// Make sure we must have a paramStopped update
+	// stopped: false -> true to trigger flink statement stopping
+	// stopped: true -> false to trigger flink statement resuming
+	if !d.HasChange(paramStopped) {
+		return diag.Errorf(`error updating Flink Statement %q: %q attribute must be updated for Flink Statement, "true" -> "false" to trigger resuming, "false" -> "true" to trigger stopping`, d.Id(), paramStopped)
 	}
 
-	if d.Get(paramStopped).(bool) == false {
-		return flinkStatementUpdateWithFlag(ctx, d, meta, false)
+	oldStopped, newStopped := d.GetChange(paramStopped)
+
+	// The resuming case: principalId, computePoolId can be optionally updated
+	if oldStopped.(bool) == true && newStopped.(bool) == false {
+		return flinkStatementResume(ctx, d, meta)
 	}
 
-	return flinkStatementUpdateWithFlag(ctx, d, meta, true)
+	// The stopping case: nothing else except the `stopped` can be updated
+	return flinkStatementStop(ctx, d, meta)
 }
 
-// On entering this function, it's guaranteed that `stopped` has a change
-// boolean flag `toStop` = true indicates a stop, false indicates a resume
-func flinkStatementUpdateWithFlag(ctx context.Context, d *schema.ResourceData, meta interface{}, toStop bool) diag.Diagnostics {
-	message := "stopping"
-	if toStop == false {
-		message = "resuming"
+func flinkStatementStop(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Only the `stopped` field can be updated for Flink statement stop
+	if d.HasChangeExcept(paramStopped) {
+		return diag.Errorf(`error stopping Flink Statement %q: only %q attribute can be updated for Flink Statement`, d.Id(), paramStopped)
 	}
+
 	restEndpoint, err := extractFlinkRestEndpoint(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	organizationId, err := extractFlinkOrganizationId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	environmentId, err := extractFlinkEnvironmentId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	computePoolId, err := extractFlinkComputePoolId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	principalId, err := extractFlinkPrincipalId(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	flinkApiKey, flinkApiSecret, err := extractFlinkApiKeyAndApiSecret(meta.(*Client), d, false)
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf(stopFlinkStatementErrorFormat, createDescriptiveError(err))
 	}
 	flinkRestClient := meta.(*Client).flinkRestClientFactory.CreateFlinkRestClient(restEndpoint, organizationId, environmentId, computePoolId, principalId, flinkApiKey, flinkApiSecret, meta.(*Client).isFlinkMetadataSet)
 
@@ -289,38 +293,92 @@ func flinkStatementUpdateWithFlag(ctx context.Context, d *schema.ResourceData, m
 	statement, _, err := req.Execute()
 
 	if err != nil {
-		return diag.Errorf("error %s Flink Statement: error fetching Flink Statement: %s", message, createDescriptiveError(err))
+		return diag.Errorf("error stopping Flink Statement: error fetching Flink Statement: %s", createDescriptiveError(err))
 	}
 
 	// The statement could be automatically stopped if no client has consumed the results for 5 minutes or more.
 	// Therefore, we need to double-check whether the backend has already stopped/resumed the statement.
-	var shouldSendUpdateRequest bool
-	if toStop {
-		// When trying to stop the statement, current statement `stopped` status should be false
-		shouldSendUpdateRequest = !statement.Spec.GetStopped()
-	} else {
-		// When trying to resume the statement, current statement `stopped` status should be true
-		shouldSendUpdateRequest = statement.Spec.GetStopped()
-	}
+	// When trying to stop the statement, current statement `stopped` status should be false
+	shouldSendUpdateRequest := !statement.Spec.GetStopped()
 
 	if shouldSendUpdateRequest {
-		statement.Spec.SetStopped(toStop)
+		statement.Spec.SetStopped(true)
 		updateFlinkStatementRequestJson, err := json.Marshal(statement)
 		if err != nil {
-			return diag.Errorf("error %s Flink Statement %q: error marshaling %#v to json: %s", message, statementName, statement, createDescriptiveError(err))
+			return diag.Errorf("error stopping Flink Statement %q: error marshaling %#v to json: %s", statementName, statement, createDescriptiveError(err))
 		}
-		tflog.Debug(ctx, fmt.Sprintf("%s Flink Statement %q: %s", message, statementName, updateFlinkStatementRequestJson), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+		tflog.Debug(ctx, fmt.Sprintf("stopping Flink Statement %q: %s", statementName, updateFlinkStatementRequestJson), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
 		req := flinkRestClient.apiClient.StatementsSqlV1Api.UpdateSqlv1Statement(flinkRestClient.apiContext(ctx), organizationId, environmentId, statementName).SqlV1Statement(statement)
 		_, err = req.Execute()
 		if err != nil {
-			return diag.Errorf("error %s Flink Statement 123 %q: %s", message, statementName, createDescriptiveError(err))
+			return diag.Errorf("error stopping Flink Statement %q: %s", statementName, createDescriptiveError(err))
 		}
-		if err := waitForFlinkStatementToBeUpdated(flinkRestClient.apiContext(ctx), flinkRestClient, statementName, meta.(*Client).isAcceptanceTestMode, toStop); err != nil {
+		if err := waitForFlinkStatementToBeUpdated(flinkRestClient.apiContext(ctx), flinkRestClient, statementName, meta.(*Client).isAcceptanceTestMode, true); err != nil {
 			return diag.Errorf("error waiting for Flink Statement %q to update: %s", statementName, createDescriptiveError(err))
 		}
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished %s Flink Statement %q", message, statementName), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished stopping Flink Statement %q", statementName), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+	return flinkStatementRead(ctx, d, meta)
+}
+
+func flinkStatementResume(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Only the `stopped`, `principal.id` and 'compute_pool.id` fields can be updated for Flink statement resume
+	if d.HasChangesExcept(paramStopped, paramPrincipal, paramComputePool) {
+		return diag.Errorf(`error resuming Flink Statement %q: only %q, %q, and %q attributes can be updated for Flink Statement`, d.Id(), paramStopped, paramPrincipal, paramComputePool)
+	}
+
+	restEndpoint, err := extractFlinkRestEndpoint(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	organizationId, err := extractFlinkOrganizationId(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	environmentId, err := extractFlinkEnvironmentId(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	computePoolId, err := extractFlinkComputePoolId(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	principalId, err := extractFlinkPrincipalId(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	flinkApiKey, flinkApiSecret, err := extractFlinkApiKeyAndApiSecret(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf(resumeFlinkStatementErrorFormat, createDescriptiveError(err))
+	}
+	flinkRestClient := meta.(*Client).flinkRestClientFactory.CreateFlinkRestClient(restEndpoint, organizationId, environmentId, computePoolId, principalId, flinkApiKey, flinkApiSecret, meta.(*Client).isFlinkMetadataSet)
+
+	statementName := d.Get(paramStatementName).(string)
+
+	getRequest := flinkRestClient.apiClient.StatementsSqlV1Api.GetSqlv1Statement(flinkRestClient.apiContext(ctx), flinkRestClient.organizationId, flinkRestClient.environmentId, statementName)
+	statement, _, err := getRequest.Execute()
+
+	if err != nil {
+		return diag.Errorf("error resuming Flink Statement: error fetching Flink Statement: %s", createDescriptiveError(err))
+	}
+
+	statement.Spec.SetStopped(false)
+	updateFlinkStatementRequestJson, err := json.Marshal(statement)
+	if err != nil {
+		return diag.Errorf("error resuming Flink Statement %q: error marshaling %#v to json: %s", statementName, statement, createDescriptiveError(err))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("resuming Flink Statement %q: %s", statementName, updateFlinkStatementRequestJson), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
+	updateRequest := flinkRestClient.apiClient.StatementsSqlV1Api.UpdateSqlv1Statement(flinkRestClient.apiContext(ctx), organizationId, environmentId, statementName).SqlV1Statement(statement)
+	_, err = updateRequest.Execute()
+	if err != nil {
+		return diag.Errorf("error resuming Flink Statement %q: %s", statementName, createDescriptiveError(err))
+	}
+	if err := waitForFlinkStatementToBeUpdated(flinkRestClient.apiContext(ctx), flinkRestClient, statementName, meta.(*Client).isAcceptanceTestMode, false); err != nil {
+		return diag.Errorf("error waiting for Flink Statement %q to update: %s", statementName, createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Finished resuming Flink Statement %q", statementName), map[string]interface{}{flinkStatementLoggingKey: d.Id()})
 	return flinkStatementRead(ctx, d, meta)
 }
 

--- a/internal/provider/resource_flink_statement_provider_block_test.go
+++ b/internal/provider/resource_flink_statement_provider_block_test.go
@@ -35,13 +35,15 @@ const (
 	scenarioStateStatementHasBeenResumed = "The statement has been resumed"
 	statementScenarioName                = "confluent_flink_statement Resource Lifecycle"
 
-	flinkPrincipalIdTest        = "u-yo9j87"
-	flinkComputePoolIdTest      = "lfcp-x7rgx1"
-	flinkStatementTest          = "SELECT CURRENT_TIMESTAMP;"
-	flinkStatementNameTest      = "workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9"
-	flinkFirstPropertyKeyTest   = "sql.local-time-zone"
-	flinkFirstPropertyValueTest = "GMT-08:00"
-	flinkStatementResourceLabel = "example"
+	flinkPrincipalIdTest          = "u-yo9j87"
+	flinkPrincipalUpdatedIdTest   = "sa-yo9j87"
+	flinkComputePoolIdTest        = "lfcp-x7rgx1"
+	flinkComputePoolUpdatedIdTest = "lfcp-x7rgx2"
+	flinkStatementTest            = "SELECT CURRENT_TIMESTAMP;"
+	flinkStatementNameTest        = "workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9"
+	flinkFirstPropertyKeyTest     = "sql.local-time-zone"
+	flinkFirstPropertyValueTest   = "GMT-08:00"
+	flinkStatementResourceLabel   = "example"
 
 	latestOffsetsTimestampEmptyValueTest   = "0001-01-01T00:00:00Z"
 	latestOffsetsTimestampStoppedValueTest = "2024-10-14T21:26:07Z"
@@ -244,7 +246,7 @@ func TestAccFlinkStatementWithEnhancedProviderBlock(t *testing.T) {
 				Config: testAccCheckFlinkStatementResumedWithEnhancedProviderBlock(confluentCloudBaseUrl, mockFlinkStatementTestServerUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlinkStatementExists(fullFlinkStatementResourceLabel),
-					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "id", fmt.Sprintf("%s/%s/%s", flinkEnvironmentIdTest, flinkComputePoolIdTest, flinkStatementNameTest)),
+					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "id", fmt.Sprintf("%s/%s/%s", flinkEnvironmentIdTest, flinkComputePoolUpdatedIdTest, flinkStatementNameTest)),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.#", "0"),
 					resource.TestCheckNoResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.0.id"),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "principal.#", "0"),
@@ -359,8 +361,8 @@ func testAccCheckFlinkStatementResumedWithEnhancedProviderBlock(confluentCloudBa
 		"%s" = "%s"
 	  }
 	}
-	`, confluentCloudBaseUrl, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
-		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest,
+	`, confluentCloudBaseUrl, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalUpdatedIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolUpdatedIdTest,
 		flinkStatementResourceLabel, flinkStatementNameTest, flinkStatementTest, flinkFirstPropertyKeyTest, flinkFirstPropertyValueTest)
 }
 

--- a/internal/provider/resource_flink_statement_provider_block_test.go
+++ b/internal/provider/resource_flink_statement_provider_block_test.go
@@ -30,6 +30,7 @@ const (
 	scenarioStateStatementHasBeenCreated = "A new statement has been just created"
 	scenarioStateStatementIsPending      = "A new statement is pending"
 	scenarioStateStatementIsDeleting     = "The statement is being deleted"
+	scenarioStateStatementIsResuming     = "The statement is being resumed"
 	scenarioStateStatementHasBeenDeleted = "The statement has been deleted"
 	scenarioStateStatementHasBeenStopped = "The statement has been stopped"
 	scenarioStateStatementHasBeenResumed = "The statement has been resumed"
@@ -129,25 +130,36 @@ func TestAccFlinkStatementWithEnhancedProviderBlock(t *testing.T) {
 			http.StatusOK,
 		))
 
-	// Update the Flink statement stopped status true -> false to trigger a resume
-	resumeFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
-	resumeFlinkStatementStub := wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+	// Update the Flink statement stopped status true -> false to trigger a resume with different `principal` and `compute_pool`
+	resumingFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resuming_flink_statement.json")
+	resumingFlinkStatementStub := wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
 		InScenario(statementScenarioName).
 		WhenScenarioStateIs(scenarioStateStatementHasBeenStopped).
-		WillSetStateTo(scenarioStateStatementHasBeenResumed).
+		WillSetStateTo(scenarioStateStatementIsResuming).
 		WillReturn(
-			string(resumeFlinkStatementResponse),
+			string(resumingFlinkStatementResponse),
 			contentTypeJSONHeader,
 			http.StatusOK,
 		)
-	_ = wiremockClient.StubFor(resumeFlinkStatementStub)
+	_ = wiremockClient.StubFor(resumingFlinkStatementStub)
 
 	readResumedFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
 		InScenario(statementScenarioName).
-		WhenScenarioStateIs(scenarioStateStatementHasBeenResumed).
+		WhenScenarioStateIs(scenarioStateStatementIsResuming).
+		WillSetStateTo(scenarioStateStatementHasBeenResumed).
 		WillReturn(
 			string(readResumedFlinkStatementResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readPostResumeFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(statementScenarioName).
+		WhenScenarioStateIs(scenarioStateStatementHasBeenResumed).
+		WillReturn(
+			string(readPostResumeFlinkStatementResponse),
 			contentTypeJSONHeader,
 			http.StatusOK,
 		))

--- a/internal/provider/resource_flink_statement_test.go
+++ b/internal/provider/resource_flink_statement_test.go
@@ -100,25 +100,36 @@ func TestAccFlinkStatement(t *testing.T) {
 			http.StatusOK,
 		))
 
-	// Update the Flink statement stopped status true -> false to trigger a resume
-	resumeFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
-	resumeFlinkStatementStub := wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+	// Update the Flink statement stopped status true -> false to trigger a resume with different `principal` and `compute_pool`
+	resumingFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resuming_flink_statement.json")
+	resumingFlinkStatementStub := wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
 		InScenario(statementScenarioName).
 		WhenScenarioStateIs(scenarioStateStatementHasBeenStopped).
-		WillSetStateTo(scenarioStateStatementHasBeenResumed).
+		WillSetStateTo(scenarioStateStatementIsResuming).
 		WillReturn(
-			string(resumeFlinkStatementResponse),
+			string(resumingFlinkStatementResponse),
 			contentTypeJSONHeader,
 			http.StatusOK,
 		)
-	_ = wiremockClient.StubFor(resumeFlinkStatementStub)
+	_ = wiremockClient.StubFor(resumingFlinkStatementStub)
 
 	readResumedFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
 		InScenario(statementScenarioName).
-		WhenScenarioStateIs(scenarioStateStatementHasBeenResumed).
+		WhenScenarioStateIs(scenarioStateStatementIsResuming).
+		WillSetStateTo(scenarioStateStatementHasBeenResumed).
 		WillReturn(
 			string(readResumedFlinkStatementResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readPostResumeFlinkStatementResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_resumed_flink_statement.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(statementScenarioName).
+		WhenScenarioStateIs(scenarioStateStatementHasBeenResumed).
+		WillReturn(
+			string(readPostResumeFlinkStatementResponse),
 			contentTypeJSONHeader,
 			http.StatusOK,
 		))

--- a/internal/provider/resource_flink_statement_test.go
+++ b/internal/provider/resource_flink_statement_test.go
@@ -248,7 +248,7 @@ func TestAccFlinkStatement(t *testing.T) {
 				Config: testAccCheckFlinkStatementResumed(confluentCloudBaseUrl, mockFlinkStatementTestServerUrl),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlinkStatementExists(fullFlinkStatementResourceLabel),
-					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "id", fmt.Sprintf("%s/%s/%s", flinkEnvironmentIdTest, flinkComputePoolIdTest, flinkStatementNameTest)),
+					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "id", fmt.Sprintf("%s/%s/%s", flinkEnvironmentIdTest, flinkComputePoolUpdatedIdTest, flinkStatementNameTest)),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "organization.#", "1"),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "organization.0.%", "1"),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "organization.0.id", flinkOrganizationIdTest),
@@ -257,10 +257,10 @@ func TestAccFlinkStatement(t *testing.T) {
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "environment.0.id", flinkEnvironmentIdTest),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.#", "1"),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.0.%", "1"),
-					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.0.id", flinkComputePoolIdTest),
+					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "compute_pool.0.id", flinkComputePoolUpdatedIdTest),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "principal.#", "1"),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "principal.0.%", "1"),
-					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "principal.0.id", flinkPrincipalIdTest),
+					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "principal.0.id", flinkPrincipalUpdatedIdTest),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "statement_name", flinkStatementNameTest),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "statement", flinkStatementTest),
 					resource.TestCheckResourceAttr(fullFlinkStatementResourceLabel, "stopped", "false"),
@@ -404,7 +404,7 @@ func testAccCheckFlinkStatementResumed(confluentCloudBaseUrl, mockServerUrl stri
 		"%s" = "%s"
 	  }
 	}
-	`, confluentCloudBaseUrl, flinkStatementResourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
-		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest,
+	`, confluentCloudBaseUrl, flinkStatementResourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalUpdatedIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolUpdatedIdTest,
 		flinkStatementNameTest, flinkStatementTest, flinkFirstPropertyKeyTest, flinkFirstPropertyValueTest)
 }

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -754,7 +754,7 @@ func waitForFlinkStatementToBeUpdated(ctx context.Context, c *FlinkRestClient, s
 		targetStates = []string{stateStopped}
 		targetStatusMessage = stateStopped
 	} else {
-		pendingStates = []string{statePending, stateStopped, stateFailed}
+		pendingStates = []string{statePending, stateStopped}
 		targetStates = []string{stateRunning, stateCompleted}
 		targetStatusMessage = fmt.Sprintf("%s or %s", stateRunning, stateCompleted)
 	}

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -754,7 +754,7 @@ func waitForFlinkStatementToBeUpdated(ctx context.Context, c *FlinkRestClient, s
 		targetStates = []string{stateStopped}
 		targetStatusMessage = stateStopped
 	} else {
-		pendingStates = []string{stateStopped, stateFailed, statePending}
+		pendingStates = []string{statePending, stateStopped, stateFailed}
 		targetStates = []string{stateRunning, stateCompleted}
 		targetStatusMessage = fmt.Sprintf("%s or %s", stateRunning, stateCompleted)
 	}

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -754,9 +754,9 @@ func waitForFlinkStatementToBeUpdated(ctx context.Context, c *FlinkRestClient, s
 		targetStates = []string{stateStopped}
 		targetStatusMessage = stateStopped
 	} else {
-		pendingStates = []string{stateStopped, stateResuming}
-		targetStates = []string{statePending, stateRunning, stateCompleted}
-		targetStatusMessage = fmt.Sprintf("%s, %s or %s", statePending, stateRunning, stateCompleted)
+		pendingStates = []string{stateStopped, stateFailed, statePending}
+		targetStates = []string{stateRunning, stateCompleted}
+		targetStatusMessage = fmt.Sprintf("%s or %s", stateRunning, stateCompleted)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/internal/testdata/flink_statement/read_resumed_flink_statement.json
+++ b/internal/testdata/flink_statement/read_resumed_flink_statement.json
@@ -12,8 +12,8 @@
   "name": "workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9",
   "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
   "spec": {
-    "compute_pool_id": "lfcp-x7rgx1",
-    "principal": "u-yo9j87",
+    "compute_pool_id": "lfcp-x7rgx2",
+    "principal": "sa-yo9j87",
     "properties": {
       "sql.local-time-zone": "GMT-08:00"
     },
@@ -26,7 +26,7 @@
       "customers_source": "partition:0,offset:9223372036854775808;partition:4,offset:9223372036854775808;partition:3,offset:9223372036854775808;partition:2,offset:9223372036854775808;partition:1,offset:9223372036854775808;partition:5,offset:9223372036854775808"
     },
     "latest_offsets_timestamp": "2024-10-14T21:26:07Z",
-    "phase": "PENDING",
+    "phase": "RUNNING",
     "result_schema": {
       "columns": [
         {

--- a/internal/testdata/flink_statement/read_resuming_flink_statement.json
+++ b/internal/testdata/flink_statement/read_resuming_flink_statement.json
@@ -1,0 +1,43 @@
+{
+  "api_version": "sql/v1",
+  "environment_id": "env-abc123",
+  "kind": "Statement",
+  "metadata": {
+    "created_at": "2023-11-15T08:34:12Z",
+    "resource_version": "1",
+    "self": "https://flink.us-east-1.aws.confluent.cloud/sql/v1/organizations/1111aaaa-11aa-11aa-11aa-111111aaaaaa/environments/env-abc123/statements/workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9",
+    "uid": "8b9c49bb-7351-416d-98d5-d5f29f6de980",
+    "updated_at": "2023-11-15T08:35:20Z"
+  },
+  "name": "workspace-2023-11-15-030109-0408d52d-eaff-4d50-a246-f822a29f2eb9",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "spec": {
+    "compute_pool_id": "lfcp-x7rgx2",
+    "principal": "sa-yo9j87",
+    "properties": {
+      "sql.local-time-zone": "GMT-08:00"
+    },
+    "statement": "SELECT CURRENT_TIMESTAMP;",
+    "stopped": false
+  },
+  "status": {
+    "detail": "",
+    "latest_offsets": {
+      "customers_source": "partition:0,offset:9223372036854775808;partition:4,offset:9223372036854775808;partition:3,offset:9223372036854775808;partition:2,offset:9223372036854775808;partition:1,offset:9223372036854775808;partition:5,offset:9223372036854775808"
+    },
+    "latest_offsets_timestamp": "2024-10-14T21:26:07Z",
+    "phase": "PENDING",
+    "result_schema": {
+      "columns": [
+        {
+          "name": "CURRENT_TIMESTAMP",
+          "type": {
+            "nullable": false,
+            "precision": 3,
+            "type": "TIMESTAMP_WITH_LOCAL_TIME_ZONE"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Summary:

This PR supports the feature of resume the Flink statement with a different principal/compute_pool.

Namely when `stopped` parameter has change from true -> false, we can update the `principal` and/or `compute_pool` in place and avoid recreating the Flink statement resource.

### Code changes:

- Split the `flinkStatementUpdate()` into `flinkStatementStop()` and `flinkStatementResume()` due to different behaviors in the process of stop and resume.
- Add custom diff function `resourceFlinkStatementDiff()` to remind and avoid users running into invalid scenarios when initiating stop or resume.
- Update the Flink statement to remove `RESUMING` statement status.
- Add associated Terraform acceptance tests.
- Update the resource docs as instruction.

### Reference:

This PR also updates the Flink statement status type according to the latest DML flow here:
https://confluentinc.atlassian.net/wiki/spaces/FLINK/pages/3420389383/Refine+the+Customer+Facing+Statement+Status#Finite-State-Machine-Definitions-and-Logic-for-Flink-in-Confluent-Cloud

The whole verification for Terraform is done and documented in the docs below.

### Testing Done:
https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?usp=sharing