### PR TITLE
RCCA-25291: Fix issue #543

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -187,7 +187,7 @@ func rulesetSchema() *schema.Schema {
 			},
 		},
 		MaxItems: 1,
-		Computed: false,
+		Computed: true,
 		Optional: true,
 	}
 }
@@ -356,10 +356,6 @@ func SetSchemaDiff(ctx context.Context, diff *schema.ResourceDiff, meta interfac
 		if tfRulesetMap[paramDomainRules] != nil {
 			ruleset.SetDomainRules(buildRules(tfRulesetMap[paramDomainRules].(*schema.Set).List()))
 		}
-		createSchemaRequest.SetRuleSet(*ruleset)
-	} else {
-		ruleset := sr.NewRuleSet()
-		ruleset.SetDomainRules([]sr.Rule{})
 		createSchemaRequest.SetRuleSet(*ruleset)
 	}
 	if tfMetadata := diff.Get(paramMetadata).([]interface{}); len(tfMetadata) == 1 {
@@ -536,10 +532,6 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if tfRulesetMap[paramDomainRules] != nil {
 			ruleset.SetDomainRules(buildRules(tfRulesetMap[paramDomainRules].(*schema.Set).List()))
 		}
-		createSchemaRequest.SetRuleSet(*ruleset)
-	} else {
-		ruleset := sr.NewRuleSet()
-		ruleset.SetDomainRules([]sr.Rule{})
 		createSchemaRequest.SetRuleSet(*ruleset)
 	}
 	if tfMetadata := d.Get(paramMetadata).([]interface{}); len(tfMetadata) == 1 {
@@ -895,12 +887,6 @@ func readSchemaRegistryConfigAndSetAttributes(ctx context.Context, d *schema.Res
 	if ruleSet, ok := srSchema.GetRuleSetOk(); ok {
 		if len(ruleSet.GetDomainRules()) > 0 {
 			if err := d.Set(paramRuleset, buildTfRules(ruleSet.GetDomainRules())); err != nil {
-				return nil, err
-			}
-		} else {
-			ruleset := sr.NewRuleSet()
-			ruleset.SetDomainRules([]sr.Rule{})
-			if err := d.Set(paramRuleset, make([]string, 0)); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/provider/resource_schema_latest_refresh_test.go
+++ b/internal/provider/resource_schema_latest_refresh_test.go
@@ -267,28 +267,6 @@ func testAccCheckLatestRefreshSchemaConfig(confluentCloudBaseUrl, mockServerUrl 
         subject_name = "%s"
         version = %d
       }
-ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryKey, testSchemaRegistrySecret, testSubjectName, testFormat, schemaContent,
 		testHardDelete, testSkipSchemaValidationDuringPlanTrue,

--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -249,37 +249,6 @@ func TestAccLatestSchema(t *testing.T) {
 					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.%", "3"),
 					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.name", testSecondSchemaReferenceDisplayName),
 					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.subject_name", testSecondSchemaReferenceSubject),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.#", "1"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.%", "2"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.#", "2"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.%", "11"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.doc", ""),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.expr", ""),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.kind", "TRANSFORM"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.mode", "WRITEREAD"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.name", "encrypt"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.on_failure", "ERROR,ERROR"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.on_success", "NONE,NONE"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.params.%", "1"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.params.encrypt.kek.name", "testkek2"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.tags.#", "1"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.tags.0", "PIIIII"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.type", "ENCRYPT"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.0.disabled", "false"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.%", "11"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.doc", ""),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.expr", ""),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.kind", "TRANSFORM"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.mode", "WRITEREAD"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.name", "encryptPII"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.on_failure", "ERROR,ERROR"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.on_success", "NONE,NONE"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.params.%", "1"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.params.encrypt.kek.name", "testkek2"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.tags.#", "1"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.tags.0", "PII"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.type", "ENCRYPT"),
-					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "ruleset.0.domain_rules.1.disabled", "false"),
 					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "schema_reference.1.version", strconv.Itoa(testSecondSchemaReferenceVersion)),
 					resource.TestCheckResourceAttr(fullSchemaResourceLabel, "%", strconv.Itoa(testNumberOfSchemaRegistrySchemaResourceAttributes)),
 				),
@@ -329,28 +298,6 @@ func testAccCheckLatestSchemaConfig(confluentCloudBaseUrl, mockServerUrl string)
         subject_name = "%s"
         version = %d
       }
