### PR TITLE
[CLI-3427] Terraform Support - Flink UDF on Azure

### DIFF
--- a/docs/resources/confluent_flink_artifact.md
+++ b/docs/resources/confluent_flink_artifact.md
@@ -38,7 +38,7 @@ resource "confluent_flink_artifact" "main" {
 The following arguments are supported:
 
 - `display_name` - (Required String) The unique name of the Flink Artifact per cloud, region, environment scope.
-- `cloud` - (Required String) The cloud service provider that runs the Flink Artifact.
+- `cloud` - (Required String) The cloud service provider that runs the Flink Artifact. Accepted values are: `AWS`, `AZURE`.
 - `region` - (Required String) The cloud service provider region that hosts the Flink Artifact.
 - `class` - (Optional String, **Deprecated**) Java class or alias for the Flink Artifact as provided by developer.
 - `artifact_file` - (Required String) The artifact file for Flink Artifact.

--- a/internal/provider/resource_custom_connector_plugin.go
+++ b/internal/provider/resource_custom_connector_plugin.go
@@ -217,7 +217,7 @@ func uploadCustomConnectorPlugin(ctx context.Context, c *Client, filename, cloud
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error fetching presigned upload URL: %s`, err)
 	}
 
-	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData(), createdPresignedUrl.GetContentFormat(), cloud); err != nil {
+	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData(), createdPresignedUrl.GetContentFormat(), cloud, false); err != nil {
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error uploading a file: %s`, err)
 	}
 	return createdPresignedUrl.GetUploadId(), nil

--- a/internal/provider/resource_custom_connector_plugin.go
+++ b/internal/provider/resource_custom_connector_plugin.go
@@ -217,7 +217,7 @@ func uploadCustomConnectorPlugin(ctx context.Context, c *Client, filename, cloud
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error fetching presigned upload URL: %s`, err)
 	}
 
-	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData(), createdPresignedUrl.GetContentFormat(), cloud); err != nil {
+	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData()); err != nil {
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error uploading a file: %s`, err)
 	}
 	return createdPresignedUrl.GetUploadId(), nil

