### PR TITLE
Expanded kafka live testing + new network resource tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,21 +104,21 @@ testacc:
 	TF_LOG=debug TF_ACC=1 $(GOCMD) test $(TEST) -v $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 	@echo "finished testacc"
 
-# Live integration tests with group filtering support
+# Live integration tests with group filtering and concurrency support
 # Usage: make live-test TF_LIVE_TEST_GROUPS="core,kafka" or make live-test (for all)
 .PHONY: live-test
 live-test:
 	@echo "Running live integration tests against Confluent Cloud..."
 	@if [ -z "$(TF_LIVE_TEST_GROUPS)" ]; then \
-		echo "Running ALL live tests..."; \
-		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$" -tags="live_test,all" -timeout 1440m; \
+		echo "Running ALL live tests with parallel execution..."; \
+		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$" -tags="live_test,all" -timeout 1440m -parallel 100; \
 	else \
-		echo "Running live tests for groups: $(TF_LIVE_TEST_GROUPS)"; \
+		echo "Running live tests for groups: $(TF_LIVE_TEST_GROUPS) with parallel execution..."; \
 		TAGS="live_test"; \
 		for group in $$(echo "$(TF_LIVE_TEST_GROUPS)" | tr ',' ' '); do \
 			TAGS="$$TAGS,$$group"; \
 		done; \
-		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$" -tags="$$TAGS" -timeout 1440m; \
+		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$" -tags="$$TAGS" -timeout 1440m -parallel 100; \
 	fi
 	@echo "Finished running live integration tests against Confluent Cloud"
 

--- a/docs/LIVE_TESTING_TEMPLATE.md
+++ b/docs/LIVE_TESTING_TEMPLATE.md
@@ -15,32 +15,40 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccYourResourceLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
 	// Skip this test unless explicitly enabled
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
 	}
 
-	// Read credentials from environment variables
+	// Read credentials and configuration from environment variables (populated by Vault)
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
 
-	// Validate required environment variables
+	// Validate required environment variables are present
 	if apiKey == "" || apiSecret == "" {
 		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
 	}
 
-	// Use timestamped names to avoid conflicts
-	resourceName := fmt.Sprintf("tf-provider-live-test-%d", time.Now().Unix())
+	// Generate unique names for test resources to avoid conflicts
+	randomSuffix := rand.Intn(100000)
+	resourceDisplayName := fmt.Sprintf("tf-live-test-%d", randomSuffix)
+	resourceLabel := "test_resource"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -48,24 +56,30 @@ func TestAccYourResourceLive(t *testing.T) {
 		CheckDestroy:      testAccCheckYourResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckYourResourceLiveConfig(endpoint, resourceName, apiKey, apiSecret),
+				Config: testAccCheckYourResourceLiveConfig(endpoint, resourceLabel, resourceDisplayName, apiKey, apiSecret),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckYourResourceExists("confluent_your_resource.test"),
-					resource.TestCheckResourceAttr("confluent_your_resource.test", "display_name", resourceName),
+					testAccCheckYourResourceExists(fmt.Sprintf("confluent_your_resource.%s", resourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_your_resource.%s", resourceLabel), "display_name", resourceDisplayName),
 					// Add more checks as needed
 				),
 			},
 			{
-				ResourceName:      "confluent_your_resource.test",
+				ResourceName:      fmt.Sprintf("confluent_your_resource.%s", resourceLabel),
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Add ImportStateIdFunc if needed for complex import formats
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					resourceId := resources[fmt.Sprintf("confluent_your_resource.%s", resourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_your_resource.%s", resourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + resourceId, nil
+				},
 			},
 		},
 	})
 }
 
