### PR TITLE
Update Makefile and Connect SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ testacc:
 	@echo "finished testacc"
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/darwin_amd64
-	cp ./bin/darwin-amd64/terraform-provider-confluent ~/.terraform.d/plugins/darwin_amd64/
+	mkdir -p ~/.terraform.d/plugins/$(GOOS)_$(GOARCH)
+	cp ./$(BUILD_DIR)/$(GOOS)-$(GOARCH)/$(NAME) ~/.terraform.d/plugins/$(GOOS)_$(GOARCH)/
 
 .PHONY: gox
 gox:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27
 	github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0
-	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.2.0
+	github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0
 	github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/data-catalog v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-2024092100
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.0-20240921001517-750d06dd7c27/go.mod h1:xqB2YHUtcYF5cbwctSDzXoYw0YXaawj13d0lzcvphEA=
 github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0 h1:ioG3TsP8FwskPtwitfGfvBgTdprYKutHB0oxG5F4Dj8=
 github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0/go.mod h1:WndyhYUqeH7usVOfh+3g9CpVPqHWxIkJqopSISD0pGg=
-github.com/confluentinc/ccloud-sdk-go-v2/connect v0.2.0 h1:rEb3sxzKCZvZCnEZ10WyGqkVIdlqxJGbmP85/4C4YdE=
-github.com/confluentinc/ccloud-sdk-go-v2/connect v0.2.0/go.mod h1:lF4AfDtxoL0V7ZIMOULWiAycPwlfyt9UG659adRNdOM=
+github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0 h1:ISrVOX9qJ2Sxiu/fGBqqHeaA0SRJQujc8yP7qAZRL3Y=
+github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0/go.mod h1:zHG/3DzsnoHC81B1AY9K/8bMX3mxbIp5/nHHdypa//w=
 github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.2 h1:NSiuOYjZOKxHTRGYI7X9wFvf57ZNzWpZaChmWv7/UQw=
 github.com/confluentinc/ccloud-sdk-go-v2/connect-custom-plugin v0.0.2/go.mod h1:AaF39Acy3LFnHSHExaUtqNmbs7kL5/AL54CXX61+Il8=
 github.com/confluentinc/ccloud-sdk-go-v2/data-catalog v0.2.0 h1:ySx0jYNGK0XLcSkgPz+hxcH05v1LI5GVb3Rg+TCqBqk=