-      ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryKey, testSchemaRegistrySecret, testSubjectName, testFormat, testSchemaContent,
 		testHardDelete, testSkipSchemaValidationDuringPlanTrue,
@@ -390,28 +337,6 @@ func testAccCheckLatestSchemaConfigWithUpdatedCredentials(confluentCloudBaseUrl,
         subject_name = "%s"
         version = %d
       }
-      ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryUpdatedKey, testSchemaRegistryUpdatedSecret, testSubjectName, testFormat, testSchemaContent,
 		testHardDelete, testRecreateOnUpdateFalse, testFirstSchemaReferenceDisplayName, testFirstSchemaReferenceSubject, testFirstSchemaReferenceVersion,

--- a/internal/provider/resource_schema_versioned_provider_block_test.go
+++ b/internal/provider/resource_schema_versioned_provider_block_test.go
@@ -190,28 +190,6 @@ func testAccCheckVersionedSchemaConfigWithEnhancedProviderBlock(confluentCloudBa
         subject_name = "%s"
         version = %d
       }
-ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, kafkaApiKey, kafkaApiSecret, mockServerUrl, testStreamGovernanceClusterId, testSchemaResourceLabel, testSubjectName, testFormat, testSchemaContent,
 		testHardDelete, testRecreateOnUpdateTrue, testSkipSchemaValidationDuringPlanFalse,

--- a/internal/provider/resource_schema_versioned_test.go
+++ b/internal/provider/resource_schema_versioned_test.go
@@ -313,28 +313,6 @@ func testAccCheckSchemaConfig(confluentCloudBaseUrl, mockServerUrl string) strin
         subject_name = "%s"
         version = %d
       }
-ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryKey, testSchemaRegistrySecret, testSubjectName, testFormat, testSchemaContent,
 		testHardDelete, testRecreateOnUpdateTrue, testSkipSchemaValidationDuringPlanTrue,
@@ -375,28 +353,6 @@ func testAccCheckSchemaConfigWithUpdatedCredentials(confluentCloudBaseUrl, mockS
         subject_name = "%s"
         version = %d
       }
