### PR TITLE
feat(api-key) support keepers for time rotating api keys

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -34,6 +34,7 @@ const (
 	paramOwner               = "owner"
 	paramResource            = "managed_resource"
 	paramDisableWaitForReady = "disable_wait_for_ready"
+	paramKeepers             = "keepers"
 
 	serviceAccountKind   = "ServiceAccount"
 	userKind             = "User"
@@ -93,6 +94,12 @@ func apiKeyResource() *schema.Resource {
 				Optional: true,
 				Default:  false,
 				ForceNew: true,
+			},
+			paramKeepers: {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Arbitrary map of values that, when changed, will trigger recreation of resource.",
 			},
 		},
 	}


### PR DESCRIPTION
Hello,

The idea is to support `keepers` for automating key rotation based on `time` resources.

As requested in https://github.com/confluentinc/terraform-provider-confluent/issues/498

Thank you