### PR TITLE
[FRT-879] Align Flink Artifact Terraform with CLI

### DIFF
--- a/docs/resources/confluent_flink_artifact.md
+++ b/docs/resources/confluent_flink_artifact.md
@@ -22,10 +22,9 @@ resource "confluent_environment" "development" {
 }
 
 resource "confluent_flink_artifact" "main" {
-  class          = "io.confluent.example.SumScalarFunction"
-  region         = "us-west-2"
   cloud          = "AWS"
-  display_name   = "flink_sumscalar_artifact"
+  region         = "us-west-2"
+  display_name   = "my_flink_sumscalar_artifact"
   content_format = "JAR"
   environment {
     id = confluent_environment.development.id
@@ -38,10 +37,10 @@ resource "confluent_flink_artifact" "main" {
 
 The following arguments are supported:
 
-- `display_name` - (Required String) The display name of Flink Artifact.
+- `display_name` - (Required String) The unique name of the Flink Artifact per cloud, region, environment scope.
 - `cloud` - (Required String) The cloud service provider that runs the Flink Artifact.
 - `region` - (Required String) The cloud service provider region that hosts the Flink Artifact.
-- `class` - (Required String) Java class or alias for the Flink Artifact as provided by developer.
+- `class` - (Optional String, **Deprecated**) Java class or alias for the Flink Artifact as provided by developer.
 - `artifact_file` - (Required String) The artifact file for Flink Artifact.
 - `environment` (Required Configuration Block) supports the following:
     - `id` - (Required String) The ID of the Environment that the Flink Artifact Pool belongs to, for example, `env-abc123`.
@@ -51,9 +50,10 @@ The following arguments are supported:
 In addition to the preceding arguments, the following attributes are exported:
 
 - `id` - (Required String) The ID of the Flink Artifact, for example, `lfa-abc123`.
-- `content_format` - (Optional String) Archive format of the Flink Artifact.
-- `runtime_language` - (Optional String) Runtime language of the Flink Artifact. The default runtime language is Java.
+- `content_format` - (Optional String) Archive format of the Flink Artifact. Accepted values are: `JAR`, `ZIP`.
+- `runtime_language` - (Optional String) Runtime language of the Flink Artifact as `Python` or `Java`. Defaults to `Java`.
 - `description` - (Optional String) Description of the Flink Artifact.
+- `documentation_link` - (Optional String) Documentation link of the Flink Artifact.
 - `api_version` - (Required String) The API Version of the schema version of the Flink Artifact Pool, for example, `fa/v2`.
 - `kind` - (Required String) The kind of the Flink Artifact Pool, for example, `FlinkArtifact`.
 

--- a/examples/configurations/flink_artifact/main.tf
+++ b/examples/configurations/flink_artifact/main.tf
@@ -23,11 +23,11 @@ resource "confluent_flink_artifact" "main" {
   environment {
     id = var.environment_id
   }
-  class          = "io.confluent.example.SumScalarFunction"
   region         = "us-west-2"
   cloud          = "AWS"
   display_name   = "flink_sumscalar_artifact"
   content_format = "JAR"
+  documentation_link = "https://github.com/confluentinc/flink-udf-java-examples"
   artifact_file  = var.artifact_file
 }
 

--- a/internal/provider/data_source_fink_artifact.go
+++ b/internal/provider/data_source_fink_artifact.go
@@ -48,12 +48,14 @@ func flinkArtifactDataSource() *schema.Resource {
 				Optional: true,
 				// A user should provide a value for either "id" or "display_name" attribute, not both
 				ExactlyOneOf: []string{paramId, paramDisplayName},
-				Description:  "Display name of the Flink Artifact.",
+				Description:  "The unique name of the Flink Artifact per cloud, region, environment scope.",
 			},
 			paramClass: {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Optional:    true,
 				Description: "Java class or alias for the Flink Artifact as provided by developer.",
+				Deprecated:  fmt.Sprintf(deprecationMessageMajorRelease3, "class", "attribute"),
 			},
 			paramCloud: {
 				Type:         schema.TypeString,
@@ -71,17 +73,22 @@ func flinkArtifactDataSource() *schema.Resource {
 			paramContentFormat: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Archive format of the Flink Artifact.",
+				Description: "Archive format of the Flink Artifact (JAR or ZIP).",
 			},
 			paramRuntimeLanguage: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Runtime language of the Flink Artifact. The default runtime language is JAVA.",
+				Description: "Runtime language of the Flink Artifact as Python or JAVA. The default runtime language is JAVA.",
 			},
 			paramDescription: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of the Flink Artifact.",
+			},
+			paramDocumentationLink: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Documentation link of the Flink Artifact.",
 			},
 			paramVersions: {
 				Type:        schema.TypeList,

--- a/internal/provider/data_source_flink_artifact_test.go
+++ b/internal/provider/data_source_flink_artifact_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/walkerus/go-wiremock"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -33,7 +33,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 	// nolint:errcheck
 	defer wiremockClient.ResetAllScenarios()
 
-	readCreatedFlinkArtifactResponse, _ := ioutil.ReadFile("../testdata/flink_artifact/read_created_artifact.json")
+	readCreatedFlinkArtifactResponse, _ := os.ReadFile("../testdata/flink_artifact/read_created_artifact.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/artifact/v1/flink-artifacts/lfcp-abc123")).
 		InScenario(dataSourceFlinkArtifactScenarioName).
 		WithQueryParam("cloud", wiremock.EqualTo("AWS")).
@@ -46,7 +46,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 			http.StatusOK,
 		))
 
