### PR TITLE
INC-2161: Resolve forced replacement when updating the value of the disable_wait_for_ready attribute

### DIFF
--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -96,7 +96,10 @@ func apiKeyResource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
+				// Suppress any diffs, as this attribute only applies during resource creation.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 		// TODO: APIT-2820

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -96,6 +96,7 @@ func apiKeyResource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 				// Suppress any diffs, as this attribute only applies during resource creation.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return true

--- a/internal/provider/resource_api_key_test.go
+++ b/internal/provider/resource_api_key_test.go
@@ -898,7 +898,7 @@ func testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafk
 		}
 		managed_resource {
 			id = "%s"
-           api_version = "%s"
+			api_version = "%s"
 			kind = "%s"
 			environment {
 				id = "%s"

--- a/internal/provider/resource_api_key_test.go
+++ b/internal/provider/resource_api_key_test.go
@@ -55,6 +55,9 @@ const (
 	scenarioStateTableflowApiKeyHasBeenUpdated = "The new tableflow api key's description and display_name have been just updated"
 	scenarioStateTableflowApiKeyHasBeenDeleted = "The new tableflow api key has been deleted"
 	tableflowApiKeyScenarioName                = "confluent_api_key (Tableflow API Key) Resource Lifecycle"
+
+	disableWaitForReadyFalse = "false"
+	disableWaitForReadyTrue  = "true"
 )
 
 func TestAccKafkaApiKey(t *testing.T) {
@@ -216,12 +219,13 @@ func TestAccKafkaApiKey(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId),
+				Config: testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId, disableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullKafkaApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "id", "7FJIYKQ4SGQDQ72H"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "display_name", kafkaApiKeyDisplayName),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "description", kafkaApiKeyDescription),
+					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -251,13 +255,13 @@ func TestAccKafkaApiKey(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyUpdatedDisplayName, kafkaApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId),
+				Config: testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyUpdatedDisplayName, kafkaApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId, disableWaitForReadyTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullKafkaApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "id", "7FJIYKQ4SGQDQ72H"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "display_name", kafkaApiKeyUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "description", kafkaApiKeyUpdatedDescription),
-					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "disable_wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullKafkaApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -412,12 +416,13 @@ func TestAccFlinkApiKey(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyDisplayName, flinkApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId),
+				Config: testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyDisplayName, flinkApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId, disableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullFlinkApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "id", "AK4NBR7MUYHVJMHW"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "display_name", flinkApiKeyDisplayName),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "description", flinkApiKeyDescription),
+					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -447,13 +452,13 @@ func TestAccFlinkApiKey(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyUpdatedDisplayName, flinkApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId),
+				Config: testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyUpdatedDisplayName, flinkApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId, disableWaitForReadyTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullFlinkApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "id", "AK4NBR7MUYHVJMHW"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "display_name", flinkApiKeyUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "description", flinkApiKeyUpdatedDescription),
-					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "disable_wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullFlinkApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -620,12 +625,13 @@ func TestAccTableflowApiKey(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind),
+				Config: testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind, disableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullTableflowApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "id", "HRVR6K4VMXYD2LDZ"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "display_name", tableflowApiKeyDisplayName),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "description", tableflowApiKeyDescription),
+					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -644,13 +650,13 @@ func TestAccTableflowApiKey(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyUpdatedDisplayName, tableflowApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind),
+				Config: testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyUpdatedDisplayName, tableflowApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind, disableWaitForReadyTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullTableflowApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "id", "HRVR6K4VMXYD2LDZ"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "display_name", tableflowApiKeyUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "description", tableflowApiKeyUpdatedDescription),
-					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "disable_wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullTableflowApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -802,12 +808,13 @@ func TestAccCloudApiKey(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, ownerId, ownerApiVersion, ownerKind),
+				Config: testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, ownerId, ownerApiVersion, ownerKind, disableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullCloudApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "id", "HRVR6K4VMXYD2LDZ"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "display_name", cloudApiKeyDisplayName),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "description", cloudApiKeyDescription),
+					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -823,13 +830,13 @@ func TestAccCloudApiKey(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyUpdatedDisplayName, cloudApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind),
+				Config: testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyUpdatedDisplayName, cloudApiKeyUpdatedDescription, ownerId, ownerApiVersion, ownerKind, disableWaitForReadyTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApiKeyExists(fullCloudApiKeyResourceLabel),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "id", "HRVR6K4VMXYD2LDZ"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "display_name", cloudApiKeyUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "description", cloudApiKeyUpdatedDescription),
-					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "disable_wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.#", "1"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.0.%", "3"),
 					resource.TestCheckResourceAttr(fullCloudApiKeyResourceLabel, "owner.0.api_version", "iam/v2"),