--- a/internal/provider/resource_connector_managed_test.go
+++ b/internal/provider/resource_connector_managed_test.go
@@ -298,7 +298,7 @@ func testAccCheckConnectorDestroy(s *terraform.State) error {
 		deletedConnectorName := rs.Primary.Attributes["config_nonsensitive.name"]
 		deletedConnectorEnvId := rs.Primary.Attributes["environment.0.id"]
 		deletedConnectorKafkaClusterId := rs.Primary.Attributes["kafka_cluster.0.id"]
-		req := c.connectClient.ConnectorsV1Api.ReadConnectv1Connector(c.connectApiContext(context.Background()), deletedConnectorName, deletedConnectorEnvId, deletedConnectorKafkaClusterId)
+		req := c.connectClient.ConnectorsConnectV1Api.ReadConnectv1Connector(c.connectApiContext(context.Background()), deletedConnectorName, deletedConnectorEnvId, deletedConnectorKafkaClusterId)
 		_, response, _ := req.Execute()
 		if isNonKafkaRestApiResourceNotFound(response) {
 			return nil


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Change `build` in the Makefile to not hardcode OS or architecture. And update the connect SDK to version 0.7.0.

Blast Radius
----
Should be minimal to none since this is only a renaming change, but any issues would affect the connector resource.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Tested creating connector (datagen source) as a sanity check.

Create plan:
```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - confluentinc/confluent in /Users/sgagniere/git/go/src/github.com/confluentinc/terraform-provider-confluent/bin/darwin-amd64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
confluent_service_account.connector-service-account: Refreshing state... [id=sa-k9nxog]
confluent_environment.staging: Refreshing state... [id=env-v6xn6p]
confluent_kafka_cluster.basic: Refreshing state... [id=lkc-wp5pgm]
confluent_role_binding.test-rb: Refreshing state... [id=rb-9k4Ker]
confluent_api_key.test-api-key: Refreshing state... [id=L77DR6DFI3UE7QZD]
confluent_kafka_acl.data-preview-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#CREATE#ALLOW]
confluent_kafka_acl.data-preview-acl-2: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#WRITE#ALLOW]
confluent_kafka_acl.sample-data-orders-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#sample_data_orders#LITERAL#User:sa-k9nxog#*#WRITE#ALLOW]
confluent_kafka_topic.orders: Refreshing state... [id=lkc-wp5pgm/orders]
confluent_kafka_acl.kafka-cluster-acl: Refreshing state... [id=lkc-wp5pgm/CLUSTER#kafka-cluster#LITERAL#User:sa-k9nxog#*#DESCRIBE#ALLOW]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # confluent_connector.source will be created
  + resource "confluent_connector" "source" {
      + config_nonsensitive = {
          + "connector.class"          = "DatagenSource"
          + "kafka.auth.mode"          = "SERVICE_ACCOUNT"
          + "kafka.service.account.id" = "sa-k9nxog"
          + "kafka.topic"              = "orders"
          + "name"                     = "DatagenSourceConnector_0"
          + "output.data.format"       = "JSON"
          + "quickstart"               = "ORDERS"
          + "tasks.max"                = "1"
        }
      + config_sensitive    = (sensitive value)
      + id                  = (known after apply)
      + status              = (known after apply)

      + environment {
          + id = "env-v6xn6p"
        }

      + kafka_cluster {
          + id = "lkc-wp5pgm"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
Create apply:
```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - confluentinc/confluent in /Users/sgagniere/git/go/src/github.com/confluentinc/terraform-provider-confluent/bin/darwin-amd64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
confluent_service_account.connector-service-account: Refreshing state... [id=sa-k9nxog]
confluent_environment.staging: Refreshing state... [id=env-v6xn6p]
confluent_kafka_cluster.basic: Refreshing state... [id=lkc-wp5pgm]
confluent_role_binding.test-rb: Refreshing state... [id=rb-9k4Ker]
confluent_api_key.test-api-key: Refreshing state... [id=L77DR6DFI3UE7QZD]
confluent_kafka_acl.data-preview-acl-2: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#WRITE#ALLOW]
confluent_kafka_acl.kafka-cluster-acl: Refreshing state... [id=lkc-wp5pgm/CLUSTER#kafka-cluster#LITERAL#User:sa-k9nxog#*#DESCRIBE#ALLOW]
confluent_kafka_acl.data-preview-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#CREATE#ALLOW]
confluent_kafka_topic.orders: Refreshing state... [id=lkc-wp5pgm/orders]
confluent_kafka_acl.sample-data-orders-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#sample_data_orders#LITERAL#User:sa-k9nxog#*#WRITE#ALLOW]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # confluent_connector.source will be created
  + resource "confluent_connector" "source" {
      + config_nonsensitive = {
          + "connector.class"          = "DatagenSource"
          + "kafka.auth.mode"          = "SERVICE_ACCOUNT"
          + "kafka.service.account.id" = "sa-k9nxog"
          + "kafka.topic"              = "orders"
          + "name"                     = "DatagenSourceConnector_0"
          + "output.data.format"       = "JSON"
          + "quickstart"               = "ORDERS"
          + "tasks.max"                = "1"
        }
      + config_sensitive    = (sensitive value)
      + id                  = (known after apply)
      + status              = (known after apply)

      + environment {
          + id = "env-v6xn6p"
        }

      + kafka_cluster {
          + id = "lkc-wp5pgm"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

confluent_connector.source: Creating...
confluent_connector.source: Still creating... [10s elapsed]
   (skipping lines here to save space)
confluent_connector.source: Still creating... [6m10s elapsed]
confluent_connector.source: Creation complete after 6m11s [id=lcc-5nwvvz]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
Plan again:
```
terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - confluentinc/confluent in /Users/sgagniere/git/go/src/github.com/confluentinc/terraform-provider-confluent/bin/darwin-amd64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
confluent_environment.staging: Refreshing state... [id=env-v6xn6p]
confluent_service_account.connector-service-account: Refreshing state... [id=sa-k9nxog]
confluent_kafka_cluster.basic: Refreshing state... [id=lkc-wp5pgm]
confluent_role_binding.test-rb: Refreshing state... [id=rb-9k4Ker]
confluent_api_key.test-api-key: Refreshing state... [id=L77DR6DFI3UE7QZD]
confluent_kafka_acl.data-preview-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#CREATE#ALLOW]
confluent_kafka_topic.orders: Refreshing state... [id=lkc-wp5pgm/orders]
confluent_kafka_acl.sample-data-orders-acl: Refreshing state... [id=lkc-wp5pgm/TOPIC#sample_data_orders#LITERAL#User:sa-k9nxog#*#WRITE#ALLOW]
confluent_kafka_acl.kafka-cluster-acl: Refreshing state... [id=lkc-wp5pgm/CLUSTER#kafka-cluster#LITERAL#User:sa-k9nxog#*#DESCRIBE#ALLOW]
confluent_kafka_acl.data-preview-acl-2: Refreshing state... [id=lkc-wp5pgm/TOPIC#data-preview#PREFIXED#User:sa-k9nxog#*#WRITE#ALLOW]
confluent_connector.source: Refreshing state... [id=lcc-5nwvvz]

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your configuration and the remote system(s). As a result, there are no actions to take.
```