### PR TITLE
Remove LA label from confluent_network.md

### DIFF
--- a/docs/data-sources/confluent_network.md
+++ b/docs/data-sources/confluent_network.md
@@ -71,8 +71,6 @@ In addition to the preceding arguments, the following attributes are exported:
   - `zone_id` - (Required String) Cloud provider zone ID.
   - `cidr` - (Required String) The IPv4 CIDR block to be used for the network. Must be `/27`. Required for VPC peering and AWS TransitGateway.
 
--> **Note:** The `zone_info` configuration block and `reserved_cidr` are in a [Limited Availability lifecycle stage](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy), and it's available only for AWS networks with PEERING connection type.
-
 - `connection_types` - (Required List of String) The list of connection types that may be used with the network. Accepted connection types are: `PEERING`, `TRANSITGATEWAY`, and `PRIVATELINK`.
 - `zones` - (Optional List of String) The 3 availability zones for this network. They can optionally be specified for AWS networks
   used with PrivateLink, for GCP networks used with Private Service Connect, and for AWS and GCP

--- a/docs/resources/confluent_network.md
+++ b/docs/resources/confluent_network.md
@@ -130,8 +130,6 @@ The following arguments are supported:
   - `zone_id` - (Required String) Cloud provider zone ID.
   - `cidr` - (Required String) The IPv4 CIDR block to be used for the network. Must be `/27`. Required for VPC peering and AWS TransitGateway.
 
--> **Note:** The `zone_info` configuration block and `reserved_cidr` are in a [Limited Availability lifecycle stage](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy), and it's available only for AWS networks with PEERING connection type.
-
 - `connection_types` - (Required List of String) The list of connection types that may be used with the network. Accepted connection types are: `PEERING`, `TRANSITGATEWAY`, and `PRIVATELINK`.
 - `zones` - (Optional List of String) The 3 availability zones for this network. They can optionally be specified for AWS networks
   used with PrivateLink, for GCP networks used with Private Service Connect, and for AWS and GCP


### PR DESCRIPTION
Release Notes
---------

New Features
- Release the `reserved_cidr` attribute and `zone_info` blocks are in [General Availabiliity lifecycle stage](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy). It's available only for AWS networks with PEERING and TRANSITGATEWAY connection type.


Checklist
---------
NA

What
----
NA

Blast Radius
----
NA

References
----------
NA

Test & Review
-------------
NA