### PR TITLE
[INC-1814,CLI-3545] Allow updating `jwks_uri` and `issuer` in `confluent_identity_provider` resource

### DIFF
--- a/internal/provider/resource_identity_provider.go
+++ b/internal/provider/resource_identity_provider.go
@@ -57,14 +57,12 @@ func identityProviderResource() *schema.Resource {
 			paramIssuer: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				Description:  "A publicly reachable issuer URI for the Identity Provider.",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			paramJwksUri: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				Description:  "A publicly reachable JWKS URI for the Identity Provider.",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
@@ -78,8 +76,8 @@ func identityProviderResource() *schema.Resource {
 }
 
 func identityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramDisplayName, paramDescription, paramIdentityClaim) {
-		return diag.Errorf("error updating Identity Provider %q: only %q, %q, %q attributes can be updated for Identity Provider", d.Id(), paramDisplayName, paramDescription, paramIdentityClaim)
+	if d.HasChangesExcept(paramDisplayName, paramDescription, paramIssuer, paramJwksUri, paramIdentityClaim) {
+		return diag.Errorf("error updating Identity Provider %q: only %q, %q, %q, %q, %q attributes can be updated for Identity Provider", d.Id(), paramDisplayName, paramDescription, paramIssuer, paramJwksUri, paramIdentityClaim)
 	}
 
 	updateIdentityProviderRequest := oidc.NewIamV2IdentityProvider()
@@ -91,6 +89,14 @@ func identityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if d.HasChange(paramDescription) {
 		updatedDescription := d.Get(paramDescription).(string)
 		updateIdentityProviderRequest.SetDescription(updatedDescription)
+	}
+	if d.HasChange(paramIssuer) {
+		updatedIssuer := d.Get(paramIssuer).(string)
+		updateIdentityProviderRequest.SetIssuer(updatedIssuer)
+	}
+	if d.HasChange(paramJwksUri) {
+		updatedJwksUri := d.Get(paramJwksUri).(string)
+		updateIdentityProviderRequest.SetJwksUri(updatedJwksUri)
 	}
 	if d.HasChange(paramIdentityClaim) {
 		updatedIdentityClaim := d.Get(paramIdentityClaim).(string)

--- a/internal/provider/resource_identity_provider_test.go
+++ b/internal/provider/resource_identity_provider_test.go
@@ -17,10 +17,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/walkerus/go-wiremock"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/walkerus/go-wiremock"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -122,6 +123,8 @@ func TestAccIdentityProvider(t *testing.T) {
 	// in order to test tf update (step #3)
 	identityProviderUpdatedDescription := "fake description updated"
 	identityProviderUpdatedDisplayName := "My OIDC Provider updated"
+	identityProviderUpdatedIssuer := "https://login.microsoftonline.com/11111111-0000-0000-0000-b3d3d184f1a5/v2.1"
+	identityProviderUpdatedJwksUri := "https://login.microsoftonline.com/common/discovery/v2.1/keys"
 	identityProviderResourceLabel := "test_identity_provider_resource_label"
 	fullIdentityProviderResourceLabel := fmt.Sprintf("confluent_identity_provider.%s", identityProviderResourceLabel)
 
@@ -151,14 +154,14 @@ func TestAccIdentityProvider(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckIdentityProviderConfig(mockServerUrl, identityProviderResourceLabel, identityProviderUpdatedDisplayName, identityProviderUpdatedDescription, identityProviderIssuer, identityProviderJwksUri),
+				Config: testAccCheckIdentityProviderConfig(mockServerUrl, identityProviderResourceLabel, identityProviderUpdatedDisplayName, identityProviderUpdatedDescription, identityProviderUpdatedIssuer, identityProviderUpdatedJwksUri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityProviderExists(fullIdentityProviderResourceLabel),
 					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramId, identityProviderId),
 					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramDisplayName, identityProviderUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramDescription, identityProviderUpdatedDescription),
-					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramIssuer, identityProviderIssuer),
-					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramJwksUri, identityProviderJwksUri),
+					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramIssuer, identityProviderUpdatedIssuer),
+					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramJwksUri, identityProviderUpdatedJwksUri),
 					resource.TestCheckResourceAttr(fullIdentityProviderResourceLabel, paramIdentityClaim, identityProviderIdentityClaim),
 				),
 			},

--- a/internal/testdata/identity_provider/read_updated_identity_provider.json
+++ b/internal/testdata/identity_provider/read_updated_identity_provider.json
@@ -11,8 +11,8 @@
   "display_name": "My OIDC Provider updated",
   "description": "fake description updated",
   "state": "ENABLED",
-  "issuer": "https://login.microsoftonline.com/11111111-0000-0000-0000-b3d3d184f1a5/v2.0",
-  "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+  "issuer": "https://login.microsoftonline.com/11111111-0000-0000-0000-b3d3d184f1a5/v2.1",
+  "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.1/keys",
   "identity_claim": "claims.aud",
   "keys": [
     {


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- The `issuer` and `jwks_uri` attributes for the `confluent_identity_provider` resource can now be updated

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
The API was updated a while ago to make `issuer` and `jwks_uri` mutable, but the TF resource was not updated to reflect this change.

This PR removes the `force_new` setting from these attributes.

Blast Radius
----
The identity provider resource would be impacted.

References
----------
https://confluentinc.atlassian.net/browse/INC-1814
https://confluentinc.atlassian.net/browse/CLI-3545

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1745519155728329
