### PR TITLE
#minor: prepare for v2.33.0 minor release: Set "sem-version go 1.22.7" in goreleaser-darwin-fips

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -27,6 +27,7 @@ blocks:
             - cd src/
             - ./make.bash -v
             - cd ../../
+            - sem-version go 1.22.7
             - export PATH=$(pwd)/go/bin:$PATH
             - export "GITHUB_TOKEN=$(gh auth token)"
             - export GOROOT=$(pwd)/go


### PR DESCRIPTION
### What
This PR updates `goreleaser.yml` to fix:

```
# internal/itoa00:15
compile: version "go1.23.10" does not match go tool version "go1.22.7"
```

### Note
We realized `goreleaser.yml` was missing `sem-version go 1.22.7` in the `goreleaser-darwin-fips` job.