### PR TITLE
Follow-up to ALL_GOOGLE_APIS option removal from GCP OPL command

### DIFF
--- a/internal/provider/resource_access_point.go
+++ b/internal/provider/resource_access_point.go
@@ -167,6 +167,18 @@ func paramGcpEgressPrivateServiceConnectEndpointSchema() *schema.Schema {
 					Required:    true,
 					ForceNew:    true,
 					Description: `URI of the service attachment for the published service that the Private Service Connect Endpoint connects to, or "all-google-apis" for global Google APIs`,
+
+					// Suppress the diff shown if the values are equivalent forms of "ALL_GOOGLE_APIS" and "all-google-apis"
+					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+						const allGoogleApisNormalized = "all-google-apis"
+
+						normalizedOld := strings.ReplaceAll(strings.ToLower(old), "_", "-")
+						normalizedNew := strings.ReplaceAll(strings.ToLower(new), "_", "-")
+						if normalizedOld == allGoogleApisNormalized && normalizedNew == allGoogleApisNormalized {
+							return true
+						}
+						return false
+					},
 				},
 				paramPrivateServiceConnectEndpointConnectionId: {
 					Type:        schema.TypeString,

--- a/internal/provider/resource_access_point_test.go
+++ b/internal/provider/resource_access_point_test.go
@@ -626,7 +626,7 @@ func testAccCheckResourceAccessPointGcpEgressWithIdSet(mockServerUrl, name strin
 			id = "gw-abc123"
 		}
 		gcp_egress_private_service_connect_endpoint {
-    		private_service_connect_endpoint_target = "all-google-apis"
+    		private_service_connect_endpoint_target = "ALL_GOOGLE_APIS"
   		}
 	}
 	`, mockServerUrl, name)


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
- A follow-up from a previous PR to ensure that no TF drift occurs for customers who already have resources created with the `ALL_GOOGLE_APIS` option 


Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
This PR is a follow-up to a previous PR, and it updates the schema logics with a difference suppress function to ensure no Terraform drift occurs for customers who already have access point resources created with the now-disabled `ALL_GOOGLE_APIS` option. 

For more context, refer to the previous PR ([Remove ALL_GOOGLE_APIS option from GCP OPL command #562](https://github.com/confluentinc/terraform-provider-confluent/pull/562)). 


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
- Customers using access point with GCP option with endpoint target specified as `ALL_GOOGLE_APIS` on Terraform.  

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

[Link to RCCA](https://confluentinc.atlassian.net/browse/RCCA-25349) 

[Link to Slack discussion](https://confluent.slack.com/archives/C01MVNENR1D/p1738893186394719) 

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
The TestAccAccessPoint acceptance tests all passed. 
