### PR TITLE
#minor: fix CI error for v2.17.0 minor release

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -32,6 +32,7 @@ blocks:
             - export GOROOT=$(pwd)/go
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml
+            # Use the --force flag to avoid the "Error pushing artifact: '...' already exists in the remote storage" error during CI reruns.
             - artifact push workflow dist/darwin-fips_darwin_amd64_v1
             - artifact push workflow dist/darwin-fips_darwin_arm64
   - name: "Draft a Release (Part 2)"

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -67,4 +67,4 @@ blocks:
             - artifact pull workflow darwin-fips_darwin_amd64_v1
             - artifact pull workflow darwin-fips_darwin_arm64
             - cd ..
-            - curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)
+            - DISTRIBUTION=pro curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -67,5 +67,4 @@ blocks:
             - artifact pull workflow darwin-fips_darwin_amd64_v1
             - artifact pull workflow darwin-fips_darwin_arm64
             - cd ..
-            - export "DISTRIBUTION=pro"
-            - curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)
+            - curl https://goreleaser.com/static/run | DISTRIBUTION=pro VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -33,8 +33,8 @@ blocks:
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml
             # Use the --force flag to avoid the "Error pushing artifact: '...' already exists in the remote storage" error during CI reruns.
-            - artifact push workflow dist/darwin-fips_darwin_amd64_v1
-            - artifact push workflow dist/darwin-fips_darwin_arm64
+            - artifact push --force workflow dist/darwin-fips_darwin_amd64_v1
+            - artifact push --force workflow dist/darwin-fips_darwin_arm64
   - name: "Draft a Release (Part 2)"
     dependencies: ["Draft a Release (Part 1)"]
     task:

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -67,4 +67,5 @@ blocks:
             - artifact pull workflow darwin-fips_darwin_amd64_v1
             - artifact pull workflow darwin-fips_darwin_arm64
             - cd ..
-            - DISTRIBUTION=pro curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)
+            - export "DISTRIBUTION=pro"
+            - curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
NA

Why did CI start to fail?
----
There was a recent change in GoReleaser's curl script: https://github.com/goreleaser/goreleaser/commit/fa7391e1818de028cd0947ac2ff1e613d9743183

![image](https://github.com/user-attachments/assets/d291cf25-b758-4317-901e-f0e902c1f0b5)

What
----
This PR makes 2 changes to our Semaphore configs:
* adds `--force` flag to resolve
```
artifact push workflow dist/darwin-fips_darwin_amd64_v1
[Feb 11 18:03:34.613] Error pushing artifact: 'artifacts/workflows/314d3afb-0bcf-465e-8070-98592bf4b1f7/darwin-fips_darwin_amd64_v1/terraform-provider-confluent_2.17.0' already exists in the remote storage; delete it first, or use --force flag
```
when rerunning the CI `goreleaser-darwin-fips` task.
* explicitly set `DISTRIBUTION=pro` to resolve the issue with the following command
```
curl https://goreleaser.com/static/run | VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)
```
as it started to fail silently. When we ran `curl https://goreleaser.com/static/run` locally, we could see that that script starts with
```
➜  ~ curl https://goreleaser.com/static/run
#!/usr/bin/env sh
set -e

if test "$DISTRIBUTION" = "pro"; then
	echo "Using Pro distribution..."
	RELEASES_URL="https://github.com/goreleaser/goreleaser-pro/releases"
	FILE_BASENAME="goreleaser-pro"
	LATEST="$(curl -sf https://goreleaser.com/static/latest-pro)"
else
	echo "Using the OSS distribution..."
	RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
	FILE_BASENAME="goreleaser"
	LATEST="$(curl -sf https://goreleaser.com/static/latest)"
fi

test -z "$VERSION" && VERSION="$LATEST"

test -z "$VERSION" && {
	echo "Unable to get goreleaser version." >&2
	exit 1
}

TMP_DIR="$(mktemp -d)"
# shellcheck disable=SC2064 # intentionally expands here
trap "rm -rf \"$TMP_DIR\"" EXIT INT TERM
```
and our last v2.16.0 successful run printed
```
Using Pro distribution...
Downloading GoReleaser v1.25.1-pro...
Verifying checksums...
Could not verify signatures, cosign is not installed.
```
in the logs, whereas the current failed one had
```
Using the OSS distribution...
Downloading GoReleaser v1.25.1-pro...
```
Moreover, `v1.25.1-pro` version only exists in `RELEASES_URL="https://github.com/goreleaser/goreleaser-pro/releases"` and not in `RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"`.


Blast Radius
----
CI for `terraform-provider-confluent` will fail.

Test & Review
-------------
NA
