### PR TITLE
RCCA-25218: Fix "Unable to create API key with managed_resource block" issue

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -98,7 +98,10 @@ func apiKeyResource() *schema.Resource {
 				ForceNew: true,
 			},
 		},
-		//CustomizeDiff: customdiff.Sequence(resourceApiKeyManagedResourceDiff),
+		// TODO: APIT-2820
+		// Temporarily disabling this as a stopgap solution. For more details, see:
+		// https://github.com/confluentinc/terraform-provider-confluent/pull/538
+		// CustomizeDiff: customdiff.Sequence(resourceApiKeyManagedResourceDiff),
 	}
 }
 

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -21,7 +21,6 @@ import (
 	apikeys "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/http"
@@ -99,7 +98,7 @@ func apiKeyResource() *schema.Resource {
 				ForceNew: true,
 			},
 		},
-		CustomizeDiff: customdiff.Sequence(resourceApiKeyManagedResourceDiff),
+		//CustomizeDiff: customdiff.Sequence(resourceApiKeyManagedResourceDiff),
 	}
 }
 

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -668,26 +668,3 @@ func optionalApiKeyEnvironmentIdBlockSchema() *schema.Schema {
 		Optional: true,
 	}
 }
-
-func resourceApiKeyManagedResourceDiff(ctx context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	// Check if the `managed_resource` block exists
-	if diff.Get("managed_resource.#").(int) > 0 {
-		// Get `managed_resource.id` from the nested block
-		resourceId := diff.Get("managed_resource.0.id").(string)
-
-		// Check if the environment block exists
-		_, environmentExists := diff.GetOk("managed_resource.0.environment.0.id")
-
-		// If managed_resource.id is not "tableflow", ensure environment block exists
-		if resourceId != "tableflow" && !environmentExists {
-			return fmt.Errorf("'environment.id' is required when 'managed_resource.id' is %s\n", resourceId)
-		}
-
-		// If managed_resource.id is "tableflow", ensure environment block is NOT set
-		if resourceId == "tableflow" && environmentExists {
-			return fmt.Errorf("'environment' block can't be present when 'managed_resource.id' is 'tableflow'")
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
Release Notes
---------
* Fixed the "Regression in v2.13.0: Unable to create API key with managed_resource block" issue (https://github.com/confluentinc/terraform-provider-confluent/issues/537).

Bug Fixes
* Fixed the "Regression in v2.13.0: Unable to create API key with managed_resource block" issue (https://github.com/confluentinc/terraform-provider-confluent/issues/537).

Examples
- NA

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR disables `customdiff.Sequence(resourceApiKeyManagedResourceDiff)` for `confluent_api_key` as it doesn't support all use cases and leads to false positives in some scenarios. See issue #537 for more details regarding one of the use cases where it fails.


Blast Radius
----
- Confluent Cloud customers who are using `confluent_api_key` resource will be blocked.

References
----------
* https://github.com/confluentinc/terraform-provider-confluent/issues/537
* https://github.com/confluentinc/terraform-provider-confluent/commit/a08c057a6a66fc5147c25814723024a3376fca0d

Test & Review
-------------
* https://confluent.slack.com/archives/C08ARD279TN/p1738088475558509

### Note
Disabling validation is not ideal. However, users will still not be able to create API keys if they provide invalid configurations; that is, they will receive 400 HTTP status code errors. Nevertheless, we should unblock the ability to create API keys as soon as possible.