-ruleset {
-		domain_rules {
-		  name = "encryptPII"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-		domain_rules  {
-		  name = "encrypt"
-		  kind = "TRANSFORM"
-		  type = "ENCRYPT"
-		  mode = "WRITEREAD"
-		  tags = ["PIIIII"]
-		  params = {
-			  "encrypt.kek.name" = "testkek2"
-		  }
-		}
-	  }
 	}
 	`, confluentCloudBaseUrl, testSchemaResourceLabel, testStreamGovernanceClusterId, mockServerUrl, testSchemaRegistryUpdatedKey, testSchemaRegistryUpdatedSecret, testSubjectName, testFormat, testSchemaContent,
 		testHardDelete, testRecreateOnUpdateTrue, testSkipSchemaValidationDuringPlanFalse,

--- a/internal/testdata/schema_registry_schema/read_latest_schema.json
+++ b/internal/testdata/schema_registry_schema/read_latest_schema.json
@@ -14,39 +14,5 @@
       "subject": "test3",
       "version":  3
     }
-  ],
-  "ruleSet": {
-    "domainRules": [
-      {
-        "name": "encryptPII",
-        "kind": "TRANSFORM",
-        "mode": "WRITEREAD",
-        "type": "ENCRYPT",
-        "tags": [
-          "PII"
-        ],
-        "params": {
-          "encrypt.kek.name": "testkek2"
-        },
-        "onSuccess": "NONE,NONE",
-        "onFailure": "ERROR,ERROR",
-        "disabled": false
-      },
-      {
-        "name": "encrypt",
-        "kind": "TRANSFORM",
-        "mode": "WRITEREAD",
-        "type": "ENCRYPT",
-        "tags": [
-          "PIIIII"
-        ],
-        "params": {
-          "encrypt.kek.name": "testkek2"
-        },
-        "onSuccess": "NONE,NONE",
-        "onFailure": "ERROR,ERROR",
-        "disabled": false
-      }
-    ]
-  }
+  ]
 }

--- a/internal/testdata/schema_registry_schema/read_latest_schema_updated.json
+++ b/internal/testdata/schema_registry_schema/read_latest_schema_updated.json
@@ -14,39 +14,5 @@
       "subject": "test3",
       "version": 3
     }
-  ],
-  "ruleSet": {
-    "domainRules": [
-      {
-        "name": "encryptPII",
-        "kind": "TRANSFORM",
-        "mode": "WRITEREAD",
-        "type": "ENCRYPT",
-        "tags": [
-          "PII"
-        ],
-        "params": {
-          "encrypt.kek.name": "testkek2"
-        },
-        "onSuccess": "NONE,NONE",
-        "onFailure": "ERROR,ERROR",
-        "disabled": false
-      },
-      {
-        "name": "encrypt",
-        "kind": "TRANSFORM",
-        "mode": "WRITEREAD",
-        "type": "ENCRYPT",
-        "tags": [
-          "PIIIII"
-        ],
-        "params": {
-          "encrypt.kek.name": "testkek2"
-        },
-        "onSuccess": "NONE,NONE",
-        "onFailure": "ERROR,ERROR",
-        "disabled": false
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
* Fixed "[error creating Schema: 403 Forbidden: Upgrade to Stream Governance Advanced package to use schema rules](https://github.com/confluentinc/terraform-provider-confluent/issues/543) ([#543](https://github.com/confluentinc/terraform-provider-confluent/issues/543)).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes #543 by reverting #550. This works as we figured even `terraform plan` after `terraform init -upgrade` (2.14.0 -> 2.15.0) triggers

```
2025-01-31T10:05:13.570-0800 [DEBUG] plugin.terraform-provider-confluent_2.15.0: Creating new Schema: {"references":[],"ruleSet":{"domainRules":[]},"schema":"{\n  \"type\": \"record\",\n  \"namespace\": \"io.confluent.developer.avro\",\n  \"name\": \"Purchase\",\n  \"fields\": [\n    {\n      \"name\": \"item\",\n      \"type\": \"string\"\n    },\n    {\n      \"name\": \"amount\",\n      \"type\": \"double\"\n    },\n    {\n      \"name\": \"customer_id\",\n      \"type\": \"string\"\n    }\n  ]\n}\n","schemaType":"AVRO"}: @module=provider tf_provider_addr=provider tf_req_id=1da259f3-0175-a58b-ad84-d34453626d0f tf_resource_type=confluent_schema tf_rpc=ApplyResourceChange @caller=src/github.com/confluentinc/terraform-provider-confluent/internal/provider/resource_schema.go:584 timestamp=2025-01-31T10:05:13.570-0800
```

Blast Radius
----

- Confluent Cloud customers who are using `confluent_schema` resource will be blocked.

References
----------
* #543 
* #500

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1738348617845079
* https://confluent.slack.com/archives/C08B3G23GTV/p1738340495122309?thread_ts=1738340181.367659&cid=C08B3G23GTV (reproducing the errors)

There are two use cases we verified:

1. Creating new schemas in version 2.16.0, where 2.16.0 is our custom binary.
2. Upgrading from 2.14.0 to 2.15.0 to 2.16.0 without creating new schemas (i.e., performing a plain terraform plan) for the SR package essentials.

The test results include Terraform state files, logs, and other relevant data.