--- a/internal/provider/resource_custom_connector_plugin.go
+++ b/internal/provider/resource_custom_connector_plugin.go
@@ -217,7 +217,7 @@ func uploadCustomConnectorPlugin(ctx context.Context, c *Client, filename, cloud
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error fetching presigned upload URL: %s`, err)
 	}
 
-	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData()); err != nil {
+	if err := uploadFile(createdPresignedUrl.GetUploadUrl(), filename, createdPresignedUrl.GetUploadFormData(), createdPresignedUrl.GetContentFormat(), cloud); err != nil {
 		return "", fmt.Errorf(`error uploading Custom Connector Plugin: error uploading a file: %s`, err)
 	}
 	return createdPresignedUrl.GetUploadId(), nil

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -156,14 +156,8 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error uploading Flink Artifact: error fetching presigned upload URL %s", createDescriptiveError(err))
 	}
 
-	if strings.ToLower(cloud) == "azure" {
-		if err := UploadFileToAzureBlob(resp.GetUploadUrl(), artifactFile, strings.ToLower(resp.GetContentFormat())); err != nil {
-			return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
-		}
-	} else {
-		if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData()); err != nil {
-			return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
-		}
+	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData(), resp.GetContentFormat(), cloud); err != nil {
+		return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
 	}
 
 	createArtifactRequest := fa.InlineObject{
@@ -194,6 +188,7 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error creating Flink Artifact: error marshaling %#v to json: %s", createArtifactRequest, createDescriptiveError(err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Creating new Flink Artifact: %s", createArtifactRequestJson))
+	//panic(fmt.Sprintf("Creating new Flink Artifact: %s", createArtifactRequestJson))
 
 	createdArtifact, _, err := executeArtifactCreate(c.faApiContext(ctx), c, createArtifactRequest)
 	if err != nil {

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -156,7 +156,7 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error uploading Flink Artifact: error fetching presigned upload URL %s", createDescriptiveError(err))
 	}
 
-	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData(), resp.GetContentFormat(), cloud); err != nil {
+	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData(), resp.GetContentFormat(), cloud, true); err != nil {
 		return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
 	}
 

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -156,7 +156,7 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error uploading Flink Artifact: error fetching presigned upload URL %s", createDescriptiveError(err))
 	}
 
-	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData(), resp.GetContentFormat(), cloud); err != nil {
+	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData()); err != nil {
 		return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
 	}
 

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -156,7 +156,7 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error uploading Flink Artifact: error fetching presigned upload URL %s", createDescriptiveError(err))
 	}
 
-	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData()); err != nil {
+	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData(), resp.GetContentFormat(), cloud); err != nil {
 		return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
 	}
 

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -156,8 +156,14 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error uploading Flink Artifact: error fetching presigned upload URL %s", createDescriptiveError(err))
 	}
 
-	if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData()); err != nil {
-		return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
+	if strings.ToLower(cloud) == "azure" {
+		if err := UploadFileToAzureBlob(resp.GetUploadUrl(), artifactFile, strings.ToLower(resp.GetContentFormat())); err != nil {
+			return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
+		}
+	} else {
+		if err := uploadFile(resp.GetUploadUrl(), artifactFile, resp.GetUploadFormData()); err != nil {
+			return diag.Errorf("error uploading Flink Artifact: %s", createDescriptiveError(err))
+		}
 	}
 
 	createArtifactRequest := fa.InlineObject{

--- a/internal/provider/resource_flink_artifact.go
+++ b/internal/provider/resource_flink_artifact.go
@@ -188,7 +188,6 @@ func artifactCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error creating Flink Artifact: error marshaling %#v to json: %s", createArtifactRequest, createDescriptiveError(err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Creating new Flink Artifact: %s", createArtifactRequestJson))
-	//panic(fmt.Sprintf("Creating new Flink Artifact: %s", createArtifactRequestJson))
 
 	createdArtifact, _, err := executeArtifactCreate(c.faApiContext(ctx), c, createArtifactRequest)
 	if err != nil {

--- a/internal/provider/resource_flink_artifact_aws_test.go
+++ b/internal/provider/resource_flink_artifact_aws_test.go
@@ -131,7 +131,7 @@ func TestAccFlinkArtifactAws(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckArtifactConfig(mockServerUrl, flinkArtifactResourceLabel),
+				Config: testAccCheckArtifactConfig(mockServerUrl, flinkArtifactResourceLabel, flinkArtifactCloud, flinkArtifactRegion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckArtifactExists(fullFlinkArtifactResourceLabel),
 					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramId, flinkArtifactId),
@@ -195,7 +195,11 @@ func testAccCheckArtifactDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckArtifactConfig(mockServerUrl, resourceLabel string) string {
+func testAccCheckArtifactConfig(mockServerUrl, resourceLabel string, cloud string, region string) string {
+	if cloud == "" || region == "" {
+		return "cloud or region parameter is empty for testAccCheckArtifactConfig"
+	}
+
 	return fmt.Sprintf(`
 	provider "confluent" {
  		endpoint = "%s"
@@ -213,7 +217,7 @@ func testAccCheckArtifactConfig(mockServerUrl, resourceLabel string) string {
 		  id = "%s"
 	    }
 	}
-	`, mockServerUrl, resourceLabel, flinkArtifactUniqueName, flinkArtifactCloud, flinkArtifactRegion, flinkArtifactClass, flinkArtifactDescription, flinkArtifactDocumentationLink, flinkArtifactRuntimeLanguage, flinkArtifactEnvironmentId)
+	`, mockServerUrl, resourceLabel, flinkArtifactUniqueName, cloud, region, flinkArtifactClass, flinkArtifactDescription, flinkArtifactDocumentationLink, flinkArtifactRuntimeLanguage, flinkArtifactEnvironmentId)
 }
 
 func testAccCheckArtifactExists(n string) resource.TestCheckFunc {

--- a/internal/provider/resource_flink_artifact_aws_test.go
+++ b/internal/provider/resource_flink_artifact_aws_test.go
@@ -195,7 +195,7 @@ func testAccCheckArtifactDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckArtifactConfig(mockServerUrl, resourceLabel string, cloud string, region string) string {
+func testAccCheckArtifactConfig(mockServerUrl, resourceLabel, cloud, region string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
  		endpoint = "%s"

--- a/internal/provider/resource_flink_artifact_aws_test.go
+++ b/internal/provider/resource_flink_artifact_aws_test.go
@@ -196,10 +196,6 @@ func testAccCheckArtifactDestroy(s *terraform.State) error {
 }
 
 func testAccCheckArtifactConfig(mockServerUrl, resourceLabel string, cloud string, region string) string {
-	if cloud == "" || region == "" {
-		return "cloud or region parameter is empty for testAccCheckArtifactConfig"
-	}
-
 	return fmt.Sprintf(`
 	provider "confluent" {
  		endpoint = "%s"

--- a/internal/provider/resource_flink_artifact_aws_test.go
+++ b/internal/provider/resource_flink_artifact_aws_test.go
@@ -34,7 +34,7 @@ const (
 
 var flinkArtifactsUrlPath = fmt.Sprintf("/artifact/v1/flink-artifacts/%s", flinkArtifactId)
 
-func TestAccFlinkArtifact(t *testing.T) {
+func TestAccFlinkArtifactAws(t *testing.T) {
 	ctx := context.Background()
 
 	wiremockContainer, err := setupWiremock(ctx)

--- a/internal/provider/resource_flink_artifact_azure_test.go
+++ b/internal/provider/resource_flink_artifact_azure_test.go
@@ -114,9 +114,9 @@ func TestAccFlinkArtifactAzure(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckArtifactConfigAzure(mockServerUrl, flinkArtifactResourceLabel),
+				Config: testAccCheckArtifactConfig(mockServerUrl, flinkArtifactResourceLabel, flinkArtifactCloudAzure, flinkArtifactRegionAzure),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArtifactExistsAzure(fullFlinkArtifactResourceLabel),
+					testAccCheckArtifactExists(fullFlinkArtifactResourceLabel),
 					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramId, flinkArtifactId),
 					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramDisplayName, flinkArtifactUniqueName),
 					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramClass, flinkArtifactClass),
@@ -176,41 +176,4 @@ func testAccCheckArtifactDestroyAzure(s *terraform.State) error {
 		return err
 	}
 	return nil
-}
-
-func testAccCheckArtifactConfigAzure(mockServerUrl, resourceLabel string) string {
-	return fmt.Sprintf(`
-	provider "confluent" {
- 		endpoint = "%s"
-	}
-	resource "confluent_flink_artifact" "%s" {
-		artifact_file    = "abc.jar"
-        display_name     = "%s"
-        cloud            = "%s"
-	    region           = "%s"
-		class = "%s"
-		description = "%s"
-	    documentation_link = "%s"
-		runtime_language = "%s"
-	    environment {
-		  id = "%s"
-	    }
-	}
-	`, mockServerUrl, resourceLabel, flinkArtifactUniqueName, flinkArtifactCloudAzure, flinkArtifactRegionAzure, flinkArtifactClass, flinkArtifactDescription, flinkArtifactDocumentationLink, flinkArtifactRuntimeLanguage, flinkArtifactEnvironmentId)
-}
-
-func testAccCheckArtifactExistsAzure(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-
-		if !ok {
-			return fmt.Errorf("%s artifact has not been found", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("ID has not been set for %s artifact", n)
-		}
-
-		return nil
-	}
 }

--- a/internal/provider/resource_flink_artifact_azure_test.go
+++ b/internal/provider/resource_flink_artifact_azure_test.go
@@ -1,0 +1,216 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"github.com/walkerus/go-wiremock"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	flinkArtifactCloudAzure  = "AZURE"
+	flinkArtifactRegionAzure = "centralus"
+)
+
+func TestAccFlinkArtifactAzure(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	createArtifactPresignedUrlResponse, _ := os.ReadFile("../testdata/flink_artifact/read_presigned_url.json")
+	createArtifactPresignedUrlStub := wiremock.Post(wiremock.URLPathEqualTo("/artifact/v1/presigned-upload-url")).
+		InScenario(flinkArtifactScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioArtifactPresignedUrlHasBeenCreated).
+		WillReturn(
+			string(createArtifactPresignedUrlResponse),
+			contentTypeJSONHeader,
+			http.StatusCreated,
+		)
+	_ = wiremockClient.StubFor(createArtifactPresignedUrlStub)
+
+	createArtifactResponse, _ := os.ReadFile("../testdata/flink_artifact/create_artifact_azure.json")
+	createArtifactStub := wiremock.Post(wiremock.URLPathEqualTo("/artifact/v1/flink-artifacts")).
+		InScenario(flinkArtifactScenarioName).
+		WhenScenarioStateIs(scenarioArtifactPresignedUrlHasBeenCreated).
+		WillSetStateTo(scenarioStateFlinkArtifactHasBeenCreated).
+		WillReturn(
+			string(createArtifactResponse),
+			contentTypeJSONHeader,
+			http.StatusCreated,
+		)
+	_ = wiremockClient.StubFor(createArtifactStub)
+
+	readCreatedArtifactResponse, _ := os.ReadFile("../testdata/flink_artifact/read_created_artifact_azure.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(flinkArtifactsUrlPath)).
+		InScenario(flinkArtifactScenarioName).
+		WithQueryParam("region", wiremock.EqualTo(flinkArtifactRegionAzure)).
+		WithQueryParam("cloud", wiremock.EqualTo(flinkArtifactCloudAzure)).
+		WithQueryParam("environment", wiremock.EqualTo(flinkArtifactEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateFlinkArtifactHasBeenCreated).
+		WillReturn(
+			string(readCreatedArtifactResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	deleteArtifactStub := wiremock.Delete(wiremock.URLPathEqualTo(flinkArtifactsUrlPath)).
+		InScenario(flinkArtifactScenarioName).
+		WithQueryParam("region", wiremock.EqualTo(flinkArtifactRegionAzure)).
+		WithQueryParam("cloud", wiremock.EqualTo(flinkArtifactCloudAzure)).
+		WithQueryParam("environment", wiremock.EqualTo(flinkArtifactEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateFlinkArtifactHasBeenCreated).
+		WillSetStateTo(scenarioStateFlinkArtifactHasBeenDeleted).
+		WillReturn(
+			"",
+			contentTypeJSONHeader,
+			http.StatusNoContent,
+		)
+	_ = wiremockClient.StubFor(deleteArtifactStub)
+
+	readDeletedArtifactResponse, _ := os.ReadFile("../testdata/flink_artifact/read_deleted_artifact.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(flinkArtifactsUrlPath)).
+		InScenario(flinkArtifactScenarioName).
+		WithQueryParam("region", wiremock.EqualTo(flinkArtifactRegionAzure)).
+		WithQueryParam("cloud", wiremock.EqualTo(flinkArtifactCloudAzure)).
+		WithQueryParam("environment", wiremock.EqualTo(flinkArtifactEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateFlinkArtifactHasBeenDeleted).
+		WillReturn(
+			string(readDeletedArtifactResponse),
+			contentTypeJSONHeader,
+			http.StatusNotFound,
+		))
+
+	flinkArtifactResourceLabel := "test"
+	fullFlinkArtifactResourceLabel := fmt.Sprintf("confluent_flink_artifact.%s", flinkArtifactResourceLabel)
+
+	_ = os.Setenv("IMPORT_ARTIFACT_FILENAME", "abc.jar")
+	defer func() {
+		_ = os.Unsetenv("IMPORT_ARTIFACT_FILENAME")
+	}()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckArtifactDestroyAzure,
+		// https://www.terraform.io/docs/extend/testing/acceptance-tests/teststep.html
+		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckArtifactConfigAzure(mockServerUrl, flinkArtifactResourceLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArtifactExistsAzure(fullFlinkArtifactResourceLabel),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramId, flinkArtifactId),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramDisplayName, flinkArtifactUniqueName),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramClass, flinkArtifactClass),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramCloud, flinkArtifactCloudAzure),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramRegion, flinkArtifactRegionAzure),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, fmt.Sprintf("%s.#", paramEnvironment), "1"),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, fmt.Sprintf("%s.0.%s", paramEnvironment, paramId), flinkArtifactEnvironmentId),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramArtifactFile, "abc.jar"),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramContentFormat, flinkArtifactContentFormat),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramRuntimeLanguage, flinkArtifactRuntimeLanguage),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramDescription, flinkArtifactDescription),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramDocumentationLink, flinkArtifactDocumentationLink),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramApiVersion, flinkArtifactApiVersion),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, paramKind, flinkArtifactKind),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, "versions.#", "1"),
+					resource.TestCheckResourceAttr(fullFlinkArtifactResourceLabel, "versions.0.version", flinkVersions),
+				),
+			},
+			{
+				ResourceName:      fullFlinkArtifactResourceLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					flinkArtifactId := resources[fullFlinkArtifactResourceLabel].Primary.ID
+					region := resources[fullFlinkArtifactResourceLabel].Primary.Attributes["region"]
+					cloud := resources[fullFlinkArtifactResourceLabel].Primary.Attributes["cloud"]
+					environment := resources[fullFlinkArtifactResourceLabel].Primary.Attributes["environment.0.id"]
+					return environment + "/" + region + "/" + cloud + "/" + flinkArtifactId, nil
+				},
+			},
+		},
+	})
+
+	checkStubCount(t, wiremockClient, createArtifactStub, fmt.Sprintf("POST %s", flinkArtifactsUrlPath), expectedCountOne)
+	checkStubCount(t, wiremockClient, deleteArtifactStub, fmt.Sprintf("DELETE %s?environment=%s", flinkArtifactsUrlPath, flinkArtifactEnvironmentId), expectedCountOne)
+}
+
+func testAccCheckArtifactDestroyAzure(s *terraform.State) error {
+	c := testAccProvider.Meta().(*Client)
+	// Loop through the resources in state, verifying each compute pool is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "confluent_flink_artifact" {
+			continue
+		}
+		deletedArtifactId := rs.Primary.ID
+		req := c.faClient.FlinkArtifactsArtifactV1Api.GetArtifactV1FlinkArtifact(c.faApiContext(context.Background()), deletedArtifactId).Cloud(flinkArtifactCloudAzure).Region(flinkArtifactRegionAzure).Environment(flinkArtifactEnvironmentId)
+		deletedArtifact, response, err := req.Execute()
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return nil
+		} else if err == nil && deletedArtifact.Id != nil {
+			// Otherwise return the error
+			if *deletedArtifact.Id == rs.Primary.ID {
+				return fmt.Errorf("artifact (%s) still exists", rs.Primary.ID)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func testAccCheckArtifactConfigAzure(mockServerUrl, resourceLabel string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+ 		endpoint = "%s"
+	}
+	resource "confluent_flink_artifact" "%s" {
+		artifact_file    = "abc.jar"
+        display_name     = "%s"
+        cloud            = "%s"
+	    region           = "%s"
+		class = "%s"
+		description = "%s"
+	    documentation_link = "%s"
+		runtime_language = "%s"
+	    environment {
+		  id = "%s"
+	    }
+	}
+	`, mockServerUrl, resourceLabel, flinkArtifactUniqueName, flinkArtifactCloudAzure, flinkArtifactRegionAzure, flinkArtifactClass, flinkArtifactDescription, flinkArtifactDocumentationLink, flinkArtifactRuntimeLanguage, flinkArtifactEnvironmentId)
+}
+
+func testAccCheckArtifactExistsAzure(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("%s artifact has not been found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID has not been set for %s artifact", n)
+		}
+
+		return nil
+	}
+}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -834,7 +834,7 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 }
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
-func uploadFile(url, filePath string, formFields map[string]any, fileExtension, cloud string, isFlinkUdfArtifact bool) error {
+func uploadFile(url, filePath string, formFields map[string]any, fileExtension, cloud string, isFlinkArtifact bool) error {
 	// TODO: We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {
@@ -870,7 +870,7 @@ func uploadFile(url, filePath string, formFields map[string]any, fileExtension, 
 	client := &http.Client{
 		Timeout: 20 * time.Minute,
 	}
-	if cloud == "AZURE" && isFlinkUdfArtifact {
+	if cloud == "AZURE" && isFlinkArtifact {
 		var contentFormat string
 		switch fileExtension {
 		case "zip":

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -840,7 +840,6 @@ func uploadFile(url, filePath string, formFields map[string]any, fileExtension s
 	if url == tfCustomConnectorPluginTestUrl {
 		return nil
 	}
-
 	var buffer bytes.Buffer
 	writer := multipart.NewWriter(&buffer)
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -835,9 +835,13 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
 func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string) error {
+	// TODO:We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {
 		return nil
+	}
+	if cloud == "" {
+		return fmt.Errorf("cloud parameter is empty for uploadFile")
 	}
 	if cloud == "AZURE" {
 		const (

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -990,6 +990,7 @@ const (
 )
 
 func UploadFileToAzureBlob(url, filePath, contentFormat string) error {
+	// This function was copied from the CLI repo. We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
 		return err

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -834,7 +834,7 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 }
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
-func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string) error {
+func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string, isFlinkUdfArtifact bool) error {
 	// TODO: We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {
@@ -870,7 +870,7 @@ func uploadFile(url, filePath string, formFields map[string]any, fileExtension s
 	client := &http.Client{
 		Timeout: 20 * time.Minute,
 	}
-	if cloud == "AZURE" {
+	if cloud == "AZURE" && isFlinkUdfArtifact {
 		var contentFormat string
 		switch fileExtension {
 		case "zip":

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -834,25 +834,13 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 }
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
-func uploadFile(url, filePath string, formFields map[string]any) error {
-	// TODO:We have a task to export the method for general use in a more maintainable way (APIT-2912)
+func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string) error {
+	// TODO: We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {
 		return nil
 	}
-	const (
-		maxFileSize     = 1024 * 1024 * 1024 // 1GB
-		maxFileSizeInGB = 1
-	)
 
-	fileInfo, err := os.Stat(filePath)
-	if err != nil {
-		return err
-	}
-
-	if fileInfo.Size() > maxFileSize {
-		return fmt.Errorf("file size %d exceeds the %dGB limit", fileInfo.Size(), maxFileSizeInGB)
-	}
 	var buffer bytes.Buffer
 	writer := multipart.NewWriter(&buffer)
 
@@ -883,13 +871,32 @@ func uploadFile(url, filePath string, formFields map[string]any) error {
 	client := &http.Client{
 		Timeout: 20 * time.Minute,
 	}
-	_, err = sling.New().
-		Client(client).
-		Base(url).
-		Set("x-ms-blob-type", "BlockBlob").
-		Put("").
-		Body(&buffer).
-		ReceiveSuccess(nil)
+	if cloud == "AZURE" {
+		var contentFormat string
+		switch fileExtension {
+		case "zip":
+			contentFormat = "application/zip"
+		case "jar":
+			contentFormat = "application/java-archive"
+		}
+
+		_, err = sling.New().
+			Client(client).
+			Base(url).
+			Set("x-ms-blob-type", "BlockBlob").
+			Set("Content-Type", contentFormat).
+			Put("").
+			Body(&buffer).
+			ReceiveSuccess(nil)
+	} else {
+		_, err = sling.New().
+			Client(client).
+			Base(url).
+			Set("Content-Type", writer.FormDataContentType()).
+			Post("").
+			Body(&buffer).
+			ReceiveSuccess(nil)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -983,3 +983,54 @@ func canUpdateEntityNameBusinessMetadata(entityType, oldEntityName, newEntityNam
 		return false
 	}
 }
+
+const (
+	maxFileSize     = 1024 * 1024 * 1024 // 1GB
+	maxFileSizeInGB = 1
+)
+
+func UploadFileToAzureBlob(url, filePath, contentFormat string) error {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo.Size() > maxFileSize {
+		return fmt.Errorf("file size %d exceeds the %dGB limit", fileInfo.Size(), maxFileSizeInGB)
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	client := &http.Client{Timeout: 20 * time.Minute}
+	request, err := http.NewRequest(http.MethodPut, url, file)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("x-ms-blob-type", "BlockBlob")
+	switch contentFormat {
+	case "zip":
+		request.Header.Set("Content-Type", "application/zip")
+	case "jar":
+		request.Header.Set("Content-Type", "application/java-archive")
+	}
+	request.ContentLength = fileInfo.Size()
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode >= 400 {
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("%s", string(responseBody))
+	}
+
+	return nil
+}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -834,29 +834,24 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 }
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
-func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string) error {
+func uploadFile(url, filePath string, formFields map[string]any) error {
 	// TODO:We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {
 		return nil
 	}
-	if cloud == "" {
-		return fmt.Errorf("cloud parameter is empty for uploadFile")
+	const (
+		maxFileSize     = 1024 * 1024 * 1024 // 1GB
+		maxFileSizeInGB = 1
+	)
+
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
 	}
-	if cloud == "AZURE" {
-		const (
-			maxFileSize     = 1024 * 1024 * 1024 // 1GB
-			maxFileSizeInGB = 1
-		)
 
-		fileInfo, err := os.Stat(filePath)
-		if err != nil {
-			return err
-		}
-
-		if fileInfo.Size() > maxFileSize {
-			return fmt.Errorf("file size %d exceeds the %dGB limit", fileInfo.Size(), maxFileSizeInGB)
-		}
+	if fileInfo.Size() > maxFileSize {
+		return fmt.Errorf("file size %d exceeds the %dGB limit", fileInfo.Size(), maxFileSizeInGB)
 	}
 	var buffer bytes.Buffer
 	writer := multipart.NewWriter(&buffer)
@@ -888,33 +883,13 @@ func uploadFile(url, filePath string, formFields map[string]any, fileExtension s
 	client := &http.Client{
 		Timeout: 20 * time.Minute,
 	}
-	if cloud == "AZURE" {
-		var contentFormat string
-		switch fileExtension {
-		case "zip":
-			contentFormat = "application/zip"
-		case "jar":
-			contentFormat = "application/java-archive"
-		}
-
-		_, err = sling.New().
-			Client(client).
-			Base(url).
-			Set("Content-Type", writer.FormDataContentType()).
-			Set("x-ms-blob-type", "BlockBlob").
-			Set("Content-Type", contentFormat).
-			Put("").
-			Body(&buffer).
-			ReceiveSuccess(nil)
-	} else if cloud == "AWS" {
-		_, err = sling.New().
-			Client(client).
-			Base(url).
-			Set("Content-Type", writer.FormDataContentType()).
-			Post("").
-			Body(&buffer).
-			ReceiveSuccess(nil)
-	}
+	_, err = sling.New().
+		Client(client).
+		Base(url).
+		Set("x-ms-blob-type", "BlockBlob").
+		Put("").
+		Body(&buffer).
+		ReceiveSuccess(nil)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -834,7 +834,7 @@ func clusterLinkSettingsKeysValidate(v interface{}, path cty.Path) diag.Diagnost
 }
 
 // https://github.com/confluentinc/cli/blob/main/internal/connect/utils.go#L88C1-L125C2
-func uploadFile(url, filePath string, formFields map[string]any, fileExtension string, cloud string, isFlinkUdfArtifact bool) error {
+func uploadFile(url, filePath string, formFields map[string]any, fileExtension, cloud string, isFlinkUdfArtifact bool) error {
 	// TODO: We have a task to export the method for general use in a more maintainable way (APIT-2912)
 	// TODO: figure out a way to mock this function and delete this hack
 	if url == tfCustomConnectorPluginTestUrl {

--- a/internal/testdata/flink_artifact/create_artifact_azure.json
+++ b/internal/testdata/flink_artifact/create_artifact_azure.json
@@ -1,0 +1,37 @@
+{
+  "api_version": "artifact/v1",
+  "kind": "FlinkArtifact",
+  "id": "lfcp-abc123",
+  "metadata": {
+    "self": "https://api.confluent.cloud/artifact/v1/flink-artifacts/lfcp-abc123",
+    "resource_name": "crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/flink-artifact=lfcp-abc123",
+    "created_at": "2006-01-02T15:04:05-07:00",
+    "updated_at": "2006-01-02T15:04:05-07:00",
+    "deleted_at": "2006-01-02T15:04:05-07:00"
+  },
+  "cloud": "AZURE",
+  "region": "centralus",
+  "environment": "env-gz903",
+  "display_name": "flink_artifact_0",
+  "class": "io.confluent.example.SumScalarFunction",
+  "content_format": "JAR",
+  "description": "string",
+  "documentation_link": "https://docs.confluent.io/cloud/current/api.html",
+  "runtime_language": "JAVA",
+  "versions": [
+    {
+      "version": "cfa-ver-001",
+      "release_notes": "string",
+      "is_beta": true,
+      "artifact_id": { },
+      "upload_source": {
+        "api_version": "artifact.v1/UploadSource",
+        "kind": "PresignedUrl",
+        "id": "lfcp-abc123",
+        "metadata": {},
+        "location": "PRESIGNED_URL_LOCATION",
+        "upload_id": "e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"
+      }
+    }
+  ]
+}

--- a/internal/testdata/flink_artifact/read_created_artifact_azure.json
+++ b/internal/testdata/flink_artifact/read_created_artifact_azure.json
@@ -1,0 +1,37 @@
+{
+  "api_version": "artifact/v1",
+  "kind": "FlinkArtifact",
+  "id": "lfcp-abc123",
+  "metadata": {
+    "self": "https://api.confluent.cloud/artifact/v1/flink-artifacts/lfcp-abc123",
+    "resource_name": "crn://confluent.cloud/organization=9bb441c4-edef-46ac-8a41-c49e44a3fd9a/flink-artifact=lfcp-abc123",
+    "created_at": "2006-01-02T15:04:05-07:00",
+    "updated_at": "2006-01-02T15:04:05-07:00",
+    "deleted_at": "2006-01-02T15:04:05-07:00"
+  },
+  "cloud": "AZURE",
+  "region": "centralus",
+  "environment": "env-gz903",
+  "display_name": "flink_artifact_0",
+  "class": "io.confluent.example.SumScalarFunction",
+  "content_format": "JAR",
+  "description": "string",
+  "documentation_link": "https://docs.confluent.io/cloud/current/api.html",
+  "runtime_language": "JAVA",
+  "versions": [
+    {
+      "version": "cfa-ver-001",
+      "release_notes": "string",
+      "is_beta": true,
+      "artifact_id": {},
+      "upload_source": {
+        "api_version": "artifact.v1/UploadSource",
+        "kind": "PresignedUrl",
+        "id": "lfcp-abc123",
+        "metadata": {},
+        "location": "PRESIGNED_URL_LOCATION",
+        "upload_id": "e53bb2e8-8de3-49fa-9fb1-4e3fd9a16b66"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Added Terraform support for Flink UDF artifact upload for Azure cloud.

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
The existing terraform supports uploading a Flink UDF artifact for AWS, this extends that to support Azure.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Flink artifact UDF upload users

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/CLI-3427?focusedCommentId=3696302

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->

![Screenshot 2025-03-04 at 2 31 25 PM](https://github.com/user-attachments/assets/e034a540-bdf0-4b69-8655-b0e67e171a77)

I also conducted the same test above and verified the Flink artifact was created for AWS which was the existing functionality (it was also visible in the UI). For Azure, it won't show up in the UI but that is expected as that work is scheduled for the near future.

Here is the output for terraform destroy, terraform plan, terraform apply, and terraform plan in that sequence.
https://docs.google.com/document/d/1hGT0XUJ7YMnsEltwl7MZiFosAXeK09kT13Ir_jQHAC4/edit?usp=sharing

Both AWS and Azure acceptance tests are passing locally.