### PR TITLE
Allow updates to `filter` attribute for Group Mapping without forcing resource re-creation

### DIFF
--- a/internal/provider/resource_group_mapping.go
+++ b/internal/provider/resource_group_mapping.go
@@ -44,7 +44,6 @@ func groupMappingResource() *schema.Resource {
 			paramFilter: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				Description:  "A human-readable name for the Group Mapping.",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
@@ -58,12 +57,16 @@ func groupMappingResource() *schema.Resource {
 }
 
 func groupMappingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramDisplayName, paramDescription) {
-		return diag.Errorf("error updating Group Mapping %q: only %q, %q attributes can be updated for Group Mapping", d.Id(), paramDisplayName, paramDescription)
+	if d.HasChangesExcept(paramFilter, paramDisplayName, paramDescription) {
+		return diag.Errorf("error updating Group Mapping %q: only %q, %q, %q attributes can be updated for Group Mapping", d.Id(), paramFilter, paramDisplayName, paramDescription)
 	}
 
 	updateGroupMappingRequest := sso.NewIamV2SsoGroupMapping()
 
+	if d.HasChange(paramFilter) {
+		updatedFilter := d.Get(paramFilter).(string)
+		updateGroupMappingRequest.SetFilter(updatedFilter)
+	}
 	if d.HasChange(paramDisplayName) {
 		updatedDisplayName := d.Get(paramDisplayName).(string)
 		updateGroupMappingRequest.SetDisplayName(updatedDisplayName)

--- a/internal/provider/resource_group_mapping_test.go
+++ b/internal/provider/resource_group_mapping_test.go
@@ -120,6 +120,7 @@ func TestAccGroupMapping(t *testing.T) {
 	_ = wiremockClient.StubFor(deleteGroupMappingStub)
 
 	// in order to test tf update (step #3)
+	groupMappingUpdatedFilter := "\"updated\" in groups"
 	groupMappingUpdatedDisplayName := "Default updated"
 	groupMappingUpdatedDescription := "Permission for all users in everyone group updated"
 	fullGroupMappingResourceLabel := fmt.Sprintf("confluent_group_mapping.%s", groupMappingResourceLabel)
@@ -148,12 +149,12 @@ func TestAccGroupMapping(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckGroupMappingConfig(mockServerUrl, groupMappingResourceLabel, groupMappingUpdatedDisplayName, groupMappingFilter, groupMappingUpdatedDescription),
+				Config: testAccCheckGroupMappingConfig(mockServerUrl, groupMappingResourceLabel, groupMappingUpdatedDisplayName, groupMappingUpdatedFilter, groupMappingUpdatedDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGroupMappingExists(fullGroupMappingResourceLabel),
 					resource.TestCheckResourceAttr(fullGroupMappingResourceLabel, "id", groupMappingId),
 					resource.TestCheckResourceAttr(fullGroupMappingResourceLabel, "display_name", groupMappingUpdatedDisplayName),
-					resource.TestCheckResourceAttr(fullGroupMappingResourceLabel, "filter", groupMappingFilter),
+					resource.TestCheckResourceAttr(fullGroupMappingResourceLabel, "filter", groupMappingUpdatedFilter),
 					resource.TestCheckResourceAttr(fullGroupMappingResourceLabel, "description", groupMappingUpdatedDescription),
 				),
 			},

--- a/internal/testdata/group_mapping/read_updated_group_mapping.json
+++ b/internal/testdata/group_mapping/read_updated_group_mapping.json
@@ -10,7 +10,7 @@
   "id": "group-w4vP",
   "display_name": "Default updated",
   "description": "Permission for all users in everyone group updated",
-  "filter": "\"engineering\" in groups",
+  "filter": "\"updated\" in groups",
   "principal": "group-w4vP",
   "state": "ENABLED"
 }


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
- Updating the `filter` attribute of `confluent_group_mapping`-resource no longer triggers resource replacement, aligning the Terraform provider with Confluent UI behavior.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
In previous versions of the Terraform provider, changing the `filter` attribute resulted in a replacement instead of an update.
Using the Confluent UI, it was always possible to update the filter without replacing the group mapping.

Previous versions:
```
  # confluent_group_mapping.group_mapping["Unclassified"] must be replaced
-/+ resource "confluent_group_mapping" "group_mapping" {
      ~ filter       = "\"Old-Group-Name\" in groups" -> "\"New-Group-Name\" in groups" # forces replacement
      ~ id           = "group-EMBR" -> (known after apply)
        # (1 unchanged attribute hidden)
    }
```

With this pr:
```
  # confluent_group_mapping.group_mapping["Unclassified"] will be updated in-place
  ~ resource "confluent_group_mapping" "group_mapping" {
      ~ filter       = "\"Old-Group-Name\" in groups" -> "\"New-Group-Name\" in groups"
         id           = "group-EMBR"
        # (2 unchanged attribute hidden)
    }
```

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
**Blast Radius**  
Users who have set `ignore_changes` for `filter` to prevent unintended recreation will need to remove this setting to achieve the correct behavior. No further impact on other resources is expected.
Since this change aligns Terraform behavior with the Confluent UI, the risk is minimal.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
- #468 

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
- Executed `make testacc` - PASS [testacc.log](https://github.com/user-attachments/files/19195885/testacc.log)

- Tested Creating and Updating a `confluent_group_mapping`-resource against a Confluent Cloud organization

### Resource Creation:

main.tf:
```hcl
terraform {
  required_providers {
    confluent = {
      source = "confluentinc/confluent"
    }
  }
}

resource "confluent_group_mapping" "example" {
  display_name = "Terraform Testing initial"
  filter       = "\"initial\" in groups"
  description  = "initial"
}
```
Plan output:
```
Terraform will perform the following actions:

  # confluent_group_mapping.example will be created
  + resource "confluent_group_mapping" "example" {
      + description  = "initial"
      + display_name = "Terraform Testing initial"
      + filter       = "\"initial\" in groups"
      + id           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```
Apply output:
```
The behavior may therefore not match any released version of the provider and applying changes may cause the state to become
incompatible with published releases.
confluent_group_mapping.example: Creating...
confluent_group_mapping.example: Creation complete after 1s [id=group-5GDAb]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
Confluent Cloud UI:
![confluent-initial-resource](https://github.com/user-attachments/assets/85104b58-33d1-4c7f-bbc1-5a6cba83b16f)

### Resource update:

```hcl
terraform {
  required_providers {
    confluent = {
      source = "confluentinc/confluent"
    }
  }
}

resource "confluent_group_mapping" "example" {
  display_name = "Terraform Testing updated"
  filter       = "\"updated\" in groups"
  description  = "updated"
}
```
Plan output:
```
Terraform will perform the following actions:

  # confluent_group_mapping.example will be updated in-place
  ~ resource "confluent_group_mapping" "example" {
      ~ description  = "initial" -> "updated"
      ~ display_name = "Terraform Testing initial" -> "Terraform Testing updated"
      ~ filter       = "\"initial\" in groups" -> "\"updated\" in groups"
        id           = "group-5GDAb"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
Apply output:
```
The behavior may therefore not match any released version of the provider and applying changes may cause the state to become
incompatible with published releases.
confluent_group_mapping.example: Modifying... [id=group-5GDAb]
confluent_group_mapping.example: Modifications complete after 2s [id=group-5GDAb]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
Confluent Cloud UI:
![confluent-updated-resource](https://github.com/user-attachments/assets/7bddf111-1961-4ae8-abc0-33b425775428)
