### PR TITLE
APIT-2773: Update the docs for TF Importer Tool

### DIFF
--- a/docs/guides/resource-importer.md
+++ b/docs/guides/resource-importer.md
@@ -113,6 +113,8 @@ In this guide, you will:
     terraform apply
     ```
 
+    -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
+
 9. You have now imported Confluent Cloud infrastructure using Terraform under `cloud-importer/imported_confluent_infrastructure`! The `terraform apply` command created a new folder called `cloud-importer/imported_confluent_infrastructure` that contains 2 files: Terraform Configuration (`main.tf`) and Terraform State (`terraform.tfstate`) files.
 
 10. Navigate into its directory:
@@ -164,5 +166,6 @@ In this guide, you will:
     Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
     ```
 
+    -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform plan -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
 
 You've successfully imported your Confluent Cloud infrastructure to Terraform. Terraform also compared your real infrastructure against your imported configuration and found no differences, so no changes are needed.

--- a/docs/guides/resource-importer.md
+++ b/docs/guides/resource-importer.md
@@ -113,7 +113,7 @@ In this guide, you will:
     terraform apply
     ```
 
-    -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
+   -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the [parallelism flag](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n). For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
 
 9. You have now imported Confluent Cloud infrastructure using Terraform under `cloud-importer/imported_confluent_infrastructure`! The `terraform apply` command created a new folder called `cloud-importer/imported_confluent_infrastructure` that contains 2 files: Terraform Configuration (`main.tf`) and Terraform State (`terraform.tfstate`) files.
 
@@ -166,6 +166,6 @@ In this guide, you will:
     Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
     ```
 
-    -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform plan -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
+    -> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the [parallelism flag](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n). For example, you can set it to 100 like this: `terraform plan -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
 
 You've successfully imported your Confluent Cloud infrastructure to Terraform. Terraform also compared your real infrastructure against your imported configuration and found no differences, so no changes are needed.

--- a/docs/resources/confluent_tf_importer.md
+++ b/docs/resources/confluent_tf_importer.md
@@ -14,7 +14,7 @@ description: |-
 
 See [Resource Importer for Confluent Terraform Provider](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/resource-importer) for step-by-step instructions on how to use the `confluent_tf_importer` resource.
 
--> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
+-> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the [parallelism flag](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n). For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
 
 ## Example Usage
 

--- a/docs/resources/confluent_tf_importer.md
+++ b/docs/resources/confluent_tf_importer.md
@@ -14,6 +14,8 @@ description: |-
 
 See [Resource Importer for Confluent Terraform Provider](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/resource-importer) for step-by-step instructions on how to use the `confluent_tf_importer` resource.
 
+-> **Note:**  If the import process is taking longer than expected, you can improve the speed by increasing the parallelism flag. For example, you can set it to 100 like this: `terraform apply -parallelism=100`. Increasing parallelism can help speed up the import process, especially when dealing with a large number of resources.
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/confluent_tf_importer.md
+++ b/docs/resources/confluent_tf_importer.md
@@ -45,3 +45,4 @@ These are the exportable resources:
 The following end-to-end examples might help to get started with the `confluent_tf_importer` resource:
   * [`cloud-importer`](https://github.com/confluentinc/terraform-provider-confluent/tree/master/examples/configurations/cloud-importer): Export _Cloud_ resources (for example, Service Accounts, Environments)
   * [`kafka-importer`](https://github.com/confluentinc/terraform-provider-confluent/tree/master/examples/configurations/kafka-importer): Export _Kafka_ resources (for example, ACLs, Topics)
+  * [`schema-registry-importer`](https://github.com/confluentinc/terraform-provider-confluent/tree/master/examples/configurations/schema-registry-importer): Export _Schema Registry_ resources (for example, Schemas)

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -302,7 +302,9 @@ func writeTfState(ctx context.Context, resources []instanceData, outputPath stri
 	stateReplaceCommandStr := "terraform state replace-provider registry.terraform.io/-/confluent registry.terraform.io/confluentinc/confluent"
 	cmd, err := commandWithResolvedSymlink(ctx, "terraform")
 	if err != nil {
-		return diag.Errorf("failed to run terraform CLI command: %q. Please run it manually in %s.", stateReplaceCommandStr, outputPath)
+		return diag.Errorf("The process was successfully completed, but there's one more manual step you'll "+
+			"need to take. Please run the following terraform CLI command: %q in %s folder.", stateReplaceCommandStr,
+			outputPath)
 	}
 
 	cmd.Args = append(cmd.Args, []string{
@@ -317,7 +319,9 @@ func writeTfState(ctx context.Context, resources []instanceData, outputPath stri
 	tflog.Info(ctx, fmt.Sprintf("Running %q in %s", stateReplaceCommandStr, outputPath))
 
 	if err = cmd.Run(); err != nil {
-		return diag.Errorf("failed to run terraform CLI command: %q. Please run it manually in %s.", stateReplaceCommandStr, outputPath)
+		return diag.Errorf("The process was successfully completed, but there's one more manual step you'll "+
+			"need to take. Please run the following terraform CLI command: %q in %s folder.", stateReplaceCommandStr,
+			outputPath)
 	}
 	return nil
 }


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- This PR updates the docs and the error message for the [Resource Importer](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/resource-importer) tool.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Based on the recent UX review, we have identified a few opportunities for improvement, and this PR implements the suggestions we received.

Blast Radius
----
Given that we edited the error message in `*.go` file, Confluent Cloud customers who are using `confluent_importer` resource could be blocked.

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2773

Test & Review
-------------
```
...
confluent_tf_importer.example: Still creating... [30s elapsed]
confluent_tf_importer.example: Still creating... [40s elapsed]

Error: The process was successfully completed, but there's one more manual step you'll need to take. Please run the following terraform CLI command: "terraform state replace-provider registry.terraform.io/-/confluent registry.terraform.io/confluentinc/confluent" in ./imported_confluent_infrastructure folder.

  on main.tf line 16, in resource "confluent_tf_importer" "example":
  18: resource "confluent_tf_importer" "example" {}
```