@@ -852,7 +859,6 @@ func TestAccCloudApiKey(t *testing.T) {
 	// Combine both stubs into a single check since it doesn't differentiate between states
 	checkStubCount(t, wiremockClient, listEnvsOrgApi401Stub, "GET /org/v2/environments", 2)
 }
-
 func testAccCheckApiKeyDestroy(s *terraform.State) error {
 	c := testAccProvider.Meta().(*Client)
 	// Loop through the resources in state, verifying each kafka api key is destroyed
@@ -876,7 +882,7 @@ func testAccCheckApiKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId string) string {
+func testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId, disableWaitForReady string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint = "%s"
@@ -884,6 +890,7 @@ func testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafk
 	resource "confluent_api_key" "%s" {
 		display_name = "%s"
 		description = "%s"
+		disable_wait_for_ready = %s
 		owner {
 			id = "%s"
 			api_version = "%s"
@@ -891,19 +898,19 @@ func testAccCheckKafkaApiKeyConfig(mockServerUrl, kafkaApiKeyResourceLabel, kafk
 		}
 		managed_resource {
 			id = "%s"
-            api_version = "%s"
+           api_version = "%s"
 			kind = "%s"
 			environment {
 				id = "%s"
 			}
 		}
 	}
-	`, mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId)
+	`, mockServerUrl, kafkaApiKeyResourceLabel, kafkaApiKeyDisplayName, kafkaApiKeyDescription, disableWaitForReady, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId)
 }
 
 func testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyDisplayName,
 	flinkApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion,
-	resourceKind, environmentId string) string {
+	resourceKind, environmentId, disableWaitForReady string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint = "%s"
@@ -911,6 +918,7 @@ func testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flin
 	resource "confluent_api_key" "%s" {
 		display_name = "%s"
 		description = "%s"
+		disable_wait_for_ready = %s
 		owner {
 			id = "%s"
 			api_version = "%s"
@@ -925,27 +933,27 @@ func testAccCheckFlinkApiKeyConfig(mockServerUrl, flinkApiKeyResourceLabel, flin
 			}
 		}
 	}
-	`, mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyDisplayName, flinkApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId)
+	`, mockServerUrl, flinkApiKeyResourceLabel, flinkApiKeyDisplayName, flinkApiKeyDescription, disableWaitForReady, ownerId, ownerApiVersion, ownerKind, resourceId, resourceApiVersion, resourceKind, environmentId)
 }
 
