### PR TITLE
[APIT-2658] Update the SQL statement in example

### DIFF
--- a/examples/configurations/flink-quickstart/statements/populate-orders-source-table.sql
+++ b/examples/configurations/flink-quickstart/statements/populate-orders-source-table.sql
@@ -1,2 +1,2 @@
-INSERT INTO orders_source
-SELECT * FROM examples.marketplace.orders;
+INSERT INTO orders_source(`order_id`, `customer_id`, `product_id`, `price`)
+SELECT `order_id`, `customer_id`, `product_id`, `price` FROM examples.marketplace.orders;


### PR DESCRIPTION
### Summary

Using our current statement example to insert data into Flink SQL database table will result in:

```
 Query schema: [order_id: STRING NOT NULL, customer_id: INT NOT NULL, product_id: STRING NOT NULL, price: DOUBLE NOT NULL]
│ Sink schema:  [key: BYTES, order_id: STRING, customer_id: INT, product_id: STRING, price: DOUBLE]
```

Reason being that the Sink schema has additional intrinsic key: BYTES, select everything from the sink schema will cause table mismatch and Flink statement creation failure.

### Change

Update the SQL statement explicitly select fields for insert operation between query and sink schema. 

### JIRA reference
https://confluentinc.atlassian.net/browse/APIT-2658