### PR TITLE
Updated 4 examples to use the latest version of TF Provider: 2.16.0

### DIFF
--- a/examples/configurations/connectors/s3-sink-connector-assume-role/main.tf
+++ b/examples/configurations/connectors/s3-sink-connector-assume-role/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.8.0"
+      version = "2.16.0"
     }
   }
 }

--- a/examples/configurations/field-level-encryption-schema/main.tf
+++ b/examples/configurations/field-level-encryption-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.60.0"
+      version = "2.16.0"
     }
   }
 }

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -7,7 +7,7 @@ terraform {
           }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.81.0"
+      version = "2.16.0"
     }
   }
 }

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -238,7 +238,6 @@ resource "confluent_kafka_topic" "orders" {
   }
   topic_name    = "orders_source"
   rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint //enterprise
-  #   private_rest_endpoint = confluent_kafka_cluster.standard.private_rest_endpoint
   credentials {
     key    = confluent_api_key.infrastructure-manager-kafka-api-key.id
     secret = confluent_api_key.infrastructure-manager-kafka-api-key.secret

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -249,7 +249,6 @@ resource "confluent_schema" "order" {
     id = data.confluent_schema_registry_cluster.essentials.id
   }
   rest_endpoint = data.confluent_schema_registry_cluster.essentials.rest_endpoint
-  #   private_rest_endpoint = confluent_schema_registry_cluster.essentials.private_rest_endpoint
   # https://developer.confluent.io/learn-kafka/schema-registry/schema-subjects/#topicnamestrategy
   subject_name = "${confluent_kafka_topic.orders.topic_name}-value"
   format       = "AVRO"

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
 
-   aws = {
-          source  = "hashicorp/aws"
-          version = ">= 5.17.0"
-          }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.17.0"
+    }
     confluent = {
       source  = "confluentinc/confluent"
       version = "2.16.0"
@@ -22,13 +22,16 @@ provider "aws" {
 }
 
 data "confluent_organization" "main" {}
+
 data "confluent_environment" "staging" {
   id = var.environment_id
 }
+
 locals {
   cloud  = "AWS"
   region = "us-east-2"
 }
+
 // In Confluent Cloud, an environment is mapped to a Flink catalog, and a Kafka cluster is mapped to a Flink database.
 # Update the config to use a cloud provider and region of your choice.
 # https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_cluster
@@ -44,8 +47,8 @@ resource "confluent_kafka_cluster" "enterprise" {
 }
 
 resource "confluent_private_link_attachment" "pla" {
-  cloud = "AWS"
-  region = local.region
+  cloud        = "AWS"
+  region       = local.region
   display_name = "staging-aws-platt"
   environment {
     id = data.confluent_environment.staging.id
@@ -79,16 +82,19 @@ resource "confluent_service_account" "statements-runner" {
   display_name = "statements-runner"
   description  = "Service account for running Flink Statements in 'inventory' Kafka cluster"
 }
+
 // Service account to set up initial infrastructure, such as creating a schema and a Kafka topic (Flink table)
 resource "confluent_service_account" "infrastructure-manager" {
   display_name = "infrastructure-manager"
   description  = "Service account for setting up schemas and Kafka topics (Flink tables)"
 }
+
 resource "confluent_role_binding" "infrastructure-manager-environment-admin" {
   principal   = "User:${confluent_service_account.infrastructure-manager.id}"
   role_name   = "EnvironmentAdmin"
   crn_pattern = data.confluent_environment.staging.resource_name
 }
+
 resource "confluent_api_key" "infrastructure-manager-kafka-api-key" {
   display_name = "infrastructure-manager-kafka-api-key"
   description  = "Kafka API Key that is owned by 'infrastructure-manager' service account"
@@ -117,6 +123,7 @@ resource "confluent_api_key" "infrastructure-manager-kafka-api-key" {
     confluent_role_binding.infrastructure-manager-environment-admin
   ]
 }
+
 resource "confluent_api_key" "infrastructure-manager-schema-registry-api-key" {
   display_name = "infrastructure-manager-schema-registry-api-key"
   description  = "Schema Registry API Key that is owned by 'infrastructure-manager' service account"
@@ -143,22 +150,26 @@ resource "confluent_api_key" "infrastructure-manager-schema-registry-api-key" {
     confluent_role_binding.infrastructure-manager-environment-admin
   ]
 }
+
 resource "confluent_role_binding" "statements-runner-environment-admin" {
   principal   = "User:${confluent_service_account.statements-runner.id}"
   role_name   = "EnvironmentAdmin"
   crn_pattern = data.confluent_environment.staging.resource_name
 }
+
 // Service account that owns Flink API Key
 resource "confluent_service_account" "app-manager" {
   display_name = "app-manager"
   description  = "Service account that has got full access to Flink resources in an environment"
 }
+
 // https://docs.confluent.io/cloud/current/access-management/access-control/rbac/predefined-rbac-roles.html#flinkadmin
 resource "confluent_role_binding" "app-manager-flink-developer" {
   principal   = "User:${confluent_service_account.app-manager.id}"
   role_name   = "FlinkAdmin"
   crn_pattern = data.confluent_environment.staging.resource_name
 }
+
 // https://docs.confluent.io/cloud/current/access-management/access-control/rbac/predefined-rbac-roles.html#assigner
 // https://docs.confluent.io/cloud/current/flink/operate-and-deploy/flink-rbac.html#submit-long-running-statements
 resource "confluent_role_binding" "app-manager-assigner" {
@@ -166,10 +177,12 @@ resource "confluent_role_binding" "app-manager-assigner" {
   role_name   = "Assigner"
   crn_pattern = "${data.confluent_organization.main.resource_name}/service-account=${confluent_service_account.statements-runner.id}"
 }
+
 data "confluent_flink_region" "us-east-2" {
   cloud  = local.cloud
   region = local.region
 }
+
 resource "confluent_api_key" "app-manager-flink-api-key" {
   display_name = "app-manager-flink-api-key"
   description  = "Flink API Key that is owned by 'app-manager' service account"
@@ -187,11 +200,13 @@ resource "confluent_api_key" "app-manager-flink-api-key" {
     }
   }
 }
+
 data "confluent_schema_registry_region" "essentials" {
   cloud   = local.cloud
   region  = local.region
   package = "ESSENTIALS"
 }
+
 resource "confluent_schema_registry_cluster" "essentials" {
   package = data.confluent_schema_registry_region.essentials.package
   environment {
@@ -202,10 +217,12 @@ resource "confluent_schema_registry_cluster" "essentials" {
     id = data.confluent_schema_registry_region.essentials.id
   }
 }
+
 data "confluent_flink_region" "main" {
-  cloud        = local.cloud
-  region       = local.region
+  cloud  = local.cloud
+  region = local.region
 }
+
 # https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html#step-1-create-a-af-compute-pool
 resource "confluent_flink_compute_pool" "main" {
   display_name = "my-compute-pool"
@@ -229,27 +246,29 @@ resource "confluent_kafka_topic" "orders" {
   }
   topic_name    = "orders_source"
   rest_endpoint = confluent_kafka_cluster.enterprise.rest_endpoint //enterprise
-#   private_rest_endpoint = confluent_kafka_cluster.standard.private_rest_endpoint
+  #   private_rest_endpoint = confluent_kafka_cluster.standard.private_rest_endpoint
   credentials {
     key    = confluent_api_key.infrastructure-manager-kafka-api-key.id
     secret = confluent_api_key.infrastructure-manager-kafka-api-key.secret
   }
 }
+
 resource "confluent_schema" "order" {
   schema_registry_cluster {
     id = confluent_schema_registry_cluster.essentials.id
   }
   rest_endpoint = confluent_schema_registry_cluster.essentials.rest_endpoint
-#   private_rest_endpoint = confluent_schema_registry_cluster.essentials.private_rest_endpoint
+  #   private_rest_endpoint = confluent_schema_registry_cluster.essentials.private_rest_endpoint
   # https://developer.confluent.io/learn-kafka/schema-registry/schema-subjects/#topicnamestrategy
-  subject_name  = "${confluent_kafka_topic.orders.topic_name}-value"
-  format        = "AVRO"
-  schema        = file("./schemas/avro/order.avsc")
+  subject_name = "${confluent_kafka_topic.orders.topic_name}-value"
+  format       = "AVRO"
+  schema       = file("./schemas/avro/order.avsc")
   credentials {
     key    = confluent_api_key.infrastructure-manager-schema-registry-api-key.id
     secret = confluent_api_key.infrastructure-manager-schema-registry-api-key.secret
   }
 }
+
 resource "confluent_flink_statement" "populate-orders-source-table" {
   organization {
     id = data.confluent_organization.main.id
@@ -264,13 +283,12 @@ resource "confluent_flink_statement" "populate-orders-source-table" {
     id = confluent_service_account.statements-runner.id
   }
   # https://docs.confluent.io/cloud/current/flink/reference/example-data.html#marketplace-database
-  statement  = file("./statements/populate-orders-source-table.sql")
+  statement = file("./statements/populate-orders-source-table.sql")
   properties = {
     "sql.current-catalog"  = data.confluent_environment.staging.display_name
     "sql.current-database" = confluent_kafka_cluster.enterprise.display_name
   }
   rest_endpoint = data.confluent_flink_region.main.private_rest_endpoint
-#   private_rest_endpoint = data.confluent_flink_region.main.private_rest_endpoint
   credentials {
     key    = confluent_api_key.app-manager-flink-api-key.id
     secret = confluent_api_key.app-manager-flink-api-key.secret

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.17.0"

--- a/examples/configurations/private-link-schema-registry/main.tf
+++ b/examples/configurations/private-link-schema-registry/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "1.81.0"
+      version = "2.16.0"
     }
   }
 }

--- a/examples/configurations/private-link-schema-registry/main.tf
+++ b/examples/configurations/private-link-schema-registry/main.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.17.0"
@@ -22,13 +21,26 @@ provider "aws" {
 }
 
 data "confluent_organization" "main" {}
+
 data "confluent_environment" "staging" {
   id = var.environment_id
 }
+
 locals {
   cloud  = "AWS"
   region = "us-west-2"
 }
+
+data "confluent_schema_registry_cluster" "essentials" {
+  environment {
+    id = data.confluent_environment.staging.id
+  }
+
+  depends_on = [
+    confluent_kafka_cluster.enterprise
+  ]
+}
+
 // In Confluent Cloud, an environment is mapped to a Flink catalog, and a Kafka cluster is mapped to a Flink database.
 # Update the config to use a cloud provider and region of your choice.
 # https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_cluster
@@ -53,7 +65,7 @@ resource "confluent_private_link_attachment" "pla" {
 }
 
 module "privatelink" {
-  source                   = "./aws-privatelink-endpoint"
+  source                   = "./aws-private-link-endpoint"
   vpc_id                   = var.vpc_id
   privatelink_service_name = confluent_private_link_attachment.pla.aws[0].vpc_endpoint_service_name
   dns_domain               = confluent_private_link_attachment.pla.dns_domain
@@ -79,16 +91,19 @@ resource "confluent_service_account" "statements-runner" {
   display_name = "statements-runner"
   description  = "Service account for running Flink Statements in 'inventory' Kafka cluster"
 }
+
 // Service account to set up initial infrastructure, such as creating a schema and a Kafka topic (Flink table)
 resource "confluent_service_account" "infrastructure-manager" {
   display_name = "infrastructure-manager"
   description  = "Service account for setting up schemas and Kafka topics (Flink tables)"
 }
+
 resource "confluent_role_binding" "infrastructure-manager-environment-admin" {
   principal   = "User:${confluent_service_account.infrastructure-manager.id}"
   role_name   = "EnvironmentAdmin"
   crn_pattern = replace(data.confluent_environment.staging.resource_name, "stag.cpdev.", "confluent.")
 }
+
 resource "confluent_api_key" "infrastructure-manager-kafka-api-key" {
   display_name = "infrastructure-manager-kafka-api-key"
   description  = "Kafka API Key that is owned by 'infrastructure-manager' service account"
@@ -117,6 +132,7 @@ resource "confluent_api_key" "infrastructure-manager-kafka-api-key" {
     confluent_role_binding.infrastructure-manager-environment-admin
   ]
 }
+
 resource "confluent_api_key" "infrastructure-manager-schema-registry-api-key" {
   display_name = "infrastructure-manager-schema-registry-api-key"
   description  = "Schema Registry API Key that is owned by 'infrastructure-manager' service account"
@@ -126,9 +142,9 @@ resource "confluent_api_key" "infrastructure-manager-schema-registry-api-key" {
     kind        = confluent_service_account.infrastructure-manager.kind
   }
   managed_resource {
-    id          = confluent_schema_registry_cluster.essentials.id
-    api_version = confluent_schema_registry_cluster.essentials.api_version
-    kind        = confluent_schema_registry_cluster.essentials.kind
+    id          = data.confluent_schema_registry_cluster.essentials.id
+    api_version = data.confluent_schema_registry_cluster.essentials.api_version
+    kind        = data.confluent_schema_registry_cluster.essentials.kind
     environment {
       id = data.confluent_environment.staging.id
     }
@@ -143,22 +159,26 @@ resource "confluent_api_key" "infrastructure-manager-schema-registry-api-key" {
     confluent_role_binding.infrastructure-manager-environment-admin
   ]
 }
+
 resource "confluent_role_binding" "statements-runner-environment-admin" {
   principal   = "User:${confluent_service_account.statements-runner.id}"
   role_name   = "EnvironmentAdmin"
   crn_pattern = replace(data.confluent_environment.staging.resource_name, "stag.cpdev.", "confluent.")
 }
+
 // Service account that owns Flink API Key
 resource "confluent_service_account" "app-manager" {
   display_name = "app-manager"
   description  = "Service account that has got full access to Flink resources in an environment"
 }
+
 // https://docs.confluent.io/cloud/current/access-management/access-control/rbac/predefined-rbac-roles.html#flinkadmin
 resource "confluent_role_binding" "app-manager-flink-developer" {
   principal   = "User:${confluent_service_account.app-manager.id}"
   role_name   = "FlinkAdmin"
   crn_pattern = replace(data.confluent_environment.staging.resource_name, "stag.cpdev.", "confluent.")
 }
+
 // https://docs.confluent.io/cloud/current/access-management/access-control/rbac/predefined-rbac-roles.html#assigner
 // https://docs.confluent.io/cloud/current/flink/operate-and-deploy/flink-rbac.html#submit-long-running-statements
 resource "confluent_role_binding" "app-manager-assigner" {
@@ -166,10 +186,12 @@ resource "confluent_role_binding" "app-manager-assigner" {
   role_name   = "Assigner"
   crn_pattern = replace("${data.confluent_organization.main.resource_name}/service-account=${confluent_service_account.statements-runner.id}", "stag.cpdev.", "confluent.")
 }
+
 data "confluent_flink_region" "us-west-2" {
   cloud  = local.cloud
   region = local.region
 }
+
 resource "confluent_api_key" "app-manager-flink-api-key" {
   display_name = "app-manager-flink-api-key"
   description  = "Flink API Key that is owned by 'app-manager' service account"
@@ -188,20 +210,11 @@ resource "confluent_api_key" "app-manager-flink-api-key" {
   }
 }
 
-data "confluent_schema_registry_cluster" "essentials" {
-  environment {
-    id = var.environment_id
-  }
-
-  depends_on = [
-    confluent_kafka_cluster.enterprise
-  ]
-}
-
 data "confluent_flink_region" "main" {
   cloud  = local.cloud
   region = local.region
 }
+
 # https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html#step-1-create-a-af-compute-pool
 resource "confluent_flink_compute_pool" "main" {
   display_name = "my-compute-pool"
@@ -230,11 +243,12 @@ resource "confluent_kafka_topic" "orders" {
     secret = confluent_api_key.infrastructure-manager-kafka-api-key.secret
   }
 }
+
 resource "confluent_schema" "order" {
   schema_registry_cluster {
-    id = confluent_schema_registry_cluster.essentials.id
+    id = data.confluent_schema_registry_cluster.essentials.id
   }
-  private_rest_endpoint = confluent_schema_registry_cluster.essentials.private_rest_endpoint
+  rest_endpoint = data.confluent_schema_registry_cluster.essentials.private_rest_endpoint
 
   # https://developer.confluent.io/learn-kafka/schema-registry/schema-subjects/#topicnamestrategy
   subject_name = "${confluent_kafka_topic.orders.topic_name}-value"


### PR DESCRIPTION
### What
- Updated 4 examples to use the latest version of TF Provider: 2.16.0 by using https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/version-2-upgrade. We also ran `terraform fmt` and `terraform validate` to resolve some minor errors:
```
terraform init 
Initializing modules...
- privatelink in 

Error: Unreadable module directory

Unable to evaluate directory symlink: lstat aws-privatelink-endpoint: no such
file or directory
```
and
```
Error: Unsupported argument

  on main.tf line 238, in resource "confluent_schema" "order":
 238:   private_rest_endpoint = data.confluent_schema_registry_cluster.essentials.private_rest_endpoint

An argument named "private_rest_endpoint" is not expected here.
```


Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
- Updated 4 examples to use the latest version of TF Provider: 2.16.0.

Test & Review
-------------
```
➜  private-link-schema-registry git:(javabrett/provider-version-updates) ✗ terraform validate 

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - terraform.confluent.io/confluentinc/confluent in /Users/linou/work/terraform-provider-confluent/bin/darwin-amd64

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

Success! The configuration is valid, but there were some validation warnings as shown above.

```

```
➜  private-flink-quickstart git:(javabrett/provider-version-updates) ✗ terraform validate 

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - terraform.confluent.io/confluentinc/confluent in /Users/linou/work/terraform-provider-confluent/bin/darwin-amd64

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

Success! The configuration is valid, but there were some validation warnings as shown above.
```
