### PR TITLE
APIT-2874: Show descriptive errors for any response formats for confluent_kafka_topic

### DIFF
--- a/internal/provider/resource_kafka_topic.go
+++ b/internal/provider/resource_kafka_topic.go
@@ -524,7 +524,7 @@ func kafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 
 			// At this point new partitions count is saved to TF file,
 			// so we need to revert it to the old value to avoid TF drift.
-			if resourceErr := d.Set(paramPartitionsCount, oldPartitionsCountInt32); err != nil {
+			if resourceErr := d.Set(paramPartitionsCount, oldPartitionsCountInt32); resourceErr != nil {
 				return diag.FromErr(createDescriptiveError(resourceErr))
 			}
 			return diag.FromErr(createDescriptiveError(err, resp))

--- a/internal/provider/resource_kafka_topic.go
+++ b/internal/provider/resource_kafka_topic.go
@@ -226,10 +226,10 @@ func kafkaTopicCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Creating new Kafka Topic: %s", createTopicRequestJson))
 
-	createdKafkaTopic, _, err := executeKafkaTopicCreate(ctx, kafkaRestClient, createTopicRequest)
+	createdKafkaTopic, resp, err := executeKafkaTopicCreate(ctx, kafkaRestClient, createTopicRequest)
 
 	if err != nil {
-		return diag.Errorf("error creating Kafka Topic: %s", createDescriptiveError(err))
+		return diag.Errorf("error creating Kafka Topic: %s", createDescriptiveError(err, resp))
 	}
 
 	kafkaTopicId := createKafkaTopicId(kafkaRestClient.clusterId, topicName)
@@ -269,10 +269,10 @@ func kafkaTopicDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 	kafkaRestClient := meta.(*Client).kafkaRestClientFactory.CreateKafkaRestClient(restEndpoint, clusterId, clusterApiKey, clusterApiSecret, meta.(*Client).isKafkaMetadataSet, meta.(*Client).isKafkaClusterIdSet)
 	topicName := d.Get(paramTopicName).(string)
 
-	_, err = kafkaRestClient.apiClient.TopicV3Api.DeleteKafkaTopic(kafkaRestClient.apiContext(ctx), kafkaRestClient.clusterId, topicName).Execute()
+	resp, err := kafkaRestClient.apiClient.TopicV3Api.DeleteKafkaTopic(kafkaRestClient.apiContext(ctx), kafkaRestClient.clusterId, topicName).Execute()
 
 	if err != nil {
-		return diag.Errorf("error deleting Kafka Topic %q: %s", d.Id(), createDescriptiveError(err))
+		return diag.Errorf("error deleting Kafka Topic %q: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 
 	if err := waitForKafkaTopicToBeDeleted(kafkaRestClient.apiContext(ctx), kafkaRestClient, topicName, meta.(*Client).isAcceptanceTestMode); err != nil {
@@ -432,7 +432,7 @@ func kafkaTopicImport(ctx context.Context, d *schema.ResourceData, meta interfac
 func readTopicAndSetAttributes(ctx context.Context, d *schema.ResourceData, c *KafkaRestClient, topicName string) ([]*schema.ResourceData, error) {
 	kafkaTopic, resp, err := c.apiClient.TopicV3Api.GetKafkaTopic(c.apiContext(ctx), c.clusterId, topicName).Execute()
 	if err != nil {
-		tflog.Warn(ctx, fmt.Sprintf("Error reading Kafka Topic %q: %s", d.Id(), createDescriptiveError(err)), map[string]interface{}{kafkaTopicLoggingKey: d.Id()})
+		tflog.Warn(ctx, fmt.Sprintf("Error reading Kafka Topic %q: %s", d.Id(), createDescriptiveError(err, resp)), map[string]interface{}{kafkaTopicLoggingKey: d.Id()})
 
 		isResourceNotFound := ResponseHasExpectedStatusCode(resp, http.StatusNotFound)
 		if isResourceNotFound && !d.IsNewResource() {
@@ -517,17 +517,17 @@ func kafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 		tflog.Debug(ctx, fmt.Sprintf("Updating Kafka Topic %q: %s", d.Id(), updateTopicRequestJson), map[string]interface{}{kafkaTopicLoggingKey: d.Id()})
 
 		// Send a request to Kafka REST API
-		_, _, err = executeKafkaTopicPartitionsCountUpdate(ctx, kafkaRestClient, topicName, updateTopicRequest)
+		_, resp, err := executeKafkaTopicPartitionsCountUpdate(ctx, kafkaRestClient, topicName, updateTopicRequest)
 		if err != nil {
 			// For example, Kafka REST API will return Bad Request if new partitions count is not bigger than the current one:
 			// 400 Bad Request: Topic currently has 6 partitions, which is higher than the requested 2.
 
 			// At this point new partitions count is saved to TF file,
 			// so we need to revert it to the old value to avoid TF drift.
-			if err := d.Set(paramPartitionsCount, oldPartitionsCountInt32); err != nil {
-				return diag.FromErr(createDescriptiveError(err))
+			if resourceErr := d.Set(paramPartitionsCount, oldPartitionsCountInt32); err != nil {
+				return diag.FromErr(createDescriptiveError(resourceErr))
 			}
-			return diag.FromErr(createDescriptiveError(err))
+			return diag.FromErr(createDescriptiveError(err, resp))
 		}
 		// Give some time to Kafka REST API to apply an update of partitions count
 		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
@@ -602,11 +602,11 @@ func kafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 		tflog.Debug(ctx, fmt.Sprintf("Updating Kafka Topic %q: %s", d.Id(), updateTopicRequestJson), map[string]interface{}{kafkaTopicLoggingKey: d.Id()})
 
 		// Send a request to Kafka REST API
-		_, err = executeKafkaTopicUpdate(ctx, kafkaRestClient, topicName, updateTopicRequest)
+		resp, err := executeKafkaTopicUpdate(ctx, kafkaRestClient, topicName, updateTopicRequest)
 		if err != nil {
 			// For example, Kafka REST API will return Bad Request if new topic setting value exceeds the max limit:
 			// 400 Bad Request: Config property 'delete.retention.ms' with value '63113904003' exceeded max limit of 60566400000.
-			return diag.FromErr(createDescriptiveError(err))
+			return diag.FromErr(createDescriptiveError(err, resp))
 		}
 		// Give some time to Kafka REST API to apply an update of topic settings
 		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
@@ -662,9 +662,9 @@ func setKafkaCredentials(kafkaApiKey, kafkaApiSecret string, d *schema.ResourceD
 }
 
 func loadTopicConfigs(ctx context.Context, d *schema.ResourceData, c *KafkaRestClient, topicName string) (map[string]string, error) {
-	topicConfigList, _, err := c.apiClient.ConfigsV3Api.ListKafkaTopicConfigs(c.apiContext(ctx), c.clusterId, topicName).Execute()
+	topicConfigList, resp, err := c.apiClient.ConfigsV3Api.ListKafkaTopicConfigs(c.apiContext(ctx), c.clusterId, topicName).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("error reading Kafka Topic %q: could not load configs %s", topicName, createDescriptiveError(err))
+		return nil, fmt.Errorf("error reading Kafka Topic %q: could not load configs %s", topicName, createDescriptiveError(err, resp))
 	}
 
 	config := make(map[string]string)
@@ -700,10 +700,10 @@ func loadAllKafkaTopics(ctx context.Context, client *Client) (InstanceIdsToNameM
 
 	kafkaRestClient := client.kafkaRestClientFactory.CreateKafkaRestClient(client.kafkaRestEndpoint, client.kafkaClusterId, client.kafkaApiKey, client.kafkaApiSecret, true, true)
 
-	topics, _, err := kafkaRestClient.apiClient.TopicV3Api.ListKafkaTopics(kafkaRestClient.apiContext(ctx), kafkaRestClient.clusterId).Execute()
+	topics, resp, err := kafkaRestClient.apiClient.TopicV3Api.ListKafkaTopics(kafkaRestClient.apiContext(ctx), kafkaRestClient.clusterId).Execute()
 	if err != nil {
-		tflog.Warn(ctx, fmt.Sprintf("Error reading Kafka Topics for Kafka Cluster %q: %s", kafkaRestClient.clusterId, createDescriptiveError(err)), map[string]interface{}{kafkaClusterLoggingKey: kafkaRestClient.clusterId})
-		return nil, diag.FromErr(createDescriptiveError(err))
+		tflog.Warn(ctx, fmt.Sprintf("Error reading Kafka Topics for Kafka Cluster %q: %s", kafkaRestClient.clusterId, createDescriptiveError(err, resp)), map[string]interface{}{kafkaClusterLoggingKey: kafkaRestClient.clusterId})
+		return nil, diag.FromErr(createDescriptiveError(err, resp))
 	}
 	topicsJson, err := json.Marshal(topics)
 	if err != nil {


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Updated confluent_kafka_topic [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_topic) to add descriptive errors for any response formats.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Currently TF Provider for Confluent doesn't show a descriptive error messages in some scenarios (for example, if the error occurs before reaching the backend API). More specifically, if you have got the following configuration:
```
terraform {
  required_providers {
    confluent = {
      source  = "confluentinc/confluent"
      version = "2.17.0"
    }
  }
}

provider "confluent" {
  kafka_api_key = "..."
  kafka_api_secret = "..."
  kafka_id = "lkc-..."
  kafka_rest_endpoint = "http://example.com/"
}

resource "confluent_kafka_topic" "example" {
  topic_name = "foobar"
}
```
and make a typo in `kafka_rest_endpoint`, you'd see a very generic "undefined response type" error from the [SDK client](https://github.com/confluentinc/ccloud-sdk-go-v2-internal/blob/master/kafkarest/v3/client.go#L431):
```
terraform apply
confluent_kafka_topic.example: Creating...
╷
│ Error: error creating Kafka Topic: undefined response type
│ 
│   with confluent_kafka_topic.example,
│   on main.tf line 47, in resource "confluent_kafka_topic" "example":
│   47: resource "confluent_kafka_topic" "example" {
```

To resolve this issue, we figured it'd be a great idea to show the raw response body for these scenarios to end up with a more descriptive error message:
```
confluent_kafka_topic.example: Creating...
╷
│ Error: error creating Kafka Topic: undefined response type; could not parse error details; raw response body: "<HTML><HEAD>\n<TITLE>Access Denied</TITLE>\n</HEAD><BODY>\n<H1>Access Denied</H1>\n \nYou don't have permission to access ..."
│ 
│   with confluent_kafka_topic.example,
│   on main.tf line 47, in resource "confluent_kafka_topic" "example":
│   47: resource "confluent_kafka_topic" "example" {
```
for the following TF configuration.


This PR updates `createDescriptiveError` to make it variadic, allowing it to accept a new optional argument: *http.Response in a non-breaking manner. Additionally, the error message has been updated for cases where we are unable to parse the Error object. In such cases, we will now return the raw response body instead of a very generic, non-descriptive error.

Note: we used `%#v` instead of `%s` in
```
errorMessage = fmt.Sprintf(
				"%s; could not parse error details; raw response body: %#v",
				errorMessage,
				string(bodyBytes),
			)
```
as it will print the value in Go-syntax representation (for a string, that includes surrounding quotes and escaped special characters).

Blast Radius
----
- Confluent Cloud customers who are using `confluent_kafka_topic` resource / data-source will be blocked.

Note: we should extend this pattern to other resources, but for now we'd limit the changes to `confluent_kafka_topic` resource/data-source to limit the blast radius of this change and help the specific user who is trying to debug an error of `confluent_kafka_topic` resource.

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2874

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1739919562941939
