### PR TITLE
#minor: Fix CI build

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -42,6 +42,7 @@ blocks:
           commands:
             - sem-version go 1.22.7
             - export "GOPATH=$(go env GOPATH)"
+            - export "GITHUB_TOKEN=$(gh auth token)"
             - >-
               export
               "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"


### PR DESCRIPTION
### What
This is a follow up to https://github.com/confluentinc/terraform-provider-confluent/pull/534 (see its PR description for more details) as there was a typo and we needed to fix the second part of the build:
![image](https://github.com/user-attachments/assets/0c6d0321-b113-49b2-93ee-5c71df6edc84)

whereas #534 updated the commands for the first part 😕 

### References
* https://semaphore.ci.confluent.io/jobs/411bc17f-f88e-46ec-94f4-9ec4ab04b77a