### PR TITLE
INC-1434: Resolve "error creating / updating Cluster Config: "ssl.enabled.protocols" cluster setting is read-only and cannot be updated" error

### DIFF
--- a/internal/provider/resource_kafka_cluster_config.go
+++ b/internal/provider/resource_kafka_cluster_config.go
@@ -31,6 +31,7 @@ import (
 // https://docs.confluent.io/cloud/current/clusters/broker-config.html#change-cluster-settings-for-dedicated-clusters
 var editableClusterSettings = []string{
 	"auto.create.topics.enable",
+	"ssl.enabled.protocols",
 	"ssl.cipher.suites",
 	"num.partitions",
 	"log.cleaner.max.compaction.lag.ms",

--- a/internal/provider/resource_kafka_cluster_config_provider_block_test.go
+++ b/internal/provider/resource_kafka_cluster_config_provider_block_test.go
@@ -120,6 +120,7 @@ func TestAccClusterConfigWithEnhancedProviderBlock(t *testing.T) {
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", thirdClusterConfigName), thirdClusterConfigUpdatedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", fourthClusterConfigName), fourthClusterConfigAddedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", fifthClusterConfigName), fifthClusterConfigAddedValue),
+					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", sixthClusterConfigName), sixthClusterConfigAddedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "credentials.#", "0"),
 				),
 			},
@@ -178,10 +179,11 @@ func testAccCheckConfigUpdatedConfigWithEnhancedProviderBlock(confluentCloudBase
 		"%s" = "%s"
 		"%s" = "%s"
 		"%s" = "%s"
+		"%s" = "%s"
 	  }
 	}
 	`, confluentCloudBaseUrl, kafkaApiKey, kafkaApiSecret, mockServerUrl, configResourceLabel, clusterId,
 		firstClusterConfigName, firstClusterConfigUpdatedValue, secondClusterConfigName, secondClusterConfigValue,
 		thirdClusterConfigName, thirdClusterConfigUpdatedValue, fourthClusterConfigName, fourthClusterConfigAddedValue,
-		fifthClusterConfigName, fifthClusterConfigAddedValue)
+		fifthClusterConfigName, fifthClusterConfigAddedValue, sixthClusterConfigName, sixthClusterConfigAddedValue)
 }

--- a/internal/provider/resource_kafka_cluster_config_provider_block_test.go
+++ b/internal/provider/resource_kafka_cluster_config_provider_block_test.go
@@ -114,7 +114,7 @@ func TestAccClusterConfigWithEnhancedProviderBlock(t *testing.T) {
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "kafka_cluster.0.id", clusterId),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "id", fmt.Sprintf("%s", clusterId)),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "%", "5"),
-					resource.TestCheckResourceAttr(fullConfigResourceLabel, "config.%", "5"),
+					resource.TestCheckResourceAttr(fullConfigResourceLabel, "config.%", "6"),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", firstClusterConfigName), firstClusterConfigUpdatedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", secondClusterConfigName), secondClusterConfigValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", thirdClusterConfigName), thirdClusterConfigUpdatedValue),

--- a/internal/provider/resource_kafka_cluster_config_test.go
+++ b/internal/provider/resource_kafka_cluster_config_test.go
@@ -43,6 +43,8 @@ const (
 	fourthClusterConfigAddedValue     = "9223372036854775807"
 	fifthClusterConfigName            = "log.retention.ms"
 	fifthClusterConfigAddedValue      = "604800001"
+	sixthClusterConfigName            = "ssl.enabled.protocols"
+	sixthClusterConfigAddedValue      = "TLSv1.3"
 	configResourceLabel               = "test_config_resource_label"
 )
 
@@ -160,6 +162,7 @@ func TestAccClusterConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", thirdClusterConfigName), thirdClusterConfigUpdatedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", fourthClusterConfigName), fourthClusterConfigAddedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", fifthClusterConfigName), fifthClusterConfigAddedValue),
+					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", sixthClusterConfigName), sixthClusterConfigAddedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "credentials.#", "1"),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "credentials.0.%", "2"),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "credentials.0.key", kafkaApiKey),
@@ -228,6 +231,7 @@ func testAccCheckConfigUpdatedConfig(confluentCloudBaseUrl, mockServerUrl string
 		"%s" = "%s"
 		"%s" = "%s"
 		"%s" = "%s"
+		"%s" = "%s"
 	  }
 
 	  credentials {
@@ -238,7 +242,7 @@ func testAccCheckConfigUpdatedConfig(confluentCloudBaseUrl, mockServerUrl string
 	`, confluentCloudBaseUrl, configResourceLabel, clusterId, mockServerUrl,
 		firstClusterConfigName, firstClusterConfigUpdatedValue, secondClusterConfigName, secondClusterConfigValue,
 		thirdClusterConfigName, thirdClusterConfigUpdatedValue, fourthClusterConfigName, fourthClusterConfigAddedValue,
