### PR TITLE
APIT-2991: Add descriptive error messages to resourceFlinkStatementDiff()

### DIFF
--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -798,6 +798,6 @@ func resourceFlinkStatementDiff(_ context.Context, diff *schema.ResourceDiff, _ 
 		}
 	}
 
-	// STOPPED -> RUNNING transition, both `paramPrincipal` and `paramComputePool` can be updated in place, so no restriction here
+	// RUNNING -> STOPPED transition, both `paramPrincipal` and `paramComputePool` can be updated in place, so no restriction here
 	return nil
 }


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Update the error messages for `confluent_flink_statement` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_statement).

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
- Confluent Cloud customers who are using `confluent_flink_statement` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_statement) will be blocked.

References
----------
* https://confluentinc.atlassian.net/browse/APIT-2991

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1741982805772009
