### PR TITLE
Remove ALL_GOOGLE_APIS option from GCP OPL command

### DIFF
--- a/docs/data-sources/confluent_access_point.md
+++ b/docs/data-sources/confluent_access_point.md
@@ -67,4 +67,4 @@ In addition to the preceding arguments, the following attributes are exported:
   - `private_service_connect_endpoint_target` - (Required String) URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs.
   - `private_service_connect_endpoint_ip_address` - (Required String) IP address of the Private Service Connect Endpoint that is connected to the endpoint target.
   - `private_service_connect_endpoint_connection_id` - (Required String) Connection ID of the Private Service Connect Endpoint that is connected to the endpoint target.
-  - `private_service_connect_endpoint_name` - (Required String) Name of the Private Servic Connect Endpoint that is connected to the endpoint target.
+  - `private_service_connect_endpoint_name` - (Required String) Name of the Private Service Connect Endpoint that is connected to the endpoint target.

--- a/docs/data-sources/confluent_access_point.md
+++ b/docs/data-sources/confluent_access_point.md
@@ -64,7 +64,7 @@ In addition to the preceding arguments, the following attributes are exported:
   - `network_interfaces` - (Required List of Strings) List of the IDs of the Elastic Network Interfaces, for example: `["eni-00000000000000000", "eni-00000000000000001", "eni-00000000000000002", "eni-00000000000000003", "eni-00000000000000004", "eni-00000000000000005"]`
   - `account` - (Required String) The AWS account ID associated with the ENIs you are using for the Confluent Private Network Interface, for example: `000000000000`.
 - `gcp_egress_private_service_connect_endpoint` (Optional Configuration Block) supports the following:
-  - `private_service_connect_endpoint_target` - (Required String) URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "ALL_GOOGLE_APIS" or "all-google-apis" for global Google APIs.
+  - `private_service_connect_endpoint_target` - (Required String) URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs.
   - `private_service_connect_endpoint_ip_address` - (Required String) IP address of the Private Service Connect Endpoint that is connected to the endpoint target.
   - `private_service_connect_endpoint_connection_id` - (Required String) Connection ID of the Private Service Connect Endpoint that is connected to the endpoint target.
-  - `private_service_connect_endpoint_name` - (Required String) Name of the Private Service Connect Endpoint that is connected to the endpoint target.
+  - `private_service_connect_endpoint_name` - (Required String) Name of the Private Servic Connect Endpoint that is connected to the endpoint target.

--- a/docs/resources/confluent_access_point.md
+++ b/docs/resources/confluent_access_point.md
@@ -77,7 +77,7 @@ The following arguments are supported:
   - `private_link_service_resource_id` - (Required String) Resource ID of the Azure Private Link service.
   - `private_link_subresource_name` - (Optional String) Name of the subresource for the Private Endpoint to connect to.
 - `gcp_egress_private_service_connect_endpoint` (Optional Configuration Block) supports the following:
-  - `private_service_connect_endpoint_target` - (Required String) URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "ALL_GOOGLE_APIS" or "all-google-apis" for global Google APIs.
+  - `private_service_connect_endpoint_target` - (Required String) URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs.
 
 ## Attributes Reference
 

--- a/examples/configurations/network-access-point-gcp-private-service-connect/main.tf
+++ b/examples/configurations/network-access-point-gcp-private-service-connect/main.tf
@@ -58,7 +58,7 @@ resource "confluent_access_point" "private-service-connect" {
     id = data.confluent_gateway.main.id
   }
   gcp_egress_private_service_connect_endpoint {
-    private_service_connect_endpoint_target = "ALL_GOOGLE_APIS"
+    private_service_connect_endpoint_target = "all-google-apis"
   }
   depends_on = [
     confluent_network.gcp-private-service-connect,

--- a/internal/provider/data_source_access_point.go
+++ b/internal/provider/data_source_access_point.go
@@ -119,7 +119,7 @@ func gcpEgressPrivateServiceConnectEndpointDataSourceSchema() *schema.Schema {
 				paramPrivateServiceConnectEndpointTarget: {
 					Type:        schema.TypeString,
 					Computed:    true,
-					Description: `URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "ALL_GOOGLE_APIS" or "all-google-apis" for global Google APIs`,
+					Description: `URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs`,
 				},
 				paramPrivateServiceConnectEndpointConnectionId: {
 					Type:        schema.TypeString,

--- a/internal/provider/resource_access_point.go
+++ b/internal/provider/resource_access_point.go
@@ -166,7 +166,7 @@ func paramGcpEgressPrivateServiceConnectEndpointSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Required:    true,
 					ForceNew:    true,
-					Description: `URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "ALL_GOOGLE_APIS" or "all-google-apis" for global Google APIs`,
+					Description: `URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs`,
 				},
 				paramPrivateServiceConnectEndpointConnectionId: {
 					Type:        schema.TypeString,


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
- Temporary fix for TF drift caused by access point resource recreation 


Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
TLDR: Remove all occurrences of ALL_GOOGLE_APIS option in TF docs and examples as a temporary fix for TF drift caused by an access-point recreation incident. 

This root cause of the issue is that in GCP OPL command, both ALL_GOOGLE_APIS and all-google-apis are considered valid input for a PSC endpoint target, however, the current endpoint target response only return the value of all-google-apis regardless of the input. Consequently, a terraform drift occurs as it detects the endpoint target response is being different from the user input (i.e the user input the ALL_GOOGLE_APIS option). This PR updates the TF docs and examples to "hide" the ALL_GOOGLE_APIS option from all users, while Sherwin's team works on long-term fix for correcting the endpoint target response. 


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

[Link to RCCA](https://confluentinc.atlassian.net/browse/RCCA-25349) 

[Link to Slack discussion](https://confluent.slack.com/archives/C01MVNENR1D/p1738893186394719) 

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
