### PR TITLE
APIT-2880: Resolve TF drift for custom connectors

### DIFF
--- a/internal/provider/resource_connector.go
+++ b/internal/provider/resource_connector.go
@@ -71,6 +71,9 @@ var ignoredConnectorConfigs = []string{
 	"kafka.dedicated",
 	"schema.registry.url",
 	"valid.kafka.api.key",
+	"confluent.custom.plugin.type",
+	"confluent.custom.plugin.version.id",
+	"confluent.resource.connector.tier",
 }
 var twoStarsOrMoreRegExp = regexp.MustCompile(twoStarsOrMorePattern)
 


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
- Updated `confluent_connector` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_connector) to resolve TF drift for custom connectors.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
  - [x] Changes were tested manually, somehow there were no tests for acceptance tests for custom connectors 🤔 
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR resolves TF drift for custom connectors. For example, when running [custom-datagen-source-connector](https://github.com/confluentinc/terraform-provider-confluent/tree/master/examples/configurations/connectors/custom-datagen-source-connector) example, users could have observed TF drift:
```
$ terraform plan
...
  # confluent_connector.source will be updated in-place
  ~ resource "confluent_connector" "source" {
      ~ config_nonsensitive = {
          - "confluent.custom.plugin.type"       = "SOURCE" -> null
          - "confluent.custom.plugin.version.id" = "ver-57p0dg" -> null
          - "confluent.resource.connector.tier"  = "2GB" -> null
            # (11 unchanged elements hidden)
        }
        id                  = "clcc-yx3m6j"
        # (2 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Blast Radius
----
- Confluent Cloud customers who are using `confluent_connector` resource will be blocked.

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2880

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1739841939694399
