### PR TITLE
APIT-2866: Update the regular-bidirectional-cluster-link-rbac example to avoid a potential race condition.

### DIFF
--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -139,13 +139,6 @@ resource "confluent_cluster_link" "east-to-west" {
       secret = confluent_api_key.app-manager-west-cluster-api-key.secret
     }
   }
-
-  // Make sure confluent_cluster_link.west-to-east is created first to avoid a race condition in the backend
-  // if confluent_cluster_link.west-to-east and confluent_cluster_link.east-to-west are created simultaneously,
-  // which can cause the cluster link IDs to differ.
-  depends_on = [
-    confluent_cluster_link.west-to-east
-  ]
 }
 
 resource "confluent_kafka_mirror_topic" "from-east" {

--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -139,6 +139,13 @@ resource "confluent_cluster_link" "east-to-west" {
       secret = confluent_api_key.app-manager-west-cluster-api-key.secret
     }
   }
+
+  // Make sure confluent_cluster_link.west-to-east is created first to avoid a race condition in the backend
+  // if confluent_cluster_link.west-to-east and confluent_cluster_link.east-to-west are created simultaneously,
+  // which can cause the cluster link IDs to differ.
+  depends_on = [
+    confluent_cluster_link.west-to-east
+  ]
 }
 
 resource "confluent_kafka_mirror_topic" "from-east" {

--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -190,6 +190,13 @@ resource "confluent_cluster_link" "west-to-east" {
       secret = confluent_api_key.app-manager-east-cluster-api-key.secret
     }
   }
+
+  // Make sure confluent_cluster_link.east-to-west is created first to avoid a race condition in the backend
+  // if confluent_cluster_link.west-to-east and confluent_cluster_link.east-to-west are created simultaneously,
+  // which can cause the cluster link IDs to differ.
+  depends_on = [
+    confluent_cluster_link.east-to-west
+  ]
 }
 
 resource "confluent_kafka_mirror_topic" "from-west" {


### PR DESCRIPTION
Release Notes
---------

Examples:
- Update the `regular-bidirectional-cluster-link-rbac` example to avoid a potential race condition.

Checklist
---------

- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR updates the `regular-bidirectional-cluster-link-rbac` example to avoid a potential race condition. Adding a depends_on block should be sufficient, as there is already a 10-second [timeout](https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/provider/resource_cluster_link.go#L180) for cluster link resource creation.

We added 
```
depends_on = [
    confluent_cluster_link.east-to-west
  ]
```
instead of
```
depends_on = [
    confluent_cluster_link.west-to-east
  ]
```
to mirror our other TF example (`advanced-bidirectional-cluster-link-rbac`) and the [example](https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/cluster-links-cc.html#create-a-cluster-link-in-bidirectional-mode) from the CL docs.

Blast Radius
----

- Confluent Cloud customers who are using  the `regular-bidirectional-cluster-link-rbac` example will run into errors.

References
----------
* https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/cluster-links-cc.html#create-a-cluster-link-in-bidirectional-mode
* https://confluentinc.atlassian.net/browse/APIT-2866

Test & Review
-------------
```
➜  regular-bidirectional-cluster-link-rbac git:(fix-cluster-link-example) ✗ terraform validate

Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - terraform.confluent.io/confluentinc/confluent in /Users/linou/work/terraform-provider-confluent/bin/darwin-amd64

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.

Success! The configuration is valid, but there were some validation warnings as shown above.

```
