### PR TITLE
#minor: prepare for v2.33.0 minor release: Update the commands order in the goreleaser-darwin-fips task

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -13,11 +13,11 @@ blocks:
       jobs:
         - name: goreleaser-darwin-fips
           commands:
-            - sudo sem-version go 1.22.7
             - sudo chown -R semaphore /Users/semaphore/.local/
             - sudo chmod -R 777 /Users/semaphore/.local/
             - sudo chown -R semaphore /Users/semaphore/.config/
             - sudo chmod -R 777 /Users/semaphore/.config/
+            - sudo sem-version go 1.22.7
             - checkout
             - cd ..
             - wget "https://go.dev/dl/go$(cat terraform-provider-confluent*/.go-version).src.tar.gz"


### PR DESCRIPTION
### Context
* https://confluent.slack.com/archives/C09EP1SS3/p1751482229512319?thread_ts=1751411143.543079&cid=C09EP1SS3