### PR TITLE
APIT-2897: Update the confluent_schema tests to verify the request payload

### DIFF
--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -37,7 +37,8 @@ func TestAccLatestSchema(t *testing.T) {
 	}
 	defer wiremockContainer.Terminate(ctx)
 
-	mockSchemaTestServerUrl := wiremockContainer.URI
+	//mockSchemaTestServerUrl := wiremockContainer.URI
+	mockSchemaTestServerUrl := "http://localhost:8080"
 	confluentCloudBaseUrl := ""
 	wiremockClient := wiremock.NewClient(mockSchemaTestServerUrl)
 	// nolint:errcheck
@@ -49,6 +50,7 @@ func TestAccLatestSchema(t *testing.T) {
 	validateSchemaStub := wiremock.Post(wiremock.URLPathEqualTo(validateSchemaPath)).
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WithBodyPattern(wiremock.EqualToJson(`{"references":[{"name":"sampleRecord2","subject":"test3","version":3},{"name":"sampleRecord","subject":"test2","version":9}],"schema":"foobar","schemaType":"AVRO"}`)).
 		WillReturn(
 			string(validateSchemaResponse),
 			contentTypeJSONHeader,

--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -41,8 +41,7 @@ func TestAccLatestSchema(t *testing.T) {
 	}
 	defer wiremockContainer.Terminate(ctx)
 
-	//mockSchemaTestServerUrl := wiremockContainer.URI
-	mockSchemaTestServerUrl := "http://localhost:8080"
+	mockSchemaTestServerUrl := wiremockContainer.URI
 	confluentCloudBaseUrl := ""
 	wiremockClient := wiremock.NewClient(mockSchemaTestServerUrl)
 	// nolint:errcheck

--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -29,7 +29,22 @@ import (
 )
 
 const (
-	testCreateSchemaRequestJson = `{"references":[{"name":"sampleRecord2","subject":"test3","version":3},{"name":"sampleRecord","subject":"test2","version":9}],"schema":"foobar","schemaType":"AVRO"}`
+	testCreateSchemaRequestJson = `{
+  "references": [
+    {
+      "name": "sampleRecord2",
+      "subject": "test3",
+      "version": 3
+    },
+    {
+      "name": "sampleRecord",
+      "subject": "test2",
+      "version": 9
+    }
+  ],
+  "schema": "foobar",
+  "schemaType": "AVRO"
+}`
 )
 
 func TestAccLatestSchema(t *testing.T) {

--- a/internal/provider/resource_schema_latest_test.go
+++ b/internal/provider/resource_schema_latest_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+const (
+	testCreateSchemaRequestJson = `{"references":[{"name":"sampleRecord2","subject":"test3","version":3},{"name":"sampleRecord","subject":"test2","version":9}],"schema":"foobar","schemaType":"AVRO"}`
+)
+
 func TestAccLatestSchema(t *testing.T) {
 	ctx := context.Background()
 
@@ -50,7 +54,7 @@ func TestAccLatestSchema(t *testing.T) {
 	validateSchemaStub := wiremock.Post(wiremock.URLPathEqualTo(validateSchemaPath)).
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
-		WithBodyPattern(wiremock.EqualToJson(`{"references":[{"name":"sampleRecord2","subject":"test3","version":3},{"name":"sampleRecord","subject":"test2","version":9}],"schema":"foobar","schemaType":"AVRO"}`)).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(validateSchemaResponse),
 			contentTypeJSONHeader,
@@ -63,6 +67,7 @@ func TestAccLatestSchema(t *testing.T) {
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
 		WillSetStateTo(scenarioStateSchemaHasBeenCreated).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(createSchemaResponse),
 			contentTypeJSONHeader,
@@ -94,6 +99,7 @@ func TestAccLatestSchema(t *testing.T) {
 	checkSchemaExistsStub := wiremock.Post(wiremock.URLPathEqualTo(createSchemaPath)).
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(scenarioStateSchemaHasBeenCreated).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(checkSchemaExistsResponse),
 			contentTypeJSONHeader,

--- a/internal/provider/resource_schema_versioned_test.go
+++ b/internal/provider/resource_schema_versioned_test.go
@@ -95,6 +95,7 @@ func TestAccVersionedSchema(t *testing.T) {
 	validateSchemaStub := wiremock.Post(wiremock.URLPathEqualTo(validateSchemaPath)).
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(validateSchemaResponse),
 			contentTypeJSONHeader,
@@ -107,6 +108,7 @@ func TestAccVersionedSchema(t *testing.T) {
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
 		WillSetStateTo(scenarioStateSchemaHasBeenCreated).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(createSchemaResponse),
 			contentTypeJSONHeader,
@@ -128,6 +130,7 @@ func TestAccVersionedSchema(t *testing.T) {
 	checkSchemaExistsStub := wiremock.Post(wiremock.URLPathEqualTo(createSchemaPath)).
 		InScenario(schemaScenarioName).
 		WhenScenarioStateIs(scenarioStateSchemaHasBeenCreated).
+		WithBodyPattern(wiremock.EqualToJson(testCreateSchemaRequestJson)).
 		WillReturn(
 			string(checkSchemaExistsResponse),
 			contentTypeJSONHeader,


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Update the `confluent_schema` resource tests to verify the request payload, ensuring that ruleset is not set to {} when ruleset is null in the Terraform configuration

Blast Radius
----
NA as this PR updates `*_test.go` files only.

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2897

Test & Review
-------------
We also ran these tests using the 8c47c04d version, and verified that the tests would have failed, preventing a bug from being released:
```
➜  terraform-provider-confluent git:(8c47c04d) ✗ git log --pretty=oneline -n 2 | cat
8c47c04d3f68a3a5ffc3f900d8be2229593dda75 Cannot remove `ruleSet` via terraform resource `confluent_schema` (#500)
6a51ed0804915b36480c6fc41c5655e2d3b4e8b7 chore: patch version bump v2.14.2
```

```
-----------------------------------------------------------------------------------------------------------------------
| Closest stub                                             | Request                                                  |
-----------------------------------------------------------------------------------------------------------------------
                                                           |
POST                                                       | POST
[path] /compatibility/subjects/test2/versions              | /compatibility/subjects/test2/versions?verbose=true
                                                           |
[equalToJson]                                              |                                                     <<<<< Body does not match
{                                                          | {
  "references" : [ {                                       |   "references" : [ {
    "name" : "sampleRecord2",                              |     "name" : "sampleRecord2",
    "subject" : "test3",                                   |     "subject" : "test3",
    "version" : 3                                          |     "version" : 3
  }, {                                                     |   }, {
    "name" : "sampleRecord",                               |     "name" : "sampleRecord",
    "subject" : "test2",                                   |     "subject" : "test2",
    "version" : 9                                          |     "version" : 9
  } ],                                                     |   } ],
  "schema" : "foobar",                                     |   "ruleSet" : {
  "schemaType" : "AVRO"                                    |     "domainRules" : [ ]
}                                                          |   },
                                                           |   "schema" : "foobar",
                                                           |   "schemaType" : "AVRO"
                                                           | }
[Scenario 'confluent_schema Resource Lifecycle' state:     | [Scenario 'confluent_schema Resource Lifecycle' state:<<<<< Scenario does not match
Started]                                                   | Started]
                                                           |
-----------------------------------------------------------------------------------------------------------------------
...
➜  terraform-provider-confluent git:(8c47c04d) ✗ TF_ACC=1 go test ./... -v -timeout 5m  -run='TestAccLatestSchema'
?       github.com/confluentinc/terraform-provider-confluent    [no test files]
=== RUN   TestAccLatestSchemaWithEnhancedProviderBlock
...
2025/02/23 20:58:16 🔔 Container is ready: e0417a3640f4
    resource_schema_latest_test.go:141: Step 1/3 error: Error running apply: exit status 1
        
        Error: error creating Schema: error sending validation request: 404 Not Found
        
          with confluent_schema.test_schema_resource_label,
          on terraform_plugin_test.tf line 5, in resource "confluent_schema" "test_schema_resource_label":
           5:   resource "confluent_schema" "test_schema_resource_label" {
        
2025/02/23 20:58:17 🐳 Terminating container: e0417a3640f4
2025/02/23 20:58:17 🚫 Container terminated: e0417a3640f4
--- FAIL: TestAccLatestSchema (2.49s)
FAIL
FAIL    github.com/confluentinc/terraform-provider-confluent/internal/provider  22.179s
FAIL
```
