### PR TITLE
APIT-2874: Fix "<invalid reflect.Value>" when displaying errors

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -447,9 +447,9 @@ func schemaValidateCheck(ctx context.Context, c *SchemaRegistryRestClient, creat
 		return fmt.Errorf("error validating Schema: error marshaling %#v to json: %s", createSchemaRequest, createDescriptiveError(err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Validating new Schema: %s", createSchemaRequestJson))
-	validationResponse, resp, err := executeSchemaValidate(ctx, c, createSchemaRequest, subjectName)
+	validationResponse, _, err := executeSchemaValidate(ctx, c, createSchemaRequest, subjectName)
 	if err != nil {
-		return fmt.Errorf("error validating Schema: error sending validation request: %s", createDescriptiveError(err, resp))
+		return fmt.Errorf("error validating Schema: error sending validation request: %s", createDescriptiveError(err))
 	}
 	// Validation has failed
 	if !validationResponse.GetIsCompatible() {
@@ -554,9 +554,9 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Validating new Schema: %s", createSchemaRequestJson))
-	validationResponse, resp, err := executeSchemaValidate(ctx, schemaRegistryRestClient, createSchemaRequest, subjectName)
+	validationResponse, _, err := executeSchemaValidate(ctx, schemaRegistryRestClient, createSchemaRequest, subjectName)
 	if err != nil {
-		return diag.Errorf("error creating Schema: error sending validation request: %s", createDescriptiveError(err, resp))
+		return diag.Errorf("error creating Schema: error sending validation request: %s", createDescriptiveError(err))
 	}
 	// Validation has failed
 	if !validationResponse.GetIsCompatible() {


### PR DESCRIPTION
Release Notes
---------
Bug Fixes:
- Updated error handling to resolve "<invalid reflect.Value>" messages when displaying errors in some corner cases.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR is a follow up to https://github.com/confluentinc/terraform-provider-confluent/pull/563.

Once we start replacing `createDescriptiveError(err)` with `createDescriptiveError(err, response)` for API calls in all resources, we'd see the following difference:

**Before**:
```
Error: error creating Schema: error sending validation request: 403 Forbidden: <invalid reflect.Value>
        
  with confluent_schema.test,
  on terraform_plugin_test.tf line 5, in resource "confluent_schema" "test":
  5:   resource "confluent_schema" "test" {
```


**After**:
```
        Error: error creating Schema: error sending validation request: 403 Forbidden; could not parse error details; raw response body: "{\n  \"errors\": [\n    {\n      \"detail\": null\n    }\n  ]\n}\n"
        
  with confluent_schema.test,
  on terraform_plugin_test.tf line 5, in resource "confluent_schema" "test":
  5:   resource "confluent_schema" "test" {
```
Note: this response was made up to trigger an `<invalid reflect.Value>` error, but we'd actually see the real API error, which is usually pretty descriptive.

Blast Radius
----
- Confluent Cloud customers who are using any resource/data source will be blocked. Realistically speaking, this PR just adds more safety checks, making our code safer 😁

To address the user's issue, we need to update the confluent_tag and other Stream Catalog resources. However, given that there are other conflicting PRs coming, I figured we might postpone these changes to avoid merge conflicts. For now, this PR will effectively omit `<invalid reflect.Value>` from the output:
```
Error: error creating Schema: error sending validation request: 403 Forbidden
```

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2874

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1739942477626139
