### PR TITLE
Fix a typo in the dedicated-vpc-peering-v2-aws-kafka-acls

### DIFF
--- a/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/terraform.tfvars
+++ b/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/terraform.tfvars
@@ -1,4 +1,4 @@
-# Cross-region access to Confluent Cloud is not supported when VPC peering is enabled with Google Cloud. Your AWS VPC and Confluent Cloud must be in the same region.
+# Cross-region access to Confluent Cloud is not supported when VPC peering is enabled with AWS. Your AWS VPC and Confluent Cloud must be in the same region.
 # The region of your VPC that you want to connect to Confluent Cloud Cluster
 # Cross-region AWS PrivateLink connections are not supported yet.
 region = "us-east-1"
@@ -10,7 +10,7 @@ customer_region = "us-east-1"
 zones_info = [
   { zone_id : "use1-az1", cidr : "192.168.2.0/27" },
   { zone_id : "use1-az2", cidr : "192.168.2.32/27" },
-  { zone_id : "use1-az3", cidr : "192.168.2.64/27" }
+  { zone_id : "use1-az4", cidr : "192.168.2.64/27" }
 ]
 
 # The AWS Account ID of the peer VPC owner.


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
NA

What
----
This PR updates a typo in the dedicated-vpc-peering-v2-aws-kafka-acls example.

https://docs.confluent.io/cloud/current/networking/peering/aws-peering.html#requirements-and-considerations

> All AWS availability zones, except use1-az3 in the us-east-1 region, are supported.

Blast Radius
----
NA

References
----------
NA

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