-	readArtifactsResponse, _ := ioutil.ReadFile("../testdata/flink_artifact/read_artifact.json")
+	readArtifactsResponse, _ := os.ReadFile("../testdata/flink_artifact/read_artifact.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/artifact/v1/flink-artifacts")).
 		InScenario(dataSourceFlinkArtifactScenarioName).
 		WithQueryParam("environment", wiremock.EqualTo(flinkArtifactEnvironmentId)).
@@ -70,7 +70,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckArtifactExists(fullArtifactDataSourceLabel),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramId, flinkArtifactId),
-					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDisplayName, flinkArtifactDisplayName),
+					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDisplayName, flinkArtifactUniqueName),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramClass, flinkArtifactClass),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramCloud, flinkArtifactCloud),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramRegion, flinkArtifactRegion),
@@ -79,6 +79,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramContentFormat, flinkArtifactContentFormat),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramRuntimeLanguage, flinkArtifactRuntimeLanguage),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDescription, flinkArtifactDescription),
+					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDocumentationLink, flinkArtifactDocumentationLink),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, "versions.#", "1"),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, "versions.0.version", flinkVersions),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramApiVersion, flinkArtifactApiVersion),
@@ -90,7 +91,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckArtifactExists(fullArtifactDataSourceLabel),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramId, flinkArtifactId),
-					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDisplayName, flinkArtifactDisplayName),
+					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDisplayName, flinkArtifactUniqueName),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramClass, flinkArtifactClass),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramCloud, flinkArtifactCloud),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramRegion, flinkArtifactRegion),
@@ -99,6 +100,7 @@ func TestAccDataSourceFlinkArtifact(t *testing.T) {
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramContentFormat, flinkArtifactContentFormat),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramRuntimeLanguage, flinkArtifactRuntimeLanguage),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDescription, flinkArtifactDescription),
+					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramDocumentationLink, flinkArtifactDocumentationLink),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, "versions.#", "1"),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, "versions.0.version", flinkVersions),
 					resource.TestCheckResourceAttr(fullArtifactDataSourceLabel, paramApiVersion, flinkArtifactApiVersion),
@@ -122,7 +124,7 @@ func testAccCheckDataSourceFlinkArtifactConfigWithDisplayNameSet(mockServerUrl s
 			id = "%s"
 	  	}
 	}
-	`, mockServerUrl, networkDataSourceLabel, flinkArtifactDisplayName, flinkArtifactCloud, flinkArtifactRegion,
+	`, mockServerUrl, networkDataSourceLabel, flinkArtifactUniqueName, flinkArtifactCloud, flinkArtifactRegion,
 		flinkArtifactEnvironmentId)
 }
 

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -31,15 +31,20 @@ func artifactResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				Description:  "The display name of Flink Artifact",
+				Description:  "The unique name of the Flink Artifact per cloud, region, environment scope.",
 				ValidateFunc: validation.StringLenBetween(1, 60),
 			},
 			paramClass: {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				Description:  "Java class or alias for the Flink Artifact as provided by developer.",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(pattern), "The class must be in the required format"),
+				Deprecated:   fmt.Sprintf(deprecationMessageMajorRelease3, "class", "attribute"),
+				// Make sure "default" and "" are equivalent, so TF does not treat them as configuration changes
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return (strings.ToLower(old) == "default" && new == "") || (old == "" && strings.ToLower(new) == "default")
+				},
 			},
 			paramCloud: {
 				Type:         schema.TypeString,
@@ -60,7 +65,7 @@ func artifactResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    true,
-				Description: "Archive format of the Flink Artifact.",
+				Description: "Archive format of the Flink Artifact (JAR or ZIP).",
 			},
 			paramArtifactFile: {
 				Type:     schema.TypeString,
@@ -73,7 +78,7 @@ func artifactResource() *schema.Resource {
 					}
 					return
 				},
-				Description: "The artifact file for Flink Artifact.",
+				Description: "The artifact file for Flink Artifact in JAR or ZIP format.",
 			},
 			paramRuntimeLanguage: {
 				Type:         schema.TypeString,
@@ -81,13 +86,19 @@ func artifactResource() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(acceptedRuntimeLanguage, true),
 				Default:      "JAVA",
-				Description:  "Runtime language of the Flink Artifact. The default runtime language is Java.",
+				Description:  "Runtime language of the Flink Artifact as Python or JAVA. The default runtime language is JAVA.",
 			},
 			paramDescription: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Description of the Flink Artifact.",
