### PR TITLE
Add descriptive error for 429

### DIFF
--- a/internal/provider/factory_utils.go
+++ b/internal/provider/factory_utils.go
@@ -228,11 +228,22 @@ func (f RetryableClientFactory) CreateRetryableClient() *http.Client {
 		retryClient.RetryMax = *f.maxRetries
 	}
 
+	retryClient.ErrorHandler = MyCustomErrorHandler
+
 	// Create a logger for retryablehttp
 	// This logger will be used to send retryablehttp's internal logs to tflog
 	retryClient.Logger = logger
 
 	return retryClient.StandardClient()
+}
+
+func MyCustomErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
+	if resp != nil {
+		if resp.StatusCode == 429 {
+			return resp, fmt.Errorf("error code 429: %v", err)
+		}
+	}
+	return resp, err
 }
 
 // Logger is used to log messages from retryablehttp.Client to tflog.

--- a/internal/provider/factory_utils.go
+++ b/internal/provider/factory_utils.go
@@ -228,7 +228,7 @@ func (f RetryableClientFactory) CreateRetryableClient() *http.Client {
 		retryClient.RetryMax = *f.maxRetries
 	}
 
-	retryClient.ErrorHandler = MyCustomErrorHandler
+	retryClient.ErrorHandler = customErrorHandler
 
 	// Create a logger for retryablehttp
 	// This logger will be used to send retryablehttp's internal logs to tflog
@@ -237,7 +237,7 @@ func (f RetryableClientFactory) CreateRetryableClient() *http.Client {
 	return retryClient.StandardClient()
 }
 
-func MyCustomErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
+func customErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
 	if resp != nil {
 		if resp.StatusCode == 429 {
 			return resp, fmt.Errorf("error code 429: %v", err)

--- a/internal/provider/factory_utils.go
+++ b/internal/provider/factory_utils.go
@@ -240,7 +240,7 @@ func (f RetryableClientFactory) CreateRetryableClient() *http.Client {
 func customErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
 	if resp != nil {
 		if resp.StatusCode == 429 {
-			return resp, fmt.Errorf("error code 429: %v", err)
+			return resp, fmt.Errorf("received HTTP 429 Too Many Requests: %v (URL: %s, Method: %s)", err, resp.Request.URL, resp.Request.Method)
 		}
 	}
 	return resp, err

--- a/internal/provider/factory_utils.go
+++ b/internal/provider/factory_utils.go
@@ -240,7 +240,7 @@ func (f RetryableClientFactory) CreateRetryableClient() *http.Client {
 func customErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
 	if resp != nil {
 		if resp.StatusCode == 429 {
-			return resp, fmt.Errorf("received HTTP 429 Too Many Requests: %v (URL: %s, Method: %s)", err, resp.Request.URL, resp.Request.Method)
+			return resp, fmt.Errorf("received HTTP 429 Too Many Requests: (URL: %s, Method: %s)", resp.Request.URL, resp.Request.Method)
 		}
 	}
 	return resp, err

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -894,7 +894,9 @@ func createDescriptiveError(err error, resp ...*http.Response) error {
 			}
 		}
 	}
-
+	if len(resp) > 0 && resp[0].StatusCode == 429 {
+		errorMessage = "Error code 429: " + errorMessage
+	}
 	// If a *http.Response was provided, and we could not parse Error object,
 	// read its *http.Response body to provide a more descriptive error message to avoid
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/53

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -894,9 +894,7 @@ func createDescriptiveError(err error, resp ...*http.Response) error {
 			}
 		}
 	}
-	if len(resp) > 0 && resp[0].StatusCode == 429 {
-		errorMessage = "Error code 429: " + errorMessage
-	}
+
 	// If a *http.Response was provided, and we could not parse Error object,
 	// read its *http.Response body to provide a more descriptive error message to avoid
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/53


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Add descriptive error message for status code 429
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
None. Only modifying error message for status code 429
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
https://confluentinc.atlassian.net/browse/APIE-425
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
For 429 status: 
![image](https://github.com/user-attachments/assets/83ea44eb-9a2a-4652-9750-b772cb7ae694)

For other status: 
![image](https://github.com/user-attachments/assets/d2c67e9e-f882-4aa4-b66c-3f6c3e2b37ee)

For 150 data source reads of environment:
1. Current behaviour
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/22b42c2d-76dd-4e2b-9fee-30d079de7ba3" />

2. New behaviour
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/51c577eb-0e74-426a-9db5-71c6dfc693c1" />

For 100 reads in both scenarios:
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/bf1809cb-a06a-4b68-830f-d26916e1a11c" />


<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
