### PR TITLE
CLI-3546: Add new "force" attribute to confluent_schema_registry_cluster_mode, confluent_subject_mode resources

### DIFF
--- a/docs/resources/confluent_schema_registry_cluster_mode.md
+++ b/docs/resources/confluent_schema_registry_cluster_mode.md
@@ -78,7 +78,8 @@ The following arguments are supported:
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_kafka_cluster_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
-- `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
+- `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`. Defaults to `READWRITE`.
+- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference
 

--- a/docs/resources/confluent_schema_registry_cluster_mode.md
+++ b/docs/resources/confluent_schema_registry_cluster_mode.md
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_kafka_cluster_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
-- `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`. Defaults to `READWRITE`.
+- `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
 - `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference

--- a/docs/resources/confluent_schema_registry_cluster_mode.md
+++ b/docs/resources/confluent_schema_registry_cluster_mode.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_kafka_cluster_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
 - `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
-- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
+- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/cloud/current/sr/schema-linking.html). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference
 

--- a/docs/resources/confluent_subject_mode.md
+++ b/docs/resources/confluent_subject_mode.md
@@ -81,7 +81,7 @@ The following arguments are supported:
 !> **Warning:** Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_subject_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
 - `subject_name` - (Required String) The name of the subject (in other words, the namespace), representing the subject under which the schema will be registered, for example, `test-subject`.
-- `mode` - (Optional String) The mode of the specified subject. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`. Defaults to `READWRITE`.
+- `mode` - (Optional String) The mode of the specified subject. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
 - `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference

--- a/docs/resources/confluent_subject_mode.md
+++ b/docs/resources/confluent_subject_mode.md
@@ -81,7 +81,8 @@ The following arguments are supported:
 !> **Warning:** Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_subject_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
 - `subject_name` - (Required String) The name of the subject (in other words, the namespace), representing the subject under which the schema will be registered, for example, `test-subject`.
-- `mode` - (Optional String) The mode of the specified subject. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
+- `mode` - (Optional String) The mode of the specified subject. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`. Defaults to `READWRITE`.
+- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference
 

--- a/docs/resources/confluent_subject_mode.md
+++ b/docs/resources/confluent_subject_mode.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 - `subject_name` - (Required String) The name of the subject (in other words, the namespace), representing the subject under which the schema will be registered, for example, `test-subject`.
 - `mode` - (Optional String) The mode of the specified subject. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
-- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#schema-linking-cp-overview). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
+- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/cloud/current/sr/schema-linking.html). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
 
 ## Attributes Reference
 

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -59,6 +59,8 @@ const (
 	paramSubjectName                          = "subject_name"
 	paramHardDelete                           = "hard_delete"
 	paramHardDeleteDefaultValue               = false
+	paramForce                                = "force"
+	paramForceDefaultValue                    = false
 	paramRecreateOnUpdate                     = "recreate_on_update"
 	paramRecreateOnUpdateDefaultValue         = false
 	paramSkipValidationDuringPlan             = "skip_validation_during_plan"


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Added support for `force` attribute available in the SR API ([1](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--mode), [2](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--mode-(string-%20subject))) to the `confluent_schema_registry_cluster_mode` and `confluent_subject_mode` resources.


Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes the following errors:
```
Error: error creating Subject Mode: 422 Cannot import since found existing subjects; error code: 42205: Cannot import since found existing subjects; error code: 42205
```
and
```
Error: error creating Schema Registry Cluster Mode: 422 Cannot import since found existing subjects; error code: 42205: Cannot import since found existing subjects; error code: 42205
```

that occur when trying to `apply` any of the following TF configs:
```
# Scenario 1
resource "confluent_schema_registry_cluster_mode" "example" {
  mode  = "IMPORT"
}

# Scenario 2
resource "confluent_subject_mode" "example" {
  subject_name = ":.testContext:"
  mode         = "IMPORT"
}
```

which is a well documented SR API ([1](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--mode), [2](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--mode-(string-%20subject))) limitation:

![image](https://github.com/user-attachments/assets/37a765bd-d55e-4cae-85eb-ff2da71a2df9)

This PR allows a user to leverage this `force` query parameter:
```
# Scenario 1
resource "confluent_schema_registry_cluster_mode" "example" {
  mode  = "IMPORT"
  force        = true
}

# Scenario 2
resource "confluent_subject_mode" "example" {
  subject_name = ":.testContext:"
  mode         = "IMPORT"
  force        = true
}
```
such that the apply is successful.

Blast Radius
----
- Confluent Cloud customers who are using `confluent_schema_registry_cluster_mode ` data source and resource will be blocked.
- Confluent Cloud customers who are using `confluent_subject_mode ` data source and resource will be blocked.


References
----------
* https://confluentinc.atlassian.net/browse/CLI-3546

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1745651283029069

Test & Review
-------------
The code was copy pasted from a similar `hard_delete` attribute of the `confluent_schema` resource.