-		fifthClusterConfigName, fifthClusterConfigAddedValue,
+		fifthClusterConfigName, fifthClusterConfigAddedValue, sixthClusterConfigName, sixthClusterConfigAddedValue,
 		kafkaApiKey, kafkaApiSecret)
 }
 

--- a/internal/provider/resource_kafka_cluster_config_test.go
+++ b/internal/provider/resource_kafka_cluster_config_test.go
@@ -156,7 +156,7 @@ func TestAccClusterConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "id", fmt.Sprintf("%s", clusterId)),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "%", "5"),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, "rest_endpoint", mockConfigTestServerUrl),
-					resource.TestCheckResourceAttr(fullConfigResourceLabel, "config.%", "5"),
+					resource.TestCheckResourceAttr(fullConfigResourceLabel, "config.%", "6"),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", firstClusterConfigName), firstClusterConfigUpdatedValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", secondClusterConfigName), secondClusterConfigValue),
 					resource.TestCheckResourceAttr(fullConfigResourceLabel, fmt.Sprintf("config.%s", thirdClusterConfigName), thirdClusterConfigUpdatedValue),

--- a/internal/testdata/kafka_config/read_updated_kafka_config.json
+++ b/internal/testdata/kafka_config/read_updated_kafka_config.json
@@ -114,6 +114,28 @@
       ],
       "config_type": "BROKER",
       "is_default": false
+    },
+    {
+      "kind": "KafkaClusterConfig",
+      "metadata": {
+        "self": "https://pkc-qy65d.us-east-1.aws.confluent.cloud/kafka/v3/clusters/lkc-190073/broker-configs/ssl.enabled.protocols",
+        "resource_name": "crn:///kafka=lkc-190073/broker-config=ssl.enabled.protocols"
+      },
+      "cluster_id": "lkc-190073",
+      "name": "ssl.enabled.protocols",
+      "value": "TLSv1.3",
+      "is_read_only": true,
+      "is_sensitive": false,
+      "source": "DYNAMIC_DEFAULT_BROKER_CONFIG",
+      "synonyms": [
+        {
+          "name": "listener.name.external.ssl.enabled.protocols",
+          "value": "TLSv1.3",
+          "source": "DYNAMIC_DEFAULT_BROKER_CONFIG"
+        }
+      ],
+      "config_type": "BROKER",
+      "is_default": false
     }
   ]
 }


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Resolved "error creating / updating Cluster Config: "ssl.enabled.protocols" cluster setting is read-only and cannot be updated" issue.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR resolves "error creating / updating Cluster Config: "ssl.enabled.protocols" cluster setting is read-only and cannot be updated" error that users could observe when trying to update / create Kafka Cluster Config using new "ssl.enabled.protocols" [attribute](https://docs.confluent.io/cloud/current/clusters/broker-config.html#change-cluster-settings-for-dedicated-clusters):
![image](https://github.com/user-attachments/assets/5d765266-6ff5-45e5-a98b-d9df13f67fc2)

For example,
```
resource "confluent_kafka_cluster_config" "main" {
  config = {
    "ssl.enabled.protocols" = "TLSv1.2"
    "log.retention.ms"      = "604800123"
  }
}
```

Thanks to @bob-barrett for proactively suggesting a fix in https://github.com/confluentinc/terraform-provider-confluent/commit/3ceeb15745d2af3e6fa33291d4087a70745a8467!

Blast Radius
----
- Confluent Cloud customers who are using `confluent_kafka_cluster_config` resource/data-source will be blocked.


Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1744248402638859
* https://confluent.slack.com/archives/C08MMCH357W/p1744245519325539