### PR TITLE
Update examples/configurations/flink-quickstart

### DIFF
--- a/examples/configurations/flink-quickstart/main.tf
+++ b/examples/configurations/flink-quickstart/main.tf
@@ -137,17 +137,17 @@ resource "confluent_role_binding" "app-manager-flink-developer" {
 // are not required for running this example, but you may have to add it in order
 // to create and complete transactions.
 // https://docs.confluent.io/cloud/current/flink/operate-and-deploy/flink-rbac.html#authorization
-// resource "confluent_role_binding" "app-manager-transaction-id-developer-read" {
-//   principal = "User:${confluent_service_account.app-manager.id}"
-//   role_name = "DeveloperRead"
-//   crn_pattern = "${confluent_kafka_cluster.standard.rbac_crn}/kafka=${confluent_kafka_cluster.standard.id}/transactional-id=_confluent-flink_"
-// }
-//
-// resource "confluent_role_binding" "app-manager-transaction-id-developer-write" {
-//   principal = "User:${confluent_service_account.app-manager.id}"
-//   role_name = "DeveloperWrite"
-//   crn_pattern = "${confluent_kafka_cluster.standard.rbac_crn}/kafka=${confluent_kafka_cluster.standard.id}/transactional-id=_confluent-flink_"
-// }
+resource "confluent_role_binding" "app-manager-transaction-id-developer-read" {
+  principal = "User:${confluent_service_account.app-manager.id}"
+  role_name = "DeveloperRead"
+  crn_pattern = "${confluent_kafka_cluster.standard.rbac_crn}/kafka=${confluent_kafka_cluster.standard.id}/transactional-id=_confluent-flink_*"
+ }
+
+resource "confluent_role_binding" "app-manager-transaction-id-developer-write" {
+  principal = "User:${confluent_service_account.app-manager.id}"
+  role_name = "DeveloperWrite"
+  crn_pattern = "${confluent_kafka_cluster.standard.rbac_crn}/kafka=${confluent_kafka_cluster.standard.id}/transactional-id=_confluent-flink_*"
+}
 
 // https://docs.confluent.io/cloud/current/access-management/access-control/rbac/predefined-rbac-roles.html#assigner
 // https://docs.confluent.io/cloud/current/flink/operate-and-deploy/flink-rbac.html#submit-long-running-statements
@@ -179,11 +179,8 @@ resource "confluent_api_key" "app-manager-flink-api-key" {
 
   depends_on = [
     confluent_role_binding.app-manager-flink-developer,
-    // Note: these role bindings (app-manager-transaction-id-developer-read, app-manager-transaction-id-developer-write)
-    // are not required for running this example, but you may have to add it in order
-    // to create and complete transactions.
-    // confluent_role_binding.app-manager-transaction-id-developer-read,
-    // confluent_role_binding.app-manager-transaction-id-developer-write
+    confluent_role_binding.app-manager-transaction-id-developer-read,
+    confluent_role_binding.app-manager-transaction-id-developer-write
   ]
 }
 


### PR DESCRIPTION
Release Notes
---------
Examples
- Updated flink-quickstart example.

Checklist
---------
NA

What
----
This PR is a follow up to https://github.com/confluentinc/terraform-provider-confluent/pull/594/files to fix the issue in 
```
    confluent_role_binding.app-manager-transaction-id-developer-read,
    confluent_role_binding.app-manager-transaction-id-developer-write
```
CRNs patters, as they should be prefixed as specified in https://docs.confluent.io/cloud/current/flink/operate-and-deploy/flink-rbac.html#authorization:
![image](https://github.com/user-attachments/assets/424d241d-a10d-4661-a29e-4e2fbcad726f)


Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
* https://confluent.slack.com/archives/C01880K2BAA/p1744404182126199?thread_ts=1741876686.517469&cid=C01880K2BAA

Test & Review
-------------
```
➜  flink-quickstart git:(update-flink-example) ✗ terraform validate 
...
Success! The configuration is valid, but there were some validation warnings as shown above.

```
