### PR TITLE
INC-2102: Resolve timeout errors for confluent_schema_exporter resource

### DIFF
--- a/docs/resources/confluent_schema_exporter.md
+++ b/docs/resources/confluent_schema_exporter.md
@@ -96,6 +96,8 @@ The following arguments are supported:
 - `status` - (Optional String) The status of the schema exporter. Accepted values are: `RUNNING` and `PAUSED`.
 - `reset_on_update` - (Optional Boolean) The flag to control whether to reset the exporter when updating configs. Defaults to `false`.
 
+-> **Note:** When Schema Registry API returns `STARTING` state, it will still be recorded as `status = RUNNING` in TF state.
+
 ## Attributes Reference
 
 In addition to the preceding arguments, the following attributes are exported:

--- a/docs/resources/confluent_schema_exporter.md
+++ b/docs/resources/confluent_schema_exporter.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 - `status` - (Optional String) The status of the schema exporter. Accepted values are: `RUNNING` and `PAUSED`.
 - `reset_on_update` - (Optional Boolean) The flag to control whether to reset the exporter when updating configs. Defaults to `false`.
 
--> **Note:** When Schema Registry API returns `STARTING` state for a Schema Exporter, it will still be recorded as `status = RUNNING` in TF state.
+-> **Note:** When Schema Registry API returns `STARTING` state for a Schema Exporter, it will still be recorded as `status = "RUNNING"` in TF state.
 
 ## Attributes Reference
 

--- a/docs/resources/confluent_schema_exporter.md
+++ b/docs/resources/confluent_schema_exporter.md
@@ -96,8 +96,6 @@ The following arguments are supported:
 - `status` - (Optional String) The status of the schema exporter. Accepted values are: `RUNNING` and `PAUSED`.
 - `reset_on_update` - (Optional Boolean) The flag to control whether to reset the exporter when updating configs. Defaults to `false`.
 
--> **Note:** When the Schema Registry API returns the `STARTING` state for a Schema Exporter, it will still be recorded as `status = "RUNNING"` in the Terraform state.
-
 ## Attributes Reference
 
 In addition to the preceding arguments, the following attributes are exported:

--- a/docs/resources/confluent_schema_exporter.md
+++ b/docs/resources/confluent_schema_exporter.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 - `status` - (Optional String) The status of the schema exporter. Accepted values are: `RUNNING` and `PAUSED`.
 - `reset_on_update` - (Optional Boolean) The flag to control whether to reset the exporter when updating configs. Defaults to `false`.
 
--> **Note:** When Schema Registry API returns `STARTING` state, it will still be recorded as `status = RUNNING` in TF state.
+-> **Note:** When Schema Registry API returns `STARTING` state for a Schema Exporter, it will still be recorded as `status = RUNNING` in TF state.
 
 ## Attributes Reference
 

--- a/docs/resources/confluent_schema_exporter.md
+++ b/docs/resources/confluent_schema_exporter.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 - `status` - (Optional String) The status of the schema exporter. Accepted values are: `RUNNING` and `PAUSED`.
 - `reset_on_update` - (Optional Boolean) The flag to control whether to reset the exporter when updating configs. Defaults to `false`.
 
--> **Note:** When Schema Registry API returns `STARTING` state for a Schema Exporter, it will still be recorded as `status = "RUNNING"` in TF state.
+-> **Note:** When the Schema Registry API returns the `STARTING` state for a Schema Exporter, it will still be recorded as `status = "RUNNING"` in the Terraform state.
 
 ## Attributes Reference
 

--- a/internal/provider/resource_schema_exporter.go
+++ b/internal/provider/resource_schema_exporter.go
@@ -47,6 +47,8 @@ const (
 	basicAuthUserInfoConfig               = "basic.auth.user.info"
 
 	schemaExporterAPICreateTimeout = 4 * time.Hour
+
+	stateStarting = "STARTING"
 )
 
 var standardConfigs = []string{basicAuthUserInfoConfig, schemaRegistryUrlConfig, basicAuthCredentialsSourceConfig}
@@ -289,7 +291,7 @@ func readSchemaExporterAndSetAttributes(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return nil, fmt.Errorf("error creating Schema Exporter Status: %s", createDescriptiveError(err))
 	}
-	if status.GetState() == stateRunning {
+	if status.GetState() == stateRunning || status.GetState() == stateStarting {
 		if err := d.Set(paramStatus, stateRunning); err != nil {
 			return nil, err
 		}

--- a/internal/provider/resource_schema_exporter_provider_block_test.go
+++ b/internal/provider/resource_schema_exporter_provider_block_test.go
@@ -105,7 +105,7 @@ func TestAccSchemaExporterWithEnhancedProviderBlock(t *testing.T) {
 			http.StatusCreated,
 		))
 
-	runningStatusResponse, _ := ioutil.ReadFile("../testdata/schema_exporter/running_status.json")
+	runningStatusResponse, _ := ioutil.ReadFile("../testdata/schema_exporter/starting_status.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedSchemaExporterStatusUrlPath)).
 		InScenario(schemaExporterResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateSchemaExporterHasBeenCreated).

--- a/internal/provider/resource_schema_exporter_test.go
+++ b/internal/provider/resource_schema_exporter_test.go
@@ -121,7 +121,7 @@ func TestAccSchemaExporter(t *testing.T) {
 			http.StatusCreated,
 		))
 
-	runningStatusResponse, _ := ioutil.ReadFile("../testdata/schema_exporter/running_status.json")
+	runningStatusResponse, _ := ioutil.ReadFile("../testdata/schema_exporter/starting_status.json")
 	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedSchemaExporterStatusUrlPath)).
 		InScenario(schemaExporterResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateSchemaExporterHasBeenCreated).

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -1429,10 +1429,7 @@ func schemaExporterProvisionStatus(ctx context.Context, c *SchemaRegistryRestCli
 			return nil, stateUnknown, err
 		}
 
-		if status.GetState() == "STARTING" {
-			return nil, stateProvisioning, nil
-		}
-		if status.GetState() == "RUNNING" || status.GetState() == "PAUSED" {
+		if status.GetState() == stateStarting || status.GetState() == stateRunning || status.GetState() == statePaused {
 			return status, stateReady, nil
 		}
 

--- a/internal/testdata/schema_exporter/starting_status.json
+++ b/internal/testdata/schema_exporter/starting_status.json
@@ -1,6 +1,6 @@
 {
   "name": "exporter1",
-  "state": "RUNNING",
+  "state": "STARTING",
   "offset": 15685259,
   "ts": 1690356186895
 }


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Updated `confluent_schema_exporter` resource to resolve time out issues for create and update operations.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR updates the confluent_schema_exporter resource to treat the "STARTING" status as "RUNNING" to speed up the provisioning and update processes.



Blast Radius
----
- Confluent Cloud customers who are using `confluent_schema_exporter` resource will be blocked.

References
----------
NA

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1746559869336479