-func testAccCheckYourResourceLiveConfig(endpoint, resourceName, apiKey, apiSecret string) string {
+func testAccCheckYourResourceLiveConfig(endpoint, resourceLabel, resourceDisplayName, apiKey, apiSecret string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint         = "%s"
@@ -73,11 +87,42 @@ func testAccCheckYourResourceLiveConfig(endpoint, resourceName, apiKey, apiSecre
 		cloud_api_secret = "%s"
 	}
 
-	resource "confluent_your_resource" "test" {
+	resource "confluent_your_resource" "%s" {
 		display_name = "%s"
 		# Add other required fields
 	}
-	`, endpoint, apiKey, apiSecret, resourceName)
+	`, endpoint, apiKey, apiSecret, resourceLabel, resourceDisplayName)
+}
+
+func testAccCheckYourResourceExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckYourResourceDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "confluent_your_resource" {
+			continue
+		}
+
+		// In live tests, we can't easily check if the resource is actually destroyed
+		// without making API calls, so we just verify the resource is removed from state
+		if rs.Primary.ID != "" {
+			// This is normal - the resource should have an ID but be removed from the live environment
+			// The actual cleanup happens through the API calls during destroy
+		}
+	}
+	return nil
 }
 ```
 
@@ -119,14 +164,70 @@ make live-test
 
 ### 5. Best Practices
 
-1. **Always use timestamped names** to avoid resource conflicts
-2. **Test the full lifecycle**: Create → Read → Update → Import → Destroy
-3. **Use real API endpoints** and credentials from environment variables
-4. **Add proper cleanup** in destroy functions
-5. **Include meaningful assertions** in your checks
-6. **Handle import state formatting** correctly for complex resources
+#### Resource Naming
+- **Use `rand.Intn(100000)` for unique suffixes** instead of timestamps to avoid conflicts
+- **Use descriptive prefixes** like `tf-live-test-` for easy identification
+- **Separate resource labels from display names** for better test organization
 
-### 6. Environment Variables Required
+#### Test Structure
+- **Always use `t.Parallel()`** to enable parallel execution for I/O bound operations
+- **Test the full lifecycle**: Create → Read → Update → Import → Destroy
+- **Use real API endpoints** and credentials from environment variables
+- **Include meaningful assertions** in your checks
+- **Handle import state formatting** correctly for complex resources
+
+#### Error Handling
+- **Validate environment variables early** with clear error messages
+- **Use default endpoints** when not specified (`https://api.confluent.cloud`)
+- **Handle timing issues** for resources that take time to provision/destroy
+
+#### Cleanup and Destroy
+- **Keep destroy functions simple** for live tests - they just verify state removal
+- **Don't make API calls in destroy functions** - let Terraform handle the actual cleanup
+- **Comment that actual cleanup happens through API calls during destroy**
+
+### 6. Common Patterns
+
+#### Multiple Test Functions
+For resources with different configurations, create multiple test functions:
+```go
+// Test Basic configuration - simplest, fastest test
+func TestAccYourResourceBasicLive(t *testing.T) {
+	t.Parallel()
+	// ... basic configuration
+}
+
+// Test Standard configuration - production-ready with extended feature set
+func TestAccYourResourceStandardLive(t *testing.T) {
+	t.Parallel()
+	// ... standard configuration
+}
+
+// Test with specific features
+func TestAccYourResourceWithFeatureLive(t *testing.T) {
+	t.Parallel()
+	// ... feature-specific configuration
+}
+```
+
+#### Resource Dependencies
+When testing resources that depend on others (like schemas depending on environments):
+```go
+// Generate unique names for all resources
+randomSuffix := rand.Intn(100000)
+environmentResourceLabel := "test_env"
+environmentDisplayName := fmt.Sprintf("tf-test-env-%d", randomSuffix)
+resourceResourceLabel := "test_resource"
+resourceDisplayName := fmt.Sprintf("tf-test-resource-%d", randomSuffix)
+```
+
+#### Timing Considerations
+- **Some resources take time to provision** (e.g., Kafka clusters, schema registry clusters)
+- **Some resources take time to fully delete** (e.g., Kafka clusters with physical infrastructure)
+- **The provider handles most waiting internally** through wait functions
+- **Don't add manual sleeps** - rely on the provider's built-in timing logic
+
+### 7. Environment Variables Required
 
 All live tests expect these environment variables:
 - `TF_ACC_PROD=1` (to enable live tests)
