### PR TITLE
[APIT-2896] Exposing additional attribution for cluster_link_id resource

### DIFF
--- a/docs/resources/confluent_cluster_link.md
+++ b/docs/resources/confluent_cluster_link.md
@@ -129,8 +129,8 @@ The following arguments are supported:
 
 In addition to the preceding arguments, the following attributes are exported:
 
-- `id` - (Required String) The ID of the Cluster Link, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
-- `cluster_link_id` - (Required String) The Cluster Link ID uniquely represents a link between two Kafka clusters.
+- `id` - (Required String) The Terraform identifier of the Cluster Link, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
+- `cluster_link_id` - (Required String) The actual Cluster Link ID assigned from Confluent Cloud that uniquely represents a link between two Kafka clusters.
 
 ## Import
 

--- a/docs/resources/confluent_cluster_link.md
+++ b/docs/resources/confluent_cluster_link.md
@@ -130,7 +130,7 @@ The following arguments are supported:
 In addition to the preceding arguments, the following attributes are exported:
 
 - `id` - (Required String) The composite ID of the Cluster Link resource, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
-- `cluster_link_id` - (Required String) The actual Cluster Link ID assigned from Confluent Cloud that uniquely represents a link between two Kafka clusters.
+- `cluster_link_id` - (Required String) The actual Cluster Link ID assigned from Confluent Cloud that uniquely represents a link between two Kafka clusters, for example, `qz0HDEV-Qz2B5aPFpcWQJQ`.
 
 ## Import
 

--- a/docs/resources/confluent_cluster_link.md
+++ b/docs/resources/confluent_cluster_link.md
@@ -130,6 +130,7 @@ The following arguments are supported:
 In addition to the preceding arguments, the following attributes are exported:
 
 - `id` - (Required String) The ID of the Cluster Link, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
+- `cluster_link_id` - (Required String) The Cluster Link ID uniquely represents a link between two Kafka clusters.
 
 ## Import
 

--- a/docs/resources/confluent_cluster_link.md
+++ b/docs/resources/confluent_cluster_link.md
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 In addition to the preceding arguments, the following attributes are exported:
 
-- `id` - (Required String) The Terraform identifier of the Cluster Link, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
+- `id` - (Required String) The composite ID of the Cluster Link resource, in the format `<Kafka cluster ID>/<Cluster link name>`, for example, `lkc-abc123/my-cluster-link`.
 - `cluster_link_id` - (Required String) The actual Cluster Link ID assigned from Confluent Cloud that uniquely represents a link between two Kafka clusters.
 
 ## Import

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -36,6 +36,7 @@ const (
 	paramRemoteKafkaCluster      = "remote_kafka_cluster"
 	paramLinkMode                = "link_mode"
 	paramConnectionMode          = "connection_mode"
+	paramClusterLinkId           = "cluster_link_id"
 
 	bootstrapServersConfigKey = "bootstrap.servers"
 	securityProtocolConfigKey = "security.protocol"
@@ -131,6 +132,11 @@ func clusterLinkResource() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{connectionModeInbound, connectionModeOutbound}, false),
 			},
+			paramClusterLinkId: {
+				Type:        schema.TypeString,
+				Description: "The Cluster Link ID uniquely represents a link between two Kafka clusters.",
+				Computed:    true,
+			},
 			paramConfigs: {
 				Type: schema.TypeMap,
 				Elem: &schema.Schema{
@@ -217,7 +223,7 @@ func clusterLinkRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 	kafkaRestClient, err := createKafkaRestClientForClusterLink(d, meta)
 	if err != nil {
-		return diag.Errorf("error creating Cluster Link: %s", createDescriptiveError(err))
+		return diag.Errorf("error reading Cluster Link: %s", createDescriptiveError(err))
 	}
 	linkName := d.Get(paramLinkName).(string)
 	linkMode := d.Get(paramLinkMode).(string)
@@ -296,6 +302,9 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 		return nil, err
 	}
 	if err := d.Set(paramConnectionMode, connectionMode); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramClusterLinkId, clusterLink.GetClusterLinkId()); err != nil {
 		return nil, err
 	}
 
@@ -438,7 +447,7 @@ func clusterLinkDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	kafkaRestClient, err := createKafkaRestClientForClusterLink(d, meta)
 	if err != nil {
-		return diag.Errorf("error creating Cluster Link: %s", createDescriptiveError(err))
+		return diag.Errorf("error deleting Cluster Link: %s", createDescriptiveError(err))
 	}
 	linkName := d.Get(paramLinkName).(string)
 
