### PR TITLE
Release a fix for issues/619.

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -65,6 +65,7 @@ const (
 	paramSkipValidationDuringPlanDefaultValue = false
 
 	latestSchemaVersionAndPlaceholderForSchemaIdentifier = "latest"
+	schemaVersionForForceCreatingNewVersion              = -1
 )
 
 var acceptedSchemaFormats = []string{avroFormat, jsonFormat, protobufFormat}
@@ -608,6 +609,12 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		}
 		return diag.Errorf("error creating Schema: error validating a schema: %s", schemaNotCompatibleErrorMessage)
 	}
+
+	// Context: https://github.com/confluentinc/terraform-provider-confluent/issues/619
+	// Set version = -1 after the validation logic (i.e., the compatability check) as
+	// https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--compatibility-subjects-(string-%20subject)-versions
+	// only request schema, schemaType, schemaType in the request object.
+	createSchemaRequest.SetVersion(schemaVersionForForceCreatingNewVersion)
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating new Schema: %s", createSchemaRequestJson))
 


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed "Persistent terraform drift when creating a confluent_schema that already existed as one of the previous versions" issue (https://github.com/confluentinc/terraform-provider-confluent/issues/619).

Checklist
---------
WIP
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes https://github.com/confluentinc/terraform-provider-confluent/issues/619 by hardcoding force creating a new version of schema in schemaCreate() method by hardcoding `version = -1` in https://docs.confluent.io/platform/current/schema-registry/develop/api.html#post--compatibility-subjects-(string-%20subject)-versions, so SR ensures that the schema differs from all previous versions, causing a new version to be created.

Blast Radius
----
- Confluent Cloud customers who are _creating_ `confluent_schema` resources will be blocked.

References
----------
* https://github.com/confluentinc/terraform-provider-confluent/issues/619

Test & Review
-------------
WIP
