### PR TITLE
APIT-2981: Updated the service account resource to support changes to the display_name attribute, alongside the description.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/flink v0.9.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0
-	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.14.0
+	github.com/confluentinc/ccloud-sdk-go-v2/iam v0.17.0
 	github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/kafkarest v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.4.0 h1:x7rT5dheLVyfzP
 github.com/confluentinc/ccloud-sdk-go-v2/flink-artifact v0.4.0/go.mod h1:j7E98ymo8yRmW18252CoQlr4rjmGv211rfo8M4fIVcQ=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0 h1:8Y1uXjolI2d5mawcfLn4OfJ81WRMQpjMFWdBm3dLdrk=
 github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway v0.17.0/go.mod h1:cJ6erfVlWSyz6L+2dR46cF2+s5I2r+pTNrPm2fNbcqU=
-github.com/confluentinc/ccloud-sdk-go-v2/iam v0.14.0 h1:nuY0KBWCh8ncnV72T5tW9fxfzAwjxyUmAtwSPBTAEG4=
-github.com/confluentinc/ccloud-sdk-go-v2/iam v0.14.0/go.mod h1:XKuyBbkZJ/0iUF2tIzGNCg1amLw/6BRLG/AQkNoZM80=
+github.com/confluentinc/ccloud-sdk-go-v2/iam v0.17.0 h1:I5nYXbiSU37Vb6cPmatzJk7szQJUNojTNPkscb+jK/4=
+github.com/confluentinc/ccloud-sdk-go-v2/iam v0.17.0/go.mod h1:jnWqax4kM22sutPGMtGmHqe2usgfqYig4UtmHsLENz0=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0 h1:9TT8UCFRc5zUdsE7UgMz7hqN+2KYnIkBcAKCaiZJrXw=
 github.com/confluentinc/ccloud-sdk-go-v2/identity-provider v0.2.0/go.mod h1:JLmrXfnT2PzcuXHD8a6c2cW1c9LKK7aMsdZjjqxYPEk=
 github.com/confluentinc/ccloud-sdk-go-v2/kafka-quotas v0.4.0 h1:T9e7lNj/VjxE89+tcpX2RS2NE4rWNWbJjxcO2yehEqM=

--- a/internal/provider/resource_service_account_test.go
+++ b/internal/provider/resource_service_account_test.go
@@ -116,6 +116,7 @@ func TestAccServiceAccount(t *testing.T) {
 	saDisplayName := "test_service_account_display_name"
 	saDescription := "The initial description of service account"
 	// in order to test tf update (step #3)
+	saUpdatedDisplayName := "test_service_account_updated_display_name"
 	saUpdatedDescription := "The updated description of service account"
 	saResourceLabel := "test_sa_resource_label"
 	fullSaResourceLabel := fmt.Sprintf("confluent_service_account.%s", saResourceLabel)
@@ -145,13 +146,13 @@ func TestAccServiceAccount(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckServiceAccountConfig(mockServerUrl, saResourceLabel, saDisplayName, saUpdatedDescription),
+				Config: testAccCheckServiceAccountConfig(mockServerUrl, saResourceLabel, saUpdatedDisplayName, saUpdatedDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceAccountExists(fullSaResourceLabel),
 					resource.TestCheckResourceAttr(fullSaResourceLabel, "id", "sa-1jjv26"),
 					resource.TestCheckResourceAttr(fullSaResourceLabel, "api_version", saApiVersion),
 					resource.TestCheckResourceAttr(fullSaResourceLabel, "kind", saKind),
-					resource.TestCheckResourceAttr(fullSaResourceLabel, "display_name", saDisplayName),
+					resource.TestCheckResourceAttr(fullSaResourceLabel, "display_name", saUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullSaResourceLabel, "description", saUpdatedDescription),
 				),
 			},

--- a/internal/testdata/service_account/read_updated_sa.json
+++ b/internal/testdata/service_account/read_updated_sa.json
@@ -9,5 +9,5 @@
     "resource_name": "crn://confluent.cloud/service-account=sa-1jjv26"
   },
   "description": "The updated description of service account",
-  "display_name": "test_service_account_display_name"
+  "display_name": "test_service_account_updated_display_name"
 }


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Added support to update `display_name` attribute of `confluent_service_account` accounts


Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
In previous versions of the Terraform provider updating the `display_name` attribute of `confluent_service_account` resources caused a resource replacement because the backend api did not support updates for display-names. 

Previous versions:
```hcl
  # confluent_service_account.app-manager must be replaced
-/+ resource "confluent_service_account" "app-manager" {
      ~ api_version  = "iam/v2" -> (known after apply)
      ~ display_name = "app-manager" -> "app-manager-updated" # forces replacement
      ~ id           = "sa-vxrm0z" -> (known after apply)
      ~ kind         = "ServiceAccount" -> (known after apply)
        # (1 unchanged attribute hidden)
    }
```

With this pr:
```hcl
  # confluent_service_account.app-manager will be updated in-place
  ~ resource "confluent_service_account" "app-manager" {
      ~ display_name = "app-manager-updated" -> "app-manager"
        id           = "sa-vxrm0z"
        # (3 unchanged attributes hidden)
    }
```

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Users who have set `ignore_changes` for `display_name` to prevent unintended recreation will need to remove this setting to achieve the correct behavior. No further impact on other resources is expected.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
- #212 

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
- Executed `make testacc` - PASS [testacc.log](https://github.com/user-attachments/files/19196790/testacc.log)
- Tested Creating and Updating a `confluent_service_account`-resource against a Confluent Cloud organization

### Resource creation:
Base terraform config was taken from this [example](https://github.com/confluentinc/terraform-provider-confluent/blob/7d166ea003525a0b69490a6755724f94c31f084c/examples/configurations/basic-kafka-acls/main.tf#L10C1-L51C2)

main.tf:
```hcl
resource "confluent_service_account" "app-manager" {
  display_name = "app-manager"
  description  = "Service account to manage 'inventory' Kafka cluster"
}
```

Plan output:
```
Terraform will perform the following actions:

  # confluent_service_account.app-manager will be created
  + resource "confluent_service_account" "app-manager" {
      + api_version  = (known after apply)
      + description  = "Service account to manage 'inventory' Kafka cluster"
      + display_name = "app-manager"
      + id           = (known after apply)
      + kind         = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Apply output:
```
The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
confluent_service_account.app-manager: Creating...
confluent_service_account.app-manager: Creation complete after 1s [id=sa-nnwmn6]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
![confluent-service-account-initial](https://github.com/user-attachments/assets/df8111ef-3ba7-46f2-a164-fb5e59cb9a78)


### Resource update:

main.tf:
```hcl
resource "confluent_service_account" "app-manager" {
  display_name = "app-manager-updated"
  description  = "Updated description"
}
```

Plan output:
```
Terraform will perform the following actions:

  # confluent_service_account.app-manager will be updated in-place
  ~ resource "confluent_service_account" "app-manager" {
      ~ description  = "Service account to manage 'inventory' Kafka cluster" -> "Updated description"
      ~ display_name = "app-manager" -> "app-manager-updated"
        id           = "sa-nnwmn6"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Apply output:
```
The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
confluent_service_account.app-manager: Modifying... [id=sa-nnwmn6]
confluent_service_account.app-manager: Modifications complete after 1s [id=sa-nnwmn6]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
![confluent-service-account-updated](https://github.com/user-attachments/assets/f205e1da-33bf-4a15-aebd-ba375339d11e)
