### PR TITLE
RCCA-25477: Fix "~ schema = jsonencode( # whitespace changes" TF drift for confluent_schema resource 

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -413,32 +413,68 @@ func SetSchemaDiff(ctx context.Context, diff *schema.ResourceDiff, meta interfac
 }
 
 func schemaLookupCheck(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRegistryRestClient, createSchemaRequest *sr.RegisterSchemaRequest, subjectName, oldSchema string) error {
-	createSchemaRequestJson, err := json.Marshal(createSchemaRequest)
-	if err != nil {
-		return fmt.Errorf("error customizing diff Schema: error marshaling %#v to json: %s", createSchemaRequest, createDescriptiveError(err))
+	setOldSchemaValue := func() error {
+		if err := diff.SetNew(paramSchema, oldSchema); err != nil {
+			return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
+		}
+		return nil
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Customizing diff new Schema: %s", createSchemaRequestJson))
-
-	registeredSchema, schemaExists, err := schemaLookup(ctx, c, createSchemaRequest, subjectName)
+	// Try with original request first
+	matched, err := trySchemaLookup(ctx, diff, c, createSchemaRequest, subjectName)
 	if err != nil {
 		return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
 	}
+
+	if matched {
+		return setOldSchemaValue()
+	}
+
+	// If original request doesn't match and doesn't have ruleset, try with empty ruleset
+	if !createSchemaRequest.HasRuleSet() {
+		requestWithRuleset := *createSchemaRequest // Create a copy to avoid modifying the original
+		requestWithRuleset.SetRuleSet(*sr.NewRuleSet())
+
+		matched, err := trySchemaLookup(ctx, diff, c, &requestWithRuleset, subjectName)
+		if err != nil {
+			return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
+		}
+
+		if matched {
+			return setOldSchemaValue()
+		}
+	}
+
+	return nil
+}
+
+func trySchemaLookup(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRegistryRestClient,
+	schemaRequest *sr.RegisterSchemaRequest, subjectName string) (bool, error) {
+	requestJson, err := json.Marshal(schemaRequest)
+	if err != nil {
+		return false, fmt.Errorf("error marshaling %#v to json: %s",
+			schemaRequest, createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Customizing diff new Schema: %s", requestJson))
+
+	registeredSchema, schemaExists, err := schemaLookup(ctx, c, schemaRequest, subjectName)
+	if err != nil {
+		return false, err
+	}
+
 	if !schemaExists {
-		return nil
+		return false, nil
 	}
 
 	schemaIdentifier := diff.Get(paramSchemaIdentifier).(int)
 	if int(registeredSchema.GetId()) == schemaIdentifier {
 		// Two schemas that are semantically equivalent
 		// https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#schema-normalization
-
-		// Set old value to paramSchema to avoid TF drift
-		if err := diff.SetNew(paramSchema, oldSchema); err != nil {
-			return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
-		}
+		return true, nil
 	}
-	return nil
+
+	return false, nil
 }
 
 func schemaValidateCheck(ctx context.Context, c *SchemaRegistryRestClient, createSchemaRequest *sr.RegisterSchemaRequest, subjectName string) error {

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -449,16 +449,16 @@ func schemaLookupCheck(ctx context.Context, diff *schema.ResourceDiff, c *Schema
 }
 
 func trySchemaLookup(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRegistryRestClient,
-	schemaRequest *sr.RegisterSchemaRequest, subjectName string) (bool, error) {
-	requestJson, err := json.Marshal(schemaRequest)
+	createSchemaRequest *sr.RegisterSchemaRequest, subjectName string) (bool, error) {
+	createSchemaRequestJson, err := json.Marshal(createSchemaRequest)
 	if err != nil {
 		return false, fmt.Errorf("error marshaling %#v to json: %s",
-			schemaRequest, createDescriptiveError(err))
+			createSchemaRequest, createDescriptiveError(err))
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Customizing diff new Schema: %s", requestJson))
+	tflog.Debug(ctx, fmt.Sprintf("Customizing diff new Schema: %s", createSchemaRequestJson))
 
-	registeredSchema, schemaExists, err := schemaLookup(ctx, c, schemaRequest, subjectName)
+	registeredSchema, schemaExists, err := schemaLookup(ctx, c, createSchemaRequest, subjectName)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed "'~ schema = jsonencode # whitespace changes' TF drift for confluent_schema resource" issue (https://github.com/confluentinc/terraform-provider-confluent/issues/573).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

**Context**: 
In short, https://github.com/confluentinc/terraform-provider-confluent/issues/573 only impacts users who used `2.15.0` version of TF Provider to manage `confluent_schema` resource.  We did [verify](https://confluent.slack.com/archives/C02TG07V058/p1741153197108959?thread_ts=1741153041.503299&cid=C02TG07V058) that we can't reproduce the issue when performing `2.10.0` -> `2.16.0` -> `2.18.0` updates, but we can reproduce it when doing `2.10.0` -> `2.15.0` -> `2.16.0`. Essentially, everyone who used `2.15.0` version of TF Provider to manage `confluent_schema` resource ended up creating a new schema version with `ruleset = {}` that was marked as _latest_.

After adding more logging and additional testing, we verified that the Schema Registry backend considers two schemas with the same content (`ruleset = null` vs `ruleset = {}`) to be different and assigns different IDs to them:
```
[
  {
    "id": 100008,
    "schema": "{\"type\":\"record\",\"name\":\"EnrichmentKey\",\"namespace\":\"com.orga.NameSpace\",\"fields\":[{\"name\":\"code\",\"type\":\"string\"}]}",
    "subject": "enrichment-key-3-value",
    "version": 1
  },
  {
    "id": 100009,
    "ruleSet": {},
    "schema": "{\"type\":\"record\",\"name\":\"EnrichmentKey\",\"namespace\":\"com.orga.NameSpace\",\"fields\":[{\"name\":\"code\",\"type\":\"string\"}]}",
    "subject": "enrichment-key-3-value",
    "version": 2
  }
]
```

There are 2 user scenarios (**update**: just user scenario #1, as we [confirmed](https://confluent.slack.com/archives/C02TG07V058/p1741585296878059), this scenario doesn't cause any issues / TF drift) that we should fix and verify in order to resolve https://github.com/confluentinc/terraform-provider-confluent/issues/573.

**Scenario `#1`**:

1. The user had a schema with `ruleset = null` that was created before switching to TF Provider v2.15.0 (SR assigned it `schemaID=100008`).
2. The user updated to TF Provider v2.15.0 and then ran into TF drift when running `terraform plan`. They ran `terraform apply`, which essentially created a new schema with `ruleset = {}` (SR assigned it `schemaID=100009`).
3. The user updated to TF Provider v2.16+.0, then ran into TF drift when running `terraform plan`. They ran `terraform apply`, and SR returned `schemaID=100008` during TF’s semantic check, but their current TF state version was `schemaID=100009`.

**Scenario `#2`**:

1. The user used TF Provider v2.15.0 to create a new schema that was implicitly created with `ruleset = {}`.
2. The user updated to TF Provider v2.16+.0, and then they may run into TF drift.

The root cause of scenario `#1` is that [this line](https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/provider/resource_schema.go#L432) fails, as SR returns `schemaID=100008`, but the existing `schemaID=100009`, and 
```
// Set old value to paramSchema to avoid TF drift
if err := diff.SetNew(paramSchema, oldSchema); err != nil {
	return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
}
```
is not being run.

As a result, we considered two fixes:

**Option 1**: Update `SetSchemaDiff()` to first check for a schema with `ruleset = null`. If the local schemaID doesn’t match the returned schemaID, check again with `ruleset = {}` and see whether the local schemaID matches the returned schemaID. If it does, the following code 

```
// Set old value to paramSchema to avoid TF drift
if err := diff.SetNew(paramSchema, oldSchema); err != nil {
	return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
}
```
will be run to resolve TF drift.

**Option 2**: Update `createSchema()` to hardcode `version = -1` to ensure SR creates a new schema regardless of the ruleset value. This fix may have a larger blast radius and may implicitly create additional schemas for customers. It would also fix another issue:

> If a schema evolves into something that matches an old version of the schema, then it won’t get a new version. The general workaround is to specify `version = -1`, so SR incorporates metadata ensuring that the schema differs from all previous versions, causing a new version to be created.

However, we decided it’s best to move forward iteratively and implement the fix with the smallest blast radius possible (Option 1).

Blast Radius
----
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will experience issues, as they'll see a TF drift when running `terraform plan`. 

References
----------
* https://github.com/confluentinc/terraform-provider-confluent/issues/573
* https://confluentinc.atlassian.net/browse/RCCA-25477

Test & Review
-------------
* Test case `#1`: reproducing the issue: `2.10.0` -> `2.15.0` -> `2.16.0`: https://confluent.slack.com/archives/C02TG07V058/p1741589273773319
* Test case `#2`: confirming that the issue has been resolved: `2.10.0` -> `2.15.0` -> the binary that corresponds to this PR: https://confluent.slack.com/archives/C02TG07V058/p1741589278930639
* Test case `#3`: verifying there is no regression when adding new lines/whitespaces to an existing schema using the binary that corresponds to this PR: https://confluent.slack.com/archives/C02TG07V058/p1741589282741319
* Test case `#4`: verifying there is no regression when adding a new attribute to an existing schema to trigger a new schema version creation using the binary that corresponds to this PR: https://confluent.slack.com/archives/C02TG07V058/p1741589290405379
* Test case `#5`: verifying there is no regression when upgrading from`2.10.0` ->  the binary that corresponds to this PR: https://confluent.slack.com/archives/C02TG07V058/p1741592655234889