+			},
+			paramDocumentationLink: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Documentation link of the Flink Artifact.",
 			},
 			paramVersions: {
 				Type:        schema.TypeList,
@@ -127,6 +138,7 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 	artifactFile := d.Get(paramArtifactFile).(string)
 	runtimeLanguage := d.Get(paramRuntimeLanguage).(string)
 	description := d.Get(paramDescription).(string)
+	documentationLink := d.Get(paramDocumentationLink).(string)
 
 	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
 
@@ -163,6 +175,9 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 	if description != "" {
 		createArtifactRequest.SetDescription(description)
+	}
+	if documentationLink != "" {
+		createArtifactRequest.SetDocumentationLink(documentationLink)
 	}
 	if runtimeLanguage != "" {
 		createArtifactRequest.SetRuntimeLanguage(runtimeLanguage)
@@ -279,6 +294,9 @@ func setArtifactAttributes(d *schema.ResourceData, artifact fa.ArtifactV1FlinkAr
 		return nil, err
 	}
 	if err := d.Set(paramDescription, artifact.GetDescription()); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramDocumentationLink, artifact.GetDocumentationLink()); err != nil {
 		return nil, err
 	}
 	if err := d.Set(paramRuntimeLanguage, artifact.GetRuntimeLanguage()); err != nil {

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -124,6 +124,10 @@ const (
 	schemaRegistryDekKey                      = "dek_id"
 	entityAttributesLoggingKey                = "entity_attributes_id"
 	providerIntegrationLoggingKey             = "provider_integration_id"
+
+	deprecationMessageMajorRelease3 = "The %q %s has been deprecated and will be removed in the next major version of the provider (3.0.0). " +
+		"Refer to the Upgrade Guide at https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/version-3-upgrade for more details. " +
+		"The guide will be published once version 3.0.0 is released."
 )
 
 func (c *Client) apiKeysApiContext(ctx context.Context) context.Context {

--- a/internal/testdata/flink_artifact/create_artifact.json
+++ b/internal/testdata/flink_artifact/create_artifact.json
@@ -16,7 +16,7 @@
   "class": "io.confluent.example.SumScalarFunction",
   "content_format": "JAR",
   "description": "string",
-  "documentation_link": "^$|^(http://|https://).",
+  "documentation_link": "https://docs.confluent.io/cloud/current/api.html",
   "runtime_language": "JAVA",
   "versions": [
     {

--- a/internal/testdata/flink_artifact/read_artifact.json
+++ b/internal/testdata/flink_artifact/read_artifact.json
@@ -21,7 +21,7 @@
       "class": "io.confluent.example.SumScalarFunction",
       "content_format": "JAR",
       "description": "string",
-      "documentation_link": "^$|^(http://|https://).",
+      "documentation_link": "https://docs.confluent.io/cloud/current/api.html",
       "runtime_language": "JAVA",
       "versions": [
         {

--- a/internal/testdata/flink_artifact/read_created_artifact.json
+++ b/internal/testdata/flink_artifact/read_created_artifact.json
@@ -16,7 +16,7 @@
   "class": "io.confluent.example.SumScalarFunction",
   "content_format": "JAR",
   "description": "string",
-  "documentation_link": "^$|^(http://|https://).",
+  "documentation_link": "https://docs.confluent.io/cloud/current/api.html",
   "runtime_language": "JAVA",
   "versions": [
     {


### PR DESCRIPTION
Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Align Flink Artifact Terraform with CLI deprecating Class field and adding `documentation_link`

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

Confluent Cloud customers who are using `artifacts` resource as part of their Flink statements with UDFs will be blocked

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

https://confluentinc.atlassian.net/browse/FRT-782
https://github.com/confluentinc/api/pull/1844

Test & Review
We run terraform plan and apply with the previously existing class parameter, and ensure there is no terraform drift:
![image](https://github.com/user-attachments/assets/b277f76f-6a45-4ddc-a322-f872656d4cae)
![image](https://github.com/user-attachments/assets/fb6c3b26-10c8-4244-8e3e-548a34e3db58)
![image](https://github.com/user-attachments/assets/875c3bbb-0c0e-42ee-b5b6-21c59b7d1b8e)

We remove the class parameter, and add the documentation link parameter. Run terraform plan and apply and ensure no TF drift
![image](https://github.com/user-attachments/assets/02801cf1-bf4b-4ec6-bec6-81b906a5236f)
![image](https://github.com/user-attachments/assets/5ed99065-2dad-4a9b-9bc7-090ed354c5e7)

-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->

We also want to do the version test. So we create a resource with terraform version 2.13.0, and run terraform apply and ensure there is no drift.
![Screenshot 2025-01-24 at 2 19 44 PM (2)](https://github.com/user-attachments/assets/2cb4f5c1-3807-4fa5-a750-40ef33f28c83)
![Screenshot 2025-01-24 at 2 19 59 PM (2)](https://github.com/user-attachments/assets/491c9377-f792-448d-a416-a334c0936117)

Now we change to our latest local version with the changes and run terraform plan to ensure no TF drift
![Screenshot 2025-01-24 at 2 20 20 PM (2)](https://github.com/user-attachments/assets/5864cbc8-2115-48f2-842f-9a25e63c50d6)