-func testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, ownerId, ownerApiVersion, ownerKind string) string {
+func testAccCheckCloudApiKeyConfig(mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, ownerId, ownerApiVersion, ownerKind, disableWaitForReady string) string {
 	return fmt.Sprintf(`
-	provider "confluent" {
-		endpoint = "%s"
-	}
-	resource "confluent_api_key" "%s" {
-		display_name = "%s"
-		description = "%s"
-		owner {
-			id = "%s"
-			api_version = "%s"
-			kind = "%s"
+		provider "confluent" {
+			endpoint = "%s"
 		}
-	}
-	`, mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, ownerId, ownerApiVersion, ownerKind)
+		resource "confluent_api_key" "%s" {
+			display_name = "%s"
+			description = "%s"
+			disable_wait_for_ready = %s
+			owner {
+				id = "%s"
+				api_version = "%s"
+				kind = "%s"
+			}
+		}
+		`, mockServerUrl, cloudApiKeyResourceLabel, cloudApiKeyDisplayName, cloudApiKeyDescription, disableWaitForReady, ownerId, ownerApiVersion, ownerKind)
 }
-
-func testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind string) string {
+func testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind, disableWaitForReady string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint = "%s"
@@ -953,6 +961,7 @@ func testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLab
 	resource "confluent_api_key" "%s" {
 		display_name = "%s"
 		description = "%s"
+		disable_wait_for_ready = %s
 		owner {
 			id = "%s"
 			api_version = "%s"
@@ -964,7 +973,7 @@ func testAccCheckTableflowApiKeyConfig(mockServerUrl, tableflowApiKeyResourceLab
 			kind = "%s"
 		}
 	}
-	`, mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind)
+	`, mockServerUrl, tableflowApiKeyResourceLabel, tableflowApiKeyDisplayName, tableflowApiKeyDescription, disableWaitForReady, ownerId, ownerApiVersion, ownerKind, resourceApiVersion, resourceId, resourceKind)
 }
 
 func testAccCheckApiKeyExists(n string) resource.TestCheckFunc {

--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -68,6 +68,7 @@ func roleBindingResource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 				// Suppress any diffs, as this attribute only applies during resource creation.
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return true

--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -68,7 +68,10 @@ func roleBindingResource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
+				// Suppress any diffs, as this attribute only applies during resource creation.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 		},
 	}

--- a/internal/provider/resource_role_binding_test.go
+++ b/internal/provider/resource_role_binding_test.go
@@ -33,10 +33,12 @@ const (
 	roleBindingId                          = "rb-OOXL7"
 	roleBindingUrlPath                     = "/iam/v2/role-bindings/rb-OOXL7"
 
-	rbPrincipal     = "User:u-vr99n5"
-	rbRolename      = "CloudClusterAdmin"
-	rbCrn           = "crn://confluent.cloud/organization=0d9c5d94-e4fe-44ec-9cf1-bd99761fca75/environment=env-ym2y0k/cloud-cluster=lkc-xrk0ng"
-	rbResourceLabel = "test_rb_resource_label"
+	rbPrincipal                = "User:u-vr99n5"
+	rbRolename                 = "CloudClusterAdmin"
+	rbCrn                      = "crn://confluent.cloud/organization=0d9c5d94-e4fe-44ec-9cf1-bd99761fca75/environment=env-ym2y0k/cloud-cluster=lkc-xrk0ng"
+	rbResourceLabel            = "test_rb_resource_label"
+	rbDisableWaitForReadyFalse = "false"
+	rbDisableWaitForReadyTrue  = "true"
 )
 
 func TestAccRoleBinding(t *testing.T) {
@@ -108,14 +110,25 @@ func TestAccRoleBinding(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn),
+				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, rbDisableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleBindingExists(fullRbResourceLabel),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "id", roleBindingId),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "principal", rbPrincipal),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "role_name", rbRolename),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "crn_pattern", rbCrn),
-					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", "false"),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", rbDisableWaitForReadyFalse),
+				),
+			},
+			{
+				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, rbDisableWaitForReadyTrue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleBindingExists(fullRbResourceLabel),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "id", roleBindingId),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "principal", rbPrincipal),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "role_name", rbRolename),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "crn_pattern", rbCrn),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", rbDisableWaitForReadyFalse),
 				),
 			},
 			{
@@ -154,7 +167,7 @@ func testAccCheckRoleBindingDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckRoleBindingConfig(mockServerUrl, label, principal, roleName, crn string) string {
+func testAccCheckRoleBindingConfig(mockServerUrl, label, principal, roleName, crn, disableWaitForReady string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint = "%s"
@@ -163,8 +176,9 @@ func testAccCheckRoleBindingConfig(mockServerUrl, label, principal, roleName, cr
 		principal = "%s"
 		role_name = "%s"
 		crn_pattern = "%s"
+        disable_wait_for_ready = %s
 	}
-	`, mockServerUrl, label, principal, roleName, crn)
+	`, mockServerUrl, label, principal, roleName, crn, disableWaitForReady)
 }
 
 func testAccCheckRoleBindingExists(n string) resource.TestCheckFunc {

--- a/internal/provider/resource_role_binding_test.go
+++ b/internal/provider/resource_role_binding_test.go
@@ -174,7 +174,7 @@ func testAccCheckRoleBindingConfig(mockServerUrl, label, principal, roleName, cr
 		principal = "%s"
 		role_name = "%s"
 		crn_pattern = "%s"
-        disable_wait_for_ready = %s
+		disable_wait_for_ready = %s
 	}
 	`, mockServerUrl, label, principal, roleName, crn, disableWaitForReady)
 }

