### PR TITLE
CLI-3340: Remove typos from confluent_kafka_cluster docs

### DIFF
--- a/docs/data-sources/confluent_kafka_cluster.md
+++ b/docs/data-sources/confluent_kafka_cluster.md
@@ -82,8 +82,6 @@ In addition to the preceding arguments, the following attributes are exported:
 
 -> **Note:** At least one from the `basic`, `standard`, `dedicated`, `enterprise` or `freight` configuration blocks should be specified.
 
--> **Note:** The `freight` block is in a [Early Access lifecycle stage](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy).
-
 -> **Note:** The `freight` Kafka cluster type is only available in AWS currently.
 
 - `network` (Optional Configuration Block) supports the following:

--- a/docs/resources/confluent_kafka_cluster.md
+++ b/docs/resources/confluent_kafka_cluster.md
@@ -268,8 +268,6 @@ The following arguments are supported:
 
 -> **Note:** Exactly one from the `basic`, `standard`, `dedicated`, `enterprise` or `freight` configuration blocks must be specified.
 
--> **Note:** The `freight` block is in an [Early Access lifecycle stage](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy).
-
 -> **Note:** The `freight` Kafka cluster type is currently available only on AWS.
 
 -> **Note:** The `enterprise` Kafka cluster type is currently available only on AWS and Azure.

--- a/docs/resources/confluent_kafka_cluster.md
+++ b/docs/resources/confluent_kafka_cluster.md
@@ -103,11 +103,7 @@ resource "confluent_kafka_cluster" "freight" {
   environment {
     id = confluent_environment.staging.id
   }
-  
-  network {
-    id = confluent_network.peering.id
-  }
-  
+
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Updated docs for [confluent_kafka_cluster](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_kafka_cluster) resource / data source.


Checklist
---------
NA

What
----
This PR updates the doc to fix a tiny typo to remove Freight EA note as this feature has been released as GA [already](https://docs.confluent.io/cloud/current/release-notes/index.html#february-3-2025).

Blast Radius
----
NA

References
----------
NA

Test & Review
-------------
NA
