### PR TITLE
#minor: fix CI error for v2.17.0 minor release 

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -32,7 +32,6 @@ blocks:
             - export GOROOT=$(pwd)/go
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml
-            # Use the --force flag to avoid the "Error pushing artifact: '...' already exists in the remote storage" error during CI reruns.
             - artifact push workflow dist/darwin-fips_darwin_amd64_v1
             - artifact push workflow dist/darwin-fips_darwin_arm64
   - name: "Draft a Release (Part 2)"

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -33,8 +33,8 @@ blocks:
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml
             # Use the --force flag to avoid the "Error pushing artifact: '...' already exists in the remote storage" error during CI reruns.
-            - artifact push --force workflow dist/darwin-fips_darwin_amd64_v1
-            - artifact push --force workflow dist/darwin-fips_darwin_arm64
+            - artifact push workflow dist/darwin-fips_darwin_amd64_v1
+            - artifact push workflow dist/darwin-fips_darwin_arm64
   - name: "Draft a Release (Part 2)"
     dependencies: ["Draft a Release (Part 1)"]
     task:


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
NA

What
----
This is a follow up to #533. Apparently, even though CI error suggested us to use `--force` flag:
```
artifact push workflow dist/darwin-fips_darwin_amd64_v1
[Feb 11 18:03:34.613] Error pushing artifact: 'artifacts/workflows/314d3afb-0bcf-465e-8070-98592bf4b1f7/darwin-fips_darwin_amd64_v1/terraform-provider-confluent_2.17.0' already exists in the remote storage; delete it first, or use --force flag
```

it isn't supported by `artifact` command:

```
artifact push --force workflow dist/darwin-fips_darwin_amd64_v1
Error: unknown flag: --force
Usage:
  artifact push [command]

Available Commands:
  job         Uploads a job file or directory to the storage.
  project     Upload a project file or directory to the storage.
  workflow    Uploads a workflow or directory file to the storage.

Flags:
  -h, --help   help for push

Global Flags:
      --config string   config file (default is $HOME/.artifact.yaml)
  -v, --verbose         verbose logging

Use "artifact push [command] --help" for more information about a command.

error: unknown flag: --force
```

We'll try another approach by deleting the artifact from remote storage if necessary during a new CI run. For what it's worth, it's very likely that this artifact upload is scoped to a Semaphore workflow ID (based on the error message), so we shouldn't encounter this issue with an entirely new CI run.

Blast Radius
----
CI for terraform-provider-confluent will fail.