### PR TITLE
[APIT-2737] Add the GitHub PR template file to document the contributing requirement and checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@ Examples
 Checklist
 ---------
 <!-- 
-Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed. Use common sense when checking items: for example, skip items 1–4 if the PR includes documentation updates only. 
+Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
+For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
 -->
 - [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
 - [ ] I have verified my PR with real Confluent Cloud resources in a production environment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,51 +1,54 @@
 Release Notes
--------------
-<!--
-If this PR introduces any user-facing changes, please document them below as a summary. Please delete any unused section titles and placeholders.
-Please match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases
--->
-
-Breaking Changes
-- PLACEHOLDER
+---------
+<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->
 
 New Features
-- PLACEHOLDER
+- [Briefly describe new features introduced in this PR].
 
 Bug Fixes
-- PLACEHOLDER
+- [Briefly describe any bugs fixed in this PR].
+
+Examples
+- [Briefly describe any Terraform configuration example updates in this PR].
 
 Checklist
 ---------
-<!--
-Check each item in the checklist to ensure high quality Terraform development practise is performed.
-PR approval won't be granted until everything in the checklist is carefully reviewed.
-Please use common sense to determine if every item has to be checked, for example, we don't need to
-verify item 1~4 for a PR with documentation update only.
+<!-- 
+Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed. Use common sense when checking items: for example, skip items 1–4 if the PR includes documentation updates only. 
 -->
-- [ ] I've validated this PR with engineering version of binary Terraform provider for Confluent.
-- [ ] I've verified that there is no Terraform drift or backward compatibility issue.
-- [ ] I've attached a manual Terraform verification result/screenshot in the "Test & Review" part below.
-- [ ] I've included corresponding Terraform acceptance tests associated with this PR.
-- [ ] I've added the corresponding docs update, and proper examples to reflect the PR changes.
-- [ ] The feature(s) associated with this PR is already available in production.
+- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
+- [ ] I have verified my PR with real Confluent Cloud resources in a production environment.
+- [ ] I have attached manual Terraform verification results or screenshots in the "Test & Review" section below.
+- [ ] I have included appropriate Terraform acceptance tests for any new resources, data sources, or functionality.
+- [ ] I confirm there will be no Terraform drift or backward compatibility issues caused by this PR.
+- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
 
 What
 ----
 <!--
-Briefly describe **what** you have changed and **why**.
-Optionally include your implementation strategy and technical details.
+Briefly describe **what** you have changed and **why** these changes are necessary.
+Optionally include: 
+- The problem being solved or the feature being added. 
+- The implementation strategy or approach taken. 
+- Key technical details, design decisions, or any additional context reviewers should be aware of.
 -->
 
 References
 ----------
-<!--
-Copy and paste links to tickets, related PRs, GitHub issues, internal documentation, etc.
+<!-- Include links to relevant resources for this PR, such as: 
+- Related GitHub issues 
+- Tickets (JIRA, etc.) 
+- Internal documentation or design specs 
+- Other related PRs 
+Copy and paste the links below for easy reference.
 -->
 
 Test & Review
 -------------
-<!--
-Has it been tested? How?
-Copy and paste the manual verification document/screenshot that can save the reviewer time.
-Example: https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j
+<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
+- Steps taken to verify the changes. 
+- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
+- Any additional notes on testing (e.g., environments used, edge cases tested). 
+- Screenshot showing successful resource creation.
+Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+Release Notes
+-------------
+<!--
+If this PR introduces any user-facing changes, please document them below as a summary. Please delete any unused section titles and placeholders.
+Please match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases
+-->
+
+Breaking Changes
+- PLACEHOLDER
+
+New Features
+- PLACEHOLDER
+
+Bug Fixes
+- PLACEHOLDER
+
+Checklist
+---------
+<!--
+Check each item in the checklist to ensure high quality Terraform development practise is performed.
+PR approval won't be granted until everything in the checklist is carefully reviewed.
+Please use common sense to determine if every item has to be checked, for example, we don't need to
+verify item 1~4 for a PR with documentation update only.
+-->
+- [ ] I've validated this PR with engineering version of binary Terraform provider for Confluent.
+- [ ] I've verified that there is no Terraform drift or backward compatibility issue.
+- [ ] I've attached a manual Terraform verification result/screenshot in the "Test & Review" part below.
+- [ ] I've included corresponding Terraform acceptance tests associated with this PR.
+- [ ] I've added the corresponding docs update, and proper examples to reflect the PR changes.
+- [ ] The feature(s) associated with this PR is already available in production.
+
+What
+----
+<!--
+Briefly describe **what** you have changed and **why**.
+Optionally include your implementation strategy and technical details.
+-->
+
+References
+----------
+<!--
+Copy and paste links to tickets, related PRs, GitHub issues, internal documentation, etc.
+-->
+
+Test & Review
+-------------
+<!--
+Has it been tested? How?
+Copy and paste the manual verification document/screenshot that can save the reviewer time.
+Example: https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j
+-->


### PR DESCRIPTION
**Summary**
As of now, the PR template file for PR submission is missing, in order to improve the PR review and Terraform provider release process, add this `pull_request_template.md` file to help developers understand what to expect from the PR review process, and what kind of verification should be done before the PR is considered **ready**.

After this PR is merged, we should expect all following PRs to have the PR description area following this template.

**Reference**
https://confluentinc.atlassian.net/browse/APIT-2737