### PR TITLE
#minor: Fix CI build

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -28,6 +28,7 @@ blocks:
             - ./make.bash -v
             - cd ../../
             - export PATH=$(pwd)/go/bin:$PATH
+            - export "GITHUB_TOKEN=$(gh auth token)"
             - export GOROOT=$(pwd)/go
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml


### PR DESCRIPTION
### What
This PR fixes CI build error:
```
  ⨯ release failed after 0s                  error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN
```