### PR TITLE
INC-2201: Resolve "Error: error waiting for Schema Exporter "lsrc-abc123/exporter" to provision: couldn't find resource (21 retries)

### DIFF
--- a/internal/provider/resource_schema_exporter.go
+++ b/internal/provider/resource_schema_exporter.go
@@ -46,7 +46,7 @@ const (
 	schemaRegistryUrlConfig               = "schema.registry.url"
 	basicAuthUserInfoConfig               = "basic.auth.user.info"
 
-	schemaExporterAPICreateTimeout = 4 * time.Hour
+	schemaExporterAPICreateTimeout = 12 * time.Hour
 )
 
 var standardConfigs = []string{basicAuthUserInfoConfig, schemaRegistryUrlConfig, basicAuthCredentialsSourceConfig}

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -1430,7 +1430,7 @@ func schemaExporterProvisionStatus(ctx context.Context, c *SchemaRegistryRestCli
 		}
 
 		if status.GetState() == "STARTING" {
-			return nil, stateProvisioning, nil
+			return status, stateProvisioning, nil
 		}
 		if status.GetState() == "RUNNING" || status.GetState() == "PAUSED" {
 			return status, stateReady, nil


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Resolved "Error: error waiting for Schema Exporter "lsrc-abc123/exporter" to provision: couldn't find resource (21 retries).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Even though the code specified 4 hour timeout for schema exporter creation:
* https://github.com/confluentinc/terraform-provider-confluent/blob/v2.24.0/internal/provider/resource_schema_exporter.go#L120
* https://github.com/confluentinc/terraform-provider-confluent/blame/v2.24.0/internal/provider/utils_wait.go#L548
* https://github.com/confluentinc/terraform-provider-confluent/blob/v2.24.0/internal/provider/resource_schema_exporter.go#L48

we could still observe this issue where TF was timing out after just 10 minutes consistently when creating a schema exporter instance:
```
confluent_schema_exporter.main: Still creating... [9m51s elapsed]
confluent_schema_exporter.main: Still creating... [10m1s elapsed]
╷
│ Error: error waiting for Schema Exporter "lsrc-abc123/exporter1" to provision: couldn't find resource (21 retries)
│ 
│   with confluent_schema_exporter.main,
│   on main.tf line 28, in resource "confluent_schema_exporter" "main":
│   28: resource "confluent_schema_exporter" "main" {
```

Interestingly enough, the exact same waiting code worked for other TF resources like confluent_network:
* https://github.com/confluentinc/terraform-provider-confluent/blob/v2.24.0/internal/provider/resource_network.go#L307
* https://github.com/confluentinc/terraform-provider-confluent/blob/v2.24.0/internal/provider/utils_wait.go#L228

First, we setup a mock server that returns hardcoded responses. More specifically, it returns 
```
{
  "name": "exporter1",
  "state": "STARTING",
  "offset": 15685259,
  "ts": 1690356186895
}
```
for 25 minutes, and then starts returning:
```
{
  "name": "exporter1",
  "state": "RUNNING",
  "offset": 15685259,
  "ts": 1690356186895
}
```

The 25-minute threshold is used because 25 minutes is the default resource timeout in Terraform, whereas 10 minutes is the threshold the user is encountering.

Then we used the following TF config that uses TF Provider version 2.24.0 to point it against this mock server:
```
terraform {
  required_providers {
    confluent = {
      source  = "confluentinc/confluent"
      version = "2.24.0"
    }
  }
}

provider "confluent" {
  cloud_api_key    = "foo"
  cloud_api_secret = "bar"
  endpoint         = "http://127.0.0.1:3000"
}

resource "confluent_schema_exporter" "main" {
  schema_registry_cluster {
    id = "lsrc-abc123"
  }
  rest_endpoint = "http://127.0.0.1:3000"
  credentials {
    key    = "car"
    secret = "bar"
  }

  name = "exporter1"
  subjects = ["foo"]

  destination_schema_registry_cluster {
    rest_endpoint = "https://psrc-1111.us-east-2.aws.confluent.cloud"
    credentials {
      key    = "car"
      secret = "bar"
    }
  }
}
```

and we could reproduce 10 minute timeout:
```
✗ python mock_server.py
 * Serving Flask app 'mock_server'
 * Debug mode: on
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:3000/
Press CTRL+C to quit
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 474-849-804
{"config":{"basic.auth.credentials.source":"USER_INFO","basic.auth.user.info":"[hidden]","schema.registry.url":"https://psrc-4xgzx.us-east-2.aws.confluent.cloud/"},"context":"tc","contextType":"CUSTOM","name":"exporter1","subjects":["foo"]}
127.0.0.1 - - [08/May/2025 13:11:55] "POST /exporters HTTP/1.1" 201 -
{"name":"exporter1","offset":15685259,"state":"STARTING","ts":1690356186895}
127.0.0.1 - - [08/May/2025 13:11:55] "GET /exporters/exporter1/status HTTP/1.1" 200 -
...
```

```
confluent_schema_exporter.main: Still creating... [9m40s elapsed]
confluent_schema_exporter.main: Still creating... [9m50s elapsed]
confluent_schema_exporter.main: Still creating... [10m0s elapsed]
╷
│ Error: error waiting for Schema Exporter "lsrc-abc123/exporter1" to provision: couldn't find resource (21 retries)
│ 
│   with confluent_schema_exporter.main,
│   on main.tf line 16, in resource "confluent_schema_exporter" "main":
│   16: resource "confluent_schema_exporter" "main" {
│ 
```

We created a similar mock server for Networking API and verified that TF doesn't time out after 10 minutes when creating `confluent_network` resource: [link](https://confluent.slack.com/archives/C08R8B0DZFE/p1746737995647179?thread_ts=1746731991.692959&cid=C08R8B0DZFE)

After comparing the waiting code for confluent_network and confluent_schema_exporter (tag: 2.24.0) we didn't find pretty much any difference.

Adding logs didn't help either, as the output looked good:
```
schemaExporterAPICreateTimeout=14400000000000: tf_rpc=ApplyResourceChange schema_exporter_id=lsrc-abc123/exporter1 tf_provider_addr=provider tf_req_id=6b7df8c4-6283-b1f4-db7d-0006eb4c4951 tf_resource_type=confluent_schema_exporter @caller=/Users/linou/work/terraform-provider-confluent/internal/provider/utils_wait.go:544 @module=provider timestamp=2025-05-08T14:42:19.480-0700
networkingAPICreateTimeout=7200000000000: @module=provider schema_exporter_id=lsrc-abc123/exporter1 tf_provider_addr=provider tf_req_id=6b7df8c4-6283-b1f4-db7d-0006eb4c4951 @caller=/Users/linou/work/terraform-provider-confluent/internal/provider/utils_wait.go:545 tf_resource_type=confluent_schema_exporter tf_rpc=ApplyResourceChange timestamp=2025-05-08T14:42:19.480-0700
Context deadline is 2025-05-08T18:42:19-07:00 (in 3h59m59.990411173s): tf_req_id=6b7df8c4-6283-b1f4-db7d-0006eb4c4951 tf_resource_type=confluent_schema_exporter tf_rpc=ApplyResourceChange tf_provider_addr=provider @caller=/Users/linou/work/terraform-provider-confluent/internal/provider/utils_wait.go:549 @module=provider schema_exporter_id=lsrc-abc123/exporter1 timestamp=2025-05-08T14:42:19.480-0700
```

But once we updated `PollInterval: 30 * time.Second` to be `PollInterval: 1 * time.Minute`, we could see that TF timed out only after 21 minutes:
```
confluent_schema_exporter.main: Still creating... [19m50s elapsed]
confluent_schema_exporter.main: Still creating... [20m0s elapsed]
╷
│ Error: error waiting for Schema Exporter "lsrc-abc123/exporter1" to provision: couldn't find resource (21 retries)
│ 
│   with confluent_schema_exporter.main,
│   on main.tf line 28, in resource "confluent_schema_exporter" "main":
│   28: resource "confluent_schema_exporter" "main" {
```

Then we realized there's some magic number 20 or 21 involved (21 minute / 1 minute, 10 minute / 30 seconds) and looked into https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/retry/state.go#L63-L66 and realized it could be related as the error message also said: `couldn't find resource (21 retries)`:
```
if conf.NotFoundChecks == 0 {
	conf.NotFoundChecks = 20
}

if res == nil {
	notfoundTick++
	if notfoundTick > conf.NotFoundChecks {
		result.Error = &NotFoundError{...}
		return
	}
}

func (e *NotFoundError) Error() string {
	if e.Message != "" {
		return e.Message
	}

	if e.Retries > 0 {
		return fmt.Sprintf("couldn't find resource (%d retries)", e.Retries)
	}

	return "couldn't find resource"
}
```

Then we realized that `if res == nil { notfoundTick++ ...` refers to the first element of the tuple:
```
func schemaExporterProvisionStatus(ctx context.Context, c *SchemaRegistryRestClient, id, name string) resource.StateRefreshFunc {
	return func() (result interface{}, s string, err error) {
		if status.GetState() == "STARTING" {
			return nil, stateProvisioning, nil
		}
		if status.GetState() == "RUNNING" || status.GetState() == "PAUSED" {
			return status, stateReady, nil
		}
```

and then we immediately realized that 
```
if status.GetState() == "STARTING" { return nil, stateProvisioning, nil }
```
Essentially, the TF SDK hits the limit (NotFoundChecks > 20) and returns a NotFound error, ending the wait early — regardless of the actual 4-hour timeout.

Note: separately, we updated 4-hour timeout to 12-hour timeout to have some additional buffer in case an environment contains a lot of schemas ([Slack thread](https://confluent.slack.com/archives/C08RH3SMGN9/p1746747755563969?thread_ts=1746745372.096019&cid=C08RH3SMGN9)).

Blast Radius
----
- Confluent Cloud customers who are using `confluent_schema_exporter` resource/data-source will be blocked.

References
----------
* https://confluent.slack.com/archives/C08RH3SMGN9/p1746744628052739

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1746746207719159

#### Mock Server Code:
```
from flask import Flask, jsonify, request, make_response
import json
import os
import sys
import time

app = Flask(__name__)

STATUS_TRANSITION_SECONDS = 25 * 60  # 25 minutes
created_at = None  # Tracks creation time of the single exporter

def load_mock_data(filename):
    """Load mock data from file"""
    if not os.path.exists(filename):
        print(f"Error: File '{filename}' not found!", file=sys.stderr)
        sys.exit(1)

    try:
        with open(filename, 'r') as f:
            return json.load(f)
    except json.JSONDecodeError:
        print(f"Error: Invalid JSON in '{filename}'!", file=sys.stderr)
        sys.exit(1)

@app.after_request
def log_response(response):
    """Log the JSON response in one line"""
    if response.content_type == 'application/json' and response.get_data():
        try:
            data = json.loads(response.get_data())
            print(json.dumps(data, separators=(',', ':')))  # compact form
        except Exception as e:
            print(f"[Log Error] Failed to log response: {e}", file=sys.stderr)
    return response

@app.route('/exporters', methods=['POST'])
def create_exporter():
    """Simulate creating the single exporter"""
    global created_at
    created_at = time.time()
    return jsonify(load_mock_data("created_exporter.json")), 201

if __name__ == '__main__':
    app.run(debug=True, port=3000)
```
