### PR TITLE
Update docs for confluent_schema_registry_cluster data source

### DIFF
--- a/docs/data-sources/confluent_schema_registry_cluster.md
+++ b/docs/data-sources/confluent_schema_registry_cluster.md
@@ -59,7 +59,7 @@ output "example_using_name" {
 
 The following arguments are supported:
 
-- `id` - (Required String) The ID of the Schema Registry cluster (for example, `lsrc-abc123`).
+- `id` - (Optional String) The ID of the Schema Registry cluster (for example, `lsrc-abc123`).
 - `display_name` - (Optional String) The name for the Schema Registry cluster.
 - `environment` (Required Configuration Block) supports the following:
     - `id` - (Required String) The ID of the Environment that the Schema Registry cluster belongs to, for example, `env-xyz456`.


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Updated docs for [confluent_schema_registry_cluster](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_schema_registry_cluster) data source.


Checklist
---------
NA

What
----
This PR updates the doc to fix a tiny typo as `id` is no longer a required input argument:
```
# Loads the only Schema Registry cluster in the target environment
data "confluent_schema_registry_cluster" "example_using_env_id" {
  environment {
    id = "env-xyz456"
  }
}
```

Blast Radius
----
NA

References
----------
NA

Test & Review
-------------
NA
