### PR TITLE
APIE-481: Update PR Template & Remove Unused Make Target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,6 @@ Checklist
 ---------
 <!-- 
 Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-For instructions, please refer to this Confluence page: https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/3938058831/
 -->
 - [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
 - [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.

--- a/Makefile
+++ b/Makefile
@@ -95,13 +95,6 @@ build: clean ## Build binary for current OS/ARCH
 	@ $(MAKE) --no-print-directory log-$@
 	$(GOBUILD) -o ./$(BUILD_DIR)/$(GOOS)-$(GOARCH)/$(NAME)
 
-.PHONY: build-all
-build-all: GOOS      = linux darwin
-build-all: GOARCH    = amd64
-build-all: clean ## Build binary for all OS/ARCH
-	@ $(MAKE) --no-print-directory log-$
-	@ ./scripts/build/build-all-osarch.sh "$(BUILD_DIR)" "$(NAME)" "$(VERSION)" "$(GOOS)" "$(GOARCH)"
-
 .PHONY: test
 test:
 	$(GOCMD) test ./...


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
NA

What
----
This PR addresses #707 and #708, namely, it 

* updates PR template (#707)
* removes `build-all` target that is no longer used anywhere in the codebase (#708)

Blast Radius
----
NA

References
----------
* https://confluentinc.atlassian.net/browse/APIE-481

Test & Review
-------------
We verified that the build-all target is not used anywhere by searching for exact matches in this project.