@@ -134,6 +235,21 @@ All live tests expect these environment variables:
 - `CONFLUENT_CLOUD_API_SECRET` (from Vault)
 - `CONFLUENT_CLOUD_ENDPOINT` (usually `https://api.confluent.cloud`)
 
-### 7. Semaphore Integration
+### 8. Semaphore Integration
 
-Once your test is tagged properly, it will automatically be included in the appropriate Semaphore pipeline. The pipeline uses the `TF_LIVE_TEST_GROUPS` parameter to control which groups to run. 
+Once your test is tagged properly, it will automatically be included in the appropriate Semaphore pipeline. The pipeline uses the `TF_LIVE_TEST_GROUPS` parameter to control which groups to run.
+
+### 9. Troubleshooting Common Issues
+
+#### Timing Issues
+- **409 Conflict errors**: Usually indicate a resource is still being deleted. Ensure proper wait functions are implemented in the provider.
+- **Resource not found errors**: May indicate timing issues with provisioning. Check if the provider has appropriate wait functions.
+
+#### Resource Conflicts
+- **Name conflicts**: Ensure you're using unique random suffixes, not timestamps
+- **Resource limits**: Be aware of account limits for certain resource types
+
+#### Test Failures
+- **Intermittent failures**: Often due to timing issues or resource limits
+- **Import failures**: Check that ImportStateIdFunc correctly formats the resource ID
+- **Destroy failures**: Usually handled by Terraform, but check for dependency issues 

--- a/internal/provider/resource_environment_live_test.go
+++ b/internal/provider/resource_environment_live_test.go
@@ -18,14 +18,17 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccEnvironmentLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
 	// Skip this test unless explicitly enabled
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
@@ -35,13 +38,16 @@ func TestAccEnvironmentLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
 
 	// Validate required environment variables are present
 	if apiKey == "" || apiSecret == "" {
 		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
 	}
 
-	environmentDisplayName := fmt.Sprintf("tf-provider-live-test-%d", time.Now().Unix())
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
 	environmentResourceLabel := "test_live_env"
 	environmentSgPackage := "ESSENTIALS"
 

--- a/internal/provider/resource_kafka_cluster.go
+++ b/internal/provider/resource_kafka_cluster.go
@@ -448,6 +448,10 @@ func kafkaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diag.Errorf("error deleting Kafka Cluster %q: %s", d.Id(), createDescriptiveError(err))
 	}
 
+	if err := waitForKafkaClusterToBeDeleted(c.cmkApiContext(ctx), c, environmentId, d.Id()); err != nil {
+		return diag.Errorf("error waiting for Kafka Cluster %q to be deleted: %s", d.Id(), createDescriptiveError(err))
+	}
+
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Kafka Cluster %q", d.Id()), map[string]interface{}{kafkaClusterLoggingKey: d.Id()})
 
 	return nil

