### PR TITLE
#minor: prepare for v2.33.0 minor release: Fix CI failure during "goreleaser-darwin-fips" step

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -13,6 +13,9 @@ blocks:
       jobs:
         - name: goreleaser-darwin-fips
           commands:
+            - sudo chown -R semaphore $HOME
+            - sudo chmod -R 777 $HOME
+            - sudo sem-version go 1.22.7
             - checkout
             - cd ..
             - wget "https://go.dev/dl/go$(cat terraform-provider-confluent*/.go-version).src.tar.gz"
@@ -27,7 +30,6 @@ blocks:
             - cd src/
             - ./make.bash -v
             - cd ../../
-            - sudo sem-version go 1.22.7
             - export PATH=$(pwd)/go/bin:$PATH
             - export "GITHUB_TOKEN=$(gh auth token)"
             - export GOROOT=$(pwd)/go


### PR DESCRIPTION
### Context
* https://confluent.slack.com/archives/C09EP1SS3/p1751475467861449?thread_ts=1751411143.543079&cid=C09EP1SS3