### PR TITLE
APIE-428: Update the confluent_cluster_link resource to allow specifying a custom value for the "topic.config.sync.include" configuration parameter.

### DIFF
--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -95,6 +95,7 @@ var editableClusterLinkSettings = []string{
 	"consumer.offset.sync.ms",
 	"mirror.start.offset.spec",
 	"topic.config.sync.ms",
+	"topic.config.sync.include",
 }
 
 func clusterLinkResource() *schema.Resource {


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Update the `confluent_cluster_link` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_cluster_link) to allow specifying a custom value for the "topic.config.sync.include" configuration parameter.

Checklist
---------

- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR updates the confluent_cluster_link resource to allow specifying a custom value for the "topic.config.sync.include" configuration parameter.

Blast Radius
----
- Confluent Cloud customers who are using `confluent_cluster_link` resource/data-source will be blocked.

References
----------
* https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/mirror-topics-cp.html#override-default-syncing-to-specify-independent-mirror-topic-behavior

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1749635391688899

Before this change, even specifying it was not possible as users could see this error:
```
➜  regular-bidirectional-cluster-link-rbac git:(update-cluster-link-resource) ✗ terraform apply -auto-approve
...
│ Error: error creating / updating Cluster Link: "topic.config.sync.include" cluster link setting is read-only and cannot be updated. Read https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/cluster-links-cc.html#configuring-cluster-link-behavior for more details.
│ 
│   with confluent_cluster_link.east-to-west,
│   on main.tf line 144, in resource "confluent_cluster_link" "east-to-west":
│  144:   config = {
│  145:     "topic.config.sync.include" = "max.message.bytes,cleanup.policy,message.timestamp.type,message.timestamp.difference.max.ms,min.compaction.lag.ms,max.compaction.lag.ms,min.insync.replicas"
│  146:   }
│ 
╵
```

In short, we tested 2 scenarios:

1. Specifying "topic.config.sync.include" during confluent_cluster_link creation.
2. Updating the value "topic.config.sync.include" cluster link setting:
```
  # confluent_cluster_link.west-to-east will be updated in-place
  ~ resource "confluent_cluster_link" "west-to-east" {
      ~ config          = {
          ~ "topic.config.sync.include" = "max.message.bytes,cleanup.policy,message.timestamp.type,message.timestamp.difference.max.ms,min.compaction.lag.ms,max.compaction.lag.ms,min.insync.replicas" -> "max.message.bytes,cleanup.policy,message.timestamp.type,message.timestamp.difference.max.ms,min.compaction.lag.ms,max.compaction.lag.ms"
        }
```