--- a/internal/provider/resource_kafka_cluster_live_test.go
+++ b/internal/provider/resource_kafka_cluster_live_test.go
@@ -18,15 +18,19 @@ package provider
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccKafkaClusterLive(t *testing.T) {
+// Test Basic cluster - simplest, fastest test
+func TestAccKafkaClusterBasicLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
 	// Skip this test unless explicitly enabled
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
@@ -36,15 +40,18 @@ func TestAccKafkaClusterLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
 
 	// Validate required environment variables are present
 	if apiKey == "" || apiSecret == "" {
 		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
 	}
 
-	clusterDisplayName := fmt.Sprintf("tf-provider-live-kafka-test-%d", time.Now().Unix())
-	environmentDisplayName := fmt.Sprintf("tf-provider-live-env-test-%d", time.Now().Unix())
-	clusterResourceLabel := "test_live_kafka_cluster"
+	clusterDisplayName := fmt.Sprintf("tf-live-basic-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_basic_cluster"
 	environmentResourceLabel := "test_live_env"
 
 	resource.Test(t, resource.TestCase{
@@ -53,13 +60,17 @@ func TestAccKafkaClusterLive(t *testing.T) {
 		CheckDestroy:      testAccCheckClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckKafkaClusterLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Config: testAccCheckKafkaClusterBasicLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "SINGLE_ZONE"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "basic.#", "1"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "bootstrap_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rest_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
 				),
 			},
 			{
@@ -77,7 +88,360 @@ func TestAccKafkaClusterLive(t *testing.T) {
 	})
 }
 
-func testAccCheckKafkaClusterLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+// Test Standard cluster - production-ready with extended feature set
+func TestAccKafkaClusterStandardLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	clusterDisplayName := fmt.Sprintf("tf-live-standard-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_standard_cluster"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckKafkaClusterStandardLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "SINGLE_ZONE"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "standard.#", "1"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "bootstrap_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rest_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+}
+
+// Test Enterprise cluster - high-performance, multi-zone
+func TestAccKafkaClusterEnterpriseLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	clusterDisplayName := fmt.Sprintf("tf-live-enterprise-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_enterprise_cluster"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckKafkaClusterEnterpriseLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "HIGH"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "enterprise.#", "1"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "bootstrap_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rest_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+}
+
+// Test Dedicated cluster with private networking - requires network dependency
+func TestAccKafkaClusterDedicatedWithNetworkLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations (Dedicated takes ~45 minutes)
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	clusterDisplayName := fmt.Sprintf("tf-live-dedicated-net-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	networkDisplayName := fmt.Sprintf("tf-live-network-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_dedicated_network_cluster"
+	environmentResourceLabel := "test_live_env"
+	networkResourceLabel := "test_live_network"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckKafkaClusterDedicatedWithNetworkLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "SINGLE_ZONE"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.#", "1"),
+					// Dedicated cluster specific attributes per API docs
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.0.cku", "1"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.0.zones.#"),
+					// Dedicated clusters should have endpoints
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "bootstrap_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rest_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "network.0.id"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+}
+
+// Test Dedicated cluster - CKU-based with optional networking and encryption
+func TestAccKafkaClusterDedicatedLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations (Dedicated takes ~45 minutes)
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	clusterDisplayName := fmt.Sprintf("tf-live-dedicated-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_dedicated_cluster"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckKafkaClusterDedicatedLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "SINGLE_ZONE"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.#", "1"),
+					// Dedicated cluster specific attributes per API docs
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.0.cku", "1"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "dedicated.0.zones.#"),
+					// Dedicated clusters should have endpoints
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "bootstrap_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rest_endpoint"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+}
+
+// Test Freight cluster - high-scale with relaxed latency requirements
+func TestAccKafkaClusterFreightLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	clusterDisplayName := fmt.Sprintf("tf-live-freight-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	clusterResourceLabel := "test_live_freight_cluster"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckKafkaClusterFreightLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "HIGH"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "freight.#", "1"),
+					// Freight clusters should have zones information
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "freight.0.zones.#"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "rbac_crn"),
+					// Note: bootstrap_endpoint and rest_endpoint are optional for Freight clusters per API docs
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+}
+
+// Configuration for Basic cluster
+func testAccCheckKafkaClusterBasicLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_kafka_cluster" "%s" {
+		display_name = "%s"
+		availability = "SINGLE_ZONE"
+		cloud        = "AWS"
+		region       = "us-east-1"
+		basic {}
+
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, environmentResourceLabel)
+}
+
+// Configuration for Standard cluster
+func testAccCheckKafkaClusterStandardLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint         = "%s"
@@ -98,6 +462,145 @@ func testAccCheckKafkaClusterLiveConfig(endpoint, environmentResourceLabel, envi
 		cloud        = "AWS"
 		region       = "us-east-1"
 		standard {}
+
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, environmentResourceLabel)
+}
+
+// Configuration for Enterprise cluster
+func testAccCheckKafkaClusterEnterpriseLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_kafka_cluster" "%s" {
+		display_name = "%s"
+		availability = "HIGH"
+		cloud        = "AWS"
+		region       = "us-east-1"
+		enterprise {}
+
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, environmentResourceLabel)
+}
+
+// Configuration for Dedicated cluster with private networking
+func testAccCheckKafkaClusterDedicatedWithNetworkLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_network" "%s" {
+		display_name     = "%s"
+		cloud            = "AWS"
+		region           = "us-east-1"
+		connection_types = ["PRIVATELINK"]
+		
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+
+	resource "confluent_kafka_cluster" "%s" {
+		display_name = "%s"
+		availability = "SINGLE_ZONE"
+		cloud        = "AWS"
+		region       = "us-east-1"
+		dedicated {
+			cku = 1
+		}
+
+		environment {
+			id = confluent_environment.%s.id
+		}
+
+		network {
+			id = confluent_network.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, environmentResourceLabel, clusterResourceLabel, clusterDisplayName, environmentResourceLabel, networkResourceLabel)
+}
+
+// Configuration for Dedicated cluster
+func testAccCheckKafkaClusterDedicatedLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_kafka_cluster" "%s" {
+		display_name = "%s"
+		availability = "SINGLE_ZONE"
+		cloud        = "AWS"
+		region       = "us-east-1"
+		dedicated {
+			cku = 1
+		}
+
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, environmentResourceLabel)
+}
+
+// Configuration for Freight cluster
+func testAccCheckKafkaClusterFreightLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, clusterResourceLabel, clusterDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_kafka_cluster" "%s" {
+		display_name = "%s"
+		availability = "HIGH"
+		cloud        = "AWS"
+		region       = "us-east-1"
+		freight {}
 
 		environment {
 			id = confluent_environment.%s.id

--- a/internal/provider/resource_network_live_test.go
+++ b/internal/provider/resource_network_live_test.go
@@ -1,0 +1,251 @@
+//go:build live_test && (all || networking)
+
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Test Private Link network for Enterprise clusters
+func TestAccNetworkPrivateLinkLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	networkDisplayName := fmt.Sprintf("tf-live-network-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	networkResourceLabel := "test_live_network"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkLiveDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNetworkPrivateLinkLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					// Core network attributes per API spec
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "display_name", networkDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "connection_types.#", "1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "connection_types.0", "PRIVATELINK"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "id"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "resource_name"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "environment.0.id"),
+					// PrivateLink specific attributes per API spec
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "dns_domain"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "endpoint_suffix"),
+					// AWS cloud specific attributes per API spec
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "aws.0.vpc"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "aws.0.account"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_network.%s", networkResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					networkId := resources[fmt.Sprintf("confluent_network.%s", networkResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_network.%s", networkResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + networkId, nil
+				},
+			},
+		},
+	})
+}
+
+// Test VPC Peering network
+func TestAccNetworkVpcPeeringLive(t *testing.T) {
+	// Enable parallel execution for I/O bound operations
+	t.Parallel()
+
+	// Skip this test unless explicitly enabled
+	if os.Getenv("TF_ACC_PROD") == "" {
+		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
+	}
+
+	// Read credentials and configuration from environment variables (populated by Vault)
+	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
+	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
+	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "https://api.confluent.cloud" // Use default endpoint if not set
+	}
+
+	// Validate required environment variables are present
+	if apiKey == "" || apiSecret == "" {
+		t.Fatal("CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for live tests")
+	}
+
+	networkDisplayName := fmt.Sprintf("tf-live-peering-%d", rand.Intn(1000000))
+	environmentDisplayName := fmt.Sprintf("tf-live-env-%d", rand.Intn(1000000))
+	networkResourceLabel := "test_live_peering_network"
+	environmentResourceLabel := "test_live_env"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkLiveDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckNetworkVpcPeeringLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, apiKey, apiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					// Core network attributes per API spec
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "display_name", networkDisplayName),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "cloud", "AWS"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "region", "us-east-1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "connection_types.#", "1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "connection_types.0", "PEERING"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "id"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "resource_name"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "environment.0.id"),
+					// VPC Peering specific attributes per API spec
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "cidr", "10.10.0.0/16"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "zones.#"),
+					// AWS cloud specific attributes per API spec
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "aws.0.vpc"),
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_network.%s", networkResourceLabel), "aws.0.account"),
+				),
+			},
+			{
+				ResourceName:      fmt.Sprintf("confluent_network.%s", networkResourceLabel),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					networkId := resources[fmt.Sprintf("confluent_network.%s", networkResourceLabel)].Primary.ID
+					environmentId := resources[fmt.Sprintf("confluent_network.%s", networkResourceLabel)].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + networkId, nil
+				},
+			},
+		},
+	})
+}
+
+// Configuration for Private Link network
+func testAccCheckNetworkPrivateLinkLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_network" "%s" {
+		display_name     = "%s"
+		cloud            = "AWS"
+		region           = "us-east-1"
+		connection_types = ["PRIVATELINK"]
+		
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, environmentResourceLabel)
+}
+
+// Configuration for VPC Peering network
+func testAccCheckNetworkVpcPeeringLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+		endpoint         = "%s"
+		cloud_api_key    = "%s"
+		cloud_api_secret = "%s"
+	}
+
+	resource "confluent_environment" "%s" {
+		display_name = "%s"
+		stream_governance {
+			package = "ESSENTIALS"
+		}
+	}
+
+	resource "confluent_network" "%s" {
+		display_name     = "%s"
+		cloud            = "AWS"
+		region           = "us-east-1"
+		connection_types = ["PEERING"]
+		cidr             = "10.10.0.0/16"
+		
+		environment {
+			id = confluent_environment.%s.id
+		}
+	}
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, networkResourceLabel, networkDisplayName, environmentResourceLabel)
+}
+
+// Helper function to verify network is properly cleaned up for live tests
+func testAccCheckNetworkLiveDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*Client)
+	// Loop through the resources in state, verifying each network is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "confluent_network" {
+			continue
+		}
+		deletedNetworkId := rs.Primary.ID
+		// Get the actual environment ID from the state, not a hardcoded constant
+		environmentId := rs.Primary.Attributes["environment.0.id"]
+		req := c.netClient.NetworksNetworkingV1Api.GetNetworkingV1Network(c.netApiContext(context.Background()), deletedNetworkId).Environment(environmentId)
+		deletedNetwork, response, err := req.Execute()
+		if response != nil && isNonKafkaRestApiResourceNotFound(response) {
+			// networking/v1/networks/{nonExistentNetworkId/deletedNetworkID} returns http.StatusForbidden instead of http.StatusNotFound
+			// If the error is equivalent to http.StatusNotFound, the network is destroyed.
+			return nil
+		} else if err == nil && deletedNetwork.Id != nil {
+			// Network still exists
+			if *deletedNetwork.Id == rs.Primary.ID {
+				return fmt.Errorf("network (%s) still exists", rs.Primary.ID)
+			}
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Added full live testing coverage for resource_kafka_cluster and resource_network as well as updated the live testing doc. I also added support for multithreaded execution with parallel test execution (up to 100 concurrent tests) to significantly improve performance for I/O-bound operations.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
I added a wait functionality for destroying a kafka cluster as this wasn't implemented previously.
**Worst case scenario**: Customer's terraform destroy hangs for 30 minutes per Kafka cluster if Confluent Cloud API issues prevent proper deletion status updates

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/APIE-491
https://confluentinc.atlassian.net/browse/APIE-492

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->

See passing Semaphore Pipeline: https://semaphore.ci.confluent.io/jobs/a326edd3-a908-4b1a-ae80-982592a357e6