--- a/internal/provider/resource_role_binding_test.go
+++ b/internal/provider/resource_role_binding_test.go
@@ -33,12 +33,10 @@ const (
 	roleBindingId                          = "rb-OOXL7"
 	roleBindingUrlPath                     = "/iam/v2/role-bindings/rb-OOXL7"
 
-	rbPrincipal                = "User:u-vr99n5"
-	rbRolename                 = "CloudClusterAdmin"
-	rbCrn                      = "crn://confluent.cloud/organization=0d9c5d94-e4fe-44ec-9cf1-bd99761fca75/environment=env-ym2y0k/cloud-cluster=lkc-xrk0ng"
-	rbResourceLabel            = "test_rb_resource_label"
-	rbDisableWaitForReadyFalse = "false"
-	rbDisableWaitForReadyTrue  = "true"
+	rbPrincipal     = "User:u-vr99n5"
+	rbRolename      = "CloudClusterAdmin"
+	rbCrn           = "crn://confluent.cloud/organization=0d9c5d94-e4fe-44ec-9cf1-bd99761fca75/environment=env-ym2y0k/cloud-cluster=lkc-xrk0ng"
+	rbResourceLabel = "test_rb_resource_label"
 )
 
 func TestAccRoleBinding(t *testing.T) {
@@ -110,25 +108,25 @@ func TestAccRoleBinding(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, rbDisableWaitForReadyFalse),
+				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, disableWaitForReadyFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleBindingExists(fullRbResourceLabel),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "id", roleBindingId),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "principal", rbPrincipal),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "role_name", rbRolename),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "crn_pattern", rbCrn),
-					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", rbDisableWaitForReadyFalse),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 				),
 			},
 			{
-				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, rbDisableWaitForReadyTrue),
+				Config: testAccCheckRoleBindingConfig(mockServerUrl, rbResourceLabel, rbPrincipal, rbRolename, rbCrn, disableWaitForReadyTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleBindingExists(fullRbResourceLabel),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "id", roleBindingId),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "principal", rbPrincipal),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "role_name", rbRolename),
 					resource.TestCheckResourceAttr(fullRbResourceLabel, "crn_pattern", rbCrn),
-					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", rbDisableWaitForReadyFalse),
+					resource.TestCheckResourceAttr(fullRbResourceLabel, "disable_wait_for_ready", disableWaitForReadyFalse),
 				),
 			},
 			{


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Resolved forced replacement when updating the value of the disable_wait_for_ready attribute

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR resolves forced replacement when updating the value of the `disable_wait_for_ready` attribute for `confluent_api_key` and `confluent_role_binding` resources.

**Why did we choose to implement DiffSuppressFunc instead of supporting in-place updates?**

Initially, we implemented in-place updates. However, we realized this approach can be confusing for users—Terraform would detect a drift, but the update would be a no-op, leading to unnecessary apply actions with no actual impact, other than updating the value of disable_wait_for_ready in the Terraform state. This creates a poor user experience by prompting users to apply a seemingly pointless change.

Instead, the best user experience is to suppress this drift altogether using DiffSuppressFunc, which avoids confusion and aligns with the principle of minimizing unnecessary diffs. This was a great recommendation by @channingdong.

Blast Radius
----
- Confluent Cloud customers who are using `confluent_api_key` and `confluent_role_binding` resources will be blocked.


References
----------
* https://confluentinc.atlassian.net/browse/INC-2161

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1747203166014879