@@ -909,7 +918,7 @@ func loadClusterLinkConfigs(ctx context.Context, d *schema.ResourceData, c *Kafk
 
 	config := make(map[string]string)
 	for _, remoteConfig := range clusterLinkConfig.GetData() {
-		// Extract configs that were set via overriden vs set by default
+		// Extract configs that were set via override vs set by default
 		if stringInSlice(remoteConfig.GetName(), editableClusterLinkSettings, false) && remoteConfig.Source == dynamicClusterLinkConfig {
 			config[remoteConfig.GetName()] = remoteConfig.GetValue()
 		}

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -134,7 +134,7 @@ func clusterLinkResource() *schema.Resource {
 			},
 			paramClusterLinkId: {
 				Type:        schema.TypeString,
-				Description: "The Cluster Link ID uniquely represents a link between two Kafka clusters.",
+				Description: "The actual Cluster Link ID assigned from Confluent Cloud that uniquely represents a link between two Kafka clusters.",
 				Computed:    true,
 			},
 			paramConfigs: {

--- a/internal/provider/resource_cluster_link_bidirectional_inbound_test.go
+++ b/internal/provider/resource_cluster_link_bidirectional_inbound_test.go
@@ -144,6 +144,7 @@ func TestAccClusterLinkBidirectionalInbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "remote_kafka_cluster.0.bootstrap_endpoint", destinationClusterBootstrapEndpoint),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "remote_kafka_cluster.0.credentials.#", "0"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "remote_kafka_cluster.0.credentials.0.%", "0"),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", sourceClusterId, clusterLinkName)),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "%", numberOfClusterLinkResourceAttributes),
 				),

--- a/internal/provider/resource_cluster_link_bidirectional_outbound_test.go
+++ b/internal/provider/resource_cluster_link_bidirectional_outbound_test.go
@@ -147,6 +147,7 @@ func TestAccClusterLinkBidirectionalOutbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "remote_kafka_cluster.0.credentials.0.key", destinationClusterApiKey),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "remote_kafka_cluster.0.credentials.0.secret", destinationClusterApiSecret),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", sourceClusterId, clusterLinkName)),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "%", numberOfClusterLinkResourceAttributes),
 				),
 			},

--- a/internal/provider/resource_cluster_link_destination_inbound_test.go
+++ b/internal/provider/resource_cluster_link_destination_inbound_test.go
@@ -144,6 +144,7 @@ func TestAccClusterLinkDestinationInbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.key", destinationClusterApiKey),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.secret", destinationClusterApiSecret),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", destinationClusterId, clusterLinkName)),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "%", numberOfClusterLinkResourceAttributes),
 				),
 			},

--- a/internal/provider/resource_cluster_link_destination_outbound_test.go
+++ b/internal/provider/resource_cluster_link_destination_outbound_test.go
@@ -47,7 +47,7 @@ const (
 	clusterLinkMode                       = "DESTINATION"
 	clusterLinkConnectionMode             = "OUTBOUND"
 	clusterLinkResourceLabel              = "test_cluster_link_resource_label"
-	numberOfClusterLinkResourceAttributes = "9"
+	numberOfClusterLinkResourceAttributes = "10"
 
 	firstClusterClusterLinkConfigName         = "acl.sync.ms"
 	firstClusterClusterLinkConfigValue        = "5100"
@@ -214,6 +214,7 @@ func TestAccClusterLinkDestinationOutbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.key", destinationClusterApiKey),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.secret", destinationClusterApiSecret),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", destinationClusterId, clusterLinkName)),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "config.%", "1"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, fmt.Sprintf("config.%s", firstClusterClusterLinkConfigName), firstClusterClusterLinkConfigValue),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "%", numberOfClusterLinkResourceAttributes),
@@ -245,6 +246,7 @@ func TestAccClusterLinkDestinationOutbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.key", destinationClusterApiKey),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.secret", destinationClusterApiSecret),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", destinationClusterId, clusterLinkName)),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "config.%", "2"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, fmt.Sprintf("config.%s", firstClusterClusterLinkConfigName), firstClusterClusterLinkConfigUpdatedValue),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, fmt.Sprintf("config.%s", secondClusterClusterLinkConfigName), secondClusterClusterLinkConfigValue),

--- a/internal/provider/resource_cluster_link_source_outbound_test.go
+++ b/internal/provider/resource_cluster_link_source_outbound_test.go
@@ -151,6 +151,7 @@ func TestAccClusterLinkSourceOutbound(t *testing.T) {
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.key", destinationClusterApiKey),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "destination_kafka_cluster.0.credentials.0.secret", destinationClusterApiSecret),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "id", fmt.Sprintf("%s/%s", sourceClusterId, clusterLinkName)),
+					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "cluster_link_id", "qz0HDEV-Qz2B5aPFpcWQJQ"),
 					resource.TestCheckResourceAttr(fullClusterLinkResourceLabel, "%", numberOfClusterLinkResourceAttributes),
 				),
 			},


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Add additional `cluster_link_id` attribute for `confluent_cluster_link` resource.

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
When customers send request to `catalog/v1/entity` endpoint, if the entity type is a Kafka cluster link, user is expected to pass in a qualified name with format of `<SR Cluster ID>/<Kafka Cluster ID>/<Kafka Cluster Link ID>`, such as `lsrc-5m375q:lkc-j825wq:_dg1_-GbTWSoo9D66WBeag`.

However in `confluent_cluster_link` resource, the Kafka cluster link ID is not visible, we should allow this additional attribute to be exposed to users in order to improve the user experience.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Customers using the `confluent_cluster_linking` resources will be impacted.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/APIT-2896
https://confluent.slack.com/archives/C089RH0GT18/p1738955703293699?thread_ts=1738628325.688809&cid=C089RH0GT18

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
https://docs.google.com/document/d/1qYbLooKgSUuQ_FjWqwtgAWZLBEMZAHaB7-1WVQJkpZk/edit?tab=t.0#heading=h.cha1fr6ws0bc