### PR TITLE
CLI-3541: Update TF docs to indicate how to configure configs at the global context level

### DIFF
--- a/docs/resources/confluent_schema_registry_cluster_config.md
+++ b/docs/resources/confluent_schema_registry_cluster_config.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_schema_registry_cluster_config` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
--> **Note:** To configure a config at the context level, affecting all subjects created within that context, use `confluent_subject_config` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config) instead.
+-> **Note:** To configure a config at the context level, affecting all subjects created within that context, use `confluent_subject_config` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config) and pass in the context name as the `subject_name`. See the [`confluent_subject_config` resource documentation](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config#argument-reference) for more details.
 
 - `compatibility_level` - (Optional String) The global Schema Registry compatibility level. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The global Schema Registry compatibility group.

--- a/docs/resources/confluent_schema_registry_cluster_config.md
+++ b/docs/resources/confluent_schema_registry_cluster_config.md
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_schema_registry_cluster_config` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
+-> **Note:** To configure config at the context level, affecting all subjects created within that context, use `confluent_subject_config` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config) instead.
+
 - `compatibility_level` - (Optional String) The global Schema Registry compatibility level. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The global Schema Registry compatibility group.
 

--- a/docs/resources/confluent_schema_registry_cluster_config.md
+++ b/docs/resources/confluent_schema_registry_cluster_config.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_schema_registry_cluster_config` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
--> **Note:** To configure config at the context level, affecting all subjects created within that context, use `confluent_subject_config` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config) instead.
+-> **Note:** To configure a config at the context level, affecting all subjects created within that context, use `confluent_subject_config` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_subject_config) instead.
 
 - `compatibility_level` - (Optional String) The global Schema Registry compatibility level. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The global Schema Registry compatibility group.

--- a/docs/resources/confluent_subject_config.md
+++ b/docs/resources/confluent_subject_config.md
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 -> **Note:** If you want to reference the subject that is located in a custom context, use the following naming pattern: `:.contextName:subjectName`. For example, use `subject_name = ":.context1:test-subject"` to reference the subject named `test-subject` in the `context1` context, and use `subject_name = "test-subject"` to reference the subject named `test-subject` in the `default` context.
 
--> **Note:** To configure config at the context level, affecting all subjects created within that context, use the following naming pattern: `:.contextName:`. For example, to set the global configuration for the `context1` context, use `subject_name = ":.context1:"`.
+-> **Note:** To configure a config at the context level, affecting all subjects created within that context, use the following naming pattern: `:.contextName:`. For example, to set the global configuration for the `context1` context, use `subject_name = ":.context1:"`.
 
 `compatibility_level` - (Optional String) The Compatibility Level of the specified subject. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The Compatibility Group of the specified subject.

--- a/docs/resources/confluent_subject_config.md
+++ b/docs/resources/confluent_subject_config.md
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 -> **Note:** To configure a config at the context level, affecting all subjects created within that context, use the following naming pattern: `:.contextName:`. For example, to set the global configuration for the `context1` context, use `subject_name = ":.context1:"`.
 
-`compatibility_level` - (Optional String) The Compatibility Level of the specified subject. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
+- `compatibility_level` - (Optional String) The Compatibility Level of the specified subject. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The Compatibility Group of the specified subject.
 
 ## Attributes Reference

--- a/docs/resources/confluent_subject_config.md
+++ b/docs/resources/confluent_subject_config.md
@@ -86,7 +86,9 @@ The following arguments are supported:
 - `subject_name` - (Required String) The name of the subject (in other words, the namespace), representing the subject under which the schema will be registered, for example, `test-subject`.
 
 -> **Note:** If you want to reference the subject that is located in a custom context, use the following naming pattern: `:.contextName:subjectName`. For example, use `subject_name = ":.context1:test-subject"` to reference the subject named `test-subject` in the `context1` context, and use `subject_name = "test-subject"` to reference the subject named `test-subject` in the `default` context.
- 
+
+-> **Note:** To configure config at the context level, affecting all subjects created within that context, use the following naming pattern: `:.contextName:`. For example, to set the global configuration for the `context1` context, use `subject_name = ":.context1:"`.
+
 `compatibility_level` - (Optional String) The Compatibility Level of the specified subject. Accepted values are: `BACKWARD`, `BACKWARD_TRANSITIVE`, `FORWARD`, `FORWARD_TRANSITIVE`, `FULL`, `FULL_TRANSITIVE`, and `NONE`. See the [Compatibility Types](https://docs.confluent.io/platform/current/schema-registry/avro.html#compatibility-types) for more details.
 - `compatibility_group` - (Optional String) The Compatibility Group of the specified subject.
 


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Updated the docs.

Checklist
---------
NA

What
----
This PR updates TF docs to indicate how to configure configs at the global "context" level even though there're only 2 available APIs:
1. cluster-level API: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#config
2. subject-level API: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--config-(string-%20subject)

Blast Radius
----
None

References
----------
* https://confluentinc.atlassian.net/browse/CLI-3541
* https://confluentinc.atlassian.net/browse/DOCS-33540

Test & Review
-------------
* https://confluentinc.atlassian.net/browse/CLI-3541
* https://confluent.slack.com/archives/CM6PEBEGM/p1745536500407019?thread_ts=1745476395.681049&cid=CM6PEBEGM

![image](https://github.com/user-attachments/assets/ebc1e66a-4975-4733-923a-97836f6e5d6b)
![image](https://github.com/user-attachments/assets/311ff342-3bee-47ae-a4ee-962578102c1c)


Doc Preview Tool: https://registry.terraform.io/tools/doc-preview
