### PR TITLE
Add time.Sleep() for Tableflow API Key.

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -523,14 +523,14 @@ func waitForApiKeyToSync(ctx context.Context, c *Client, createdApiKey apikeys.I
 				return fmt.Errorf("error waiting for Kafka API Key %q to sync: %s", createdApiKey.GetId(), createDescriptiveError(err))
 			}
 		} else if isSchemaRegistryApiKey(createdApiKey) || isFlinkApiKey(createdApiKey) {
-			time.Sleep(1 * time.Minute)
+			SleepIfNotTestMode(1*time.Minute, c.isAcceptanceTestMode)
 		} else if isKsqlDbClusterApiKey(createdApiKey) {
 			// Currently, there are no data plane API for ksqlDB clusters so there is no endpoint we could leverage
 			// to check whether the Cluster API Key is synced which is why we're adding SleepIfNotTestMode() here.
 			// TODO: SVCF-3560
 			SleepIfNotTestMode(5*time.Minute, c.isAcceptanceTestMode)
 		} else if isTableflowApiKey(createdApiKey) {
-			time.Sleep(1 * time.Minute)
+			SleepIfNotTestMode(1*time.Minute, c.isAcceptanceTestMode)
 			// TODO: APIT-2764
 		} else {
 			resourceJson, err := json.Marshal(createdApiKey.Spec.GetResource())

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -509,7 +509,6 @@ func isTableflowApiKey(apiKey apikeys.IamV2ApiKey) bool {
 func waitForApiKeyToSync(ctx context.Context, c *Client, createdApiKey apikeys.IamV2ApiKey, isResourceSpecificApiKey bool, environmentId string) error {
 	// For Kafka API Key use Kafka REST API's List Topics request and wait for http.StatusOK
 	// For Cloud API Key use Org API's List Environments request and wait for http.StatusOK
-	// For Flink API Key use Statements API's List of Statements request and wait for http.StatusOK
 	// For Tableflow API Key skipped the waitForCreatedTableflowApiKeyToSync function for now, until backend support for tableflow secret/key verification is ready
 
 	if isResourceSpecificApiKey {
@@ -524,16 +523,15 @@ func waitForApiKeyToSync(ctx context.Context, c *Client, createdApiKey apikeys.I
 				return fmt.Errorf("error waiting for Kafka API Key %q to sync: %s", createdApiKey.GetId(), createDescriptiveError(err))
 			}
 		} else if isSchemaRegistryApiKey(createdApiKey) || isFlinkApiKey(createdApiKey) {
-			time.Sleep(2 * time.Minute)
+			time.Sleep(1 * time.Minute)
 		} else if isKsqlDbClusterApiKey(createdApiKey) {
 			// Currently, there are no data plane API for ksqlDB clusters so there is no endpoint we could leverage
 			// to check whether the Cluster API Key is synced which is why we're adding SleepIfNotTestMode() here.
 			// TODO: SVCF-3560
 			SleepIfNotTestMode(5*time.Minute, c.isAcceptanceTestMode)
 		} else if isTableflowApiKey(createdApiKey) {
-			// TODO: add sync implementation once backend support for tableflow secret/key verification is ready
-			// 		 tracked with JIRA Ticket APIT-2764
-			return nil
+			time.Sleep(1 * time.Minute)
+			// TODO: APIT-2764
 		} else {
 			resourceJson, err := json.Marshal(createdApiKey.Spec.GetResource())
 			if err != nil {


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only


What
----
This PR does 2 things:
* adds time.Sleep() for Tableflow API Key just in case.
* updates sleeping time for SR and Flink API Keys from 2 minutes to 1 minute (FWIW it seems like 5-10 seconds should be sufficient anyway).

Note: it also uses `SleepIfNotTestMode(1*time.Minute, c.isAcceptanceTestMode)` instead of `time.Sleep(1 * time.Minute)` to make sure our acceptance tests are still quick.

Blast Radius
----

- Confluent Cloud customers who are creating new instances of `confluent_api_key` resource will be blocked.

References
----------
NA

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1742230082294999 (we verified SR & Flink API key creation, along with subsequent schema and statement creation, without encountering any issues. This confirms that the API keys were synced within a minute).