### PR TITLE
[CLI-3586] OAuth support for Kafka cluster link

### DIFF
--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     confluent = {
-      # source  = "confluentinc/confluent"
-      # version = "2.35.0"
-      source = "terraform.confluent.io/confluentinc/confluent"
+      source  = "confluentinc/confluent"
+      version = "2.36.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
@@ -1,0 +1,108 @@
+terraform {
+  required_providers {
+    confluent = {
+      # source  = "confluentinc/confluent"
+      # version = "2.35.0"
+      source = "terraform.confluent.io/confluentinc/confluent"
+    }
+  }
+}
+
+provider "confluent" {
+  oauth {
+    oauth_external_token_url = var.oauth_external_token_url
+    oauth_external_client_id  = var.oauth_external_client_id
+    oauth_external_client_secret = var.oauth_external_client_secret
+    oauth_identity_pool_id = var.oauth_identity_pool_id
+  }
+}
+
+data "confluent_environment" "east" {
+  id = var.east_kafka_cluster_environment_id
+}
+
+data "confluent_environment" "west" {
+  id = var.west_kafka_cluster_environment_id
+}
+
+data "confluent_kafka_cluster" "east" {
+  id = var.east_kafka_cluster_id
+  environment {
+    id = data.confluent_environment.east.id
+  }
+}
+
+data "confluent_kafka_cluster" "west" {
+  id = var.west_kafka_cluster_id
+  environment {
+    id = data.confluent_environment.west.id
+  }
+}
+
+resource "confluent_cluster_link" "east-to-west" {
+  link_name = var.cluster_link_name
+  link_mode = "BIDIRECTIONAL"
+  connection_mode = "INBOUND"
+  local_kafka_cluster {
+    id            = data.confluent_kafka_cluster.west.id
+    rest_endpoint = data.confluent_kafka_cluster.west.rest_endpoint
+  }
+
+  remote_kafka_cluster {
+    id                 = data.confluent_kafka_cluster.east.id
+    bootstrap_endpoint = data.confluent_kafka_cluster.east.bootstrap_endpoint
+  }
+}
+
+resource "confluent_cluster_link" "west-to-east" {
+  link_name = var.cluster_link_name
+  link_mode = "BIDIRECTIONAL"
+  local_kafka_cluster {
+    id            = data.confluent_kafka_cluster.east.id
+    rest_endpoint = data.confluent_kafka_cluster.east.rest_endpoint
+  }
+
+  remote_kafka_cluster {
+    id                 = data.confluent_kafka_cluster.west.id
+    bootstrap_endpoint = data.confluent_kafka_cluster.west.bootstrap_endpoint
+  }
+  depends_on = [
+    confluent_cluster_link.east-to-west
+  ]
+}
+
+resource "confluent_kafka_mirror_topic" "from-east" {
+  source_kafka_topic {
+    topic_name = var.east_topic_name
+  }
+  cluster_link {
+    link_name = confluent_cluster_link.east-to-west.link_name
+  }
+  kafka_cluster {
+    id            = data.confluent_kafka_cluster.west.id
+    rest_endpoint = data.confluent_kafka_cluster.west.rest_endpoint
+  }
+
+  depends_on = [
+    confluent_cluster_link.east-to-west,
+    confluent_cluster_link.west-to-east,
+  ]
+}
+
+resource "confluent_kafka_mirror_topic" "from-west" {
+  source_kafka_topic {
+    topic_name = var.west_topic_name
+  }
+  cluster_link {
+    link_name = confluent_cluster_link.west-to-east.link_name
+  }
+  kafka_cluster {
+    id            = data.confluent_kafka_cluster.east.id
+    rest_endpoint = data.confluent_kafka_cluster.east.rest_endpoint
+  }
+
+  depends_on = [
+    confluent_cluster_link.east-to-west,
+    confluent_cluster_link.west-to-east,
+  ]
+}

--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/terraform.tfvars
@@ -1,3 +1,6 @@
+# To setup advanced bi-directional Cluster Link using OAuth authentication between two Kafka Clusters (Private and Public) in Confluent Cloud
+# https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/cluster-links-cc.html#cluster-linking-bidirectional-advanced
+
 # The OAuth 2.0 token endpoint from external identity provider
 oauth_external_token_url = ""
 
@@ -11,22 +14,22 @@ oauth_external_client_secret = ""
 # https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/identity-providers.html
 oauth_identity_pool_id = ""
 
-# ID of the 'west' Kafka Cluster
+# ID of the 'west' Kafka Cluster (Public)
 west_kafka_cluster_id = ""
 
-# ID of the Environment that the 'west' Kafka Cluster belongs to
+# ID of the Environment that the 'west' Kafka Cluster  (Public) belongs to
 west_kafka_cluster_environment_id = ""
 
-# Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for
+# Name of the Topic on the 'west' Kafka Cluster (Public) to create a Mirror Topic for
 west_topic_name = ""
 
-# ID of the 'east' Kafka Cluster
+# ID of the 'east' Kafka Cluster (Private)
 east_kafka_cluster_id = ""
 
-# ID of the Environment that the 'east' Kafka Cluster belongs to
+# ID of the Environment that the 'east' Kafka Cluster (Private) belongs to
 east_kafka_cluster_environment_id = ""
 
-# Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for
+# Name of the Topic on the 'east' Kafka Cluster (Private) to create a Mirror Topic for
 east_topic_name = ""
 
 # Name of the Cluster Link to create

--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/variables.tf
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/variables.tf
@@ -1,66 +1,55 @@
 variable "oauth_external_token_url" {
   description = "The OAuth token URL from external identity provider"
   type        = string
-  default     = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
 }
 
 variable "oauth_external_client_id" {
   description = "The OAuth token client id from external identity provider"
   type        = string
-  default     = "0oaod69tu7yYnbrMn697"
 }
 
 variable "oauth_external_client_secret" {
   description = "The OAuth token client secret from external identity provider"
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "oauth_identity_pool_id" {
   description = "The OAuth identity pool id from external identity provider, registered with Confluent Cloud"
   type        = string
-  default     = "pool-W5Qe"
 }
 
 variable "west_kafka_cluster_id" {
   description = "ID of the 'west' Kafka Cluster (Public)"
   type        = string
-  default     = "lkc-w359pg"
 }
 
 variable "west_kafka_cluster_environment_id" {
   description = "ID of the Environment that the 'west' Kafka Cluster (Public) belongs to"
   type        = string
-  default     = "env-y2omyj"
 }
 
 variable "east_kafka_cluster_id" {
   description = "ID of the 'east' Kafka Cluster (Private)"
   type        = string
-  default     = "lkc-rxd15k"
 }
 
 variable "east_kafka_cluster_environment_id" {
   description = "ID of the Environment that the 'east' Kafka Cluster (Private) belongs to"
   type        = string
-  default     = "env-8y1wv7"
 }
 
 variable "east_topic_name" {
-  description = "Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for"
+  description = "Name of the Topic on the private 'east' Kafka Cluster to create a Mirror Topic for"
   type        = string
-  default     = "public.topic-on-east"
 }
 
 variable "west_topic_name" {
-  description = "Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for"
+  description = "Name of the Topic on the public 'west' Kafka Cluster to create a Mirror Topic for"
   type        = string
-  default     = "public.topic-on-west"
 }
 
 variable "cluster_link_name" {
   description = "Name of the Cluster Link to create"
   type        = string
-  default     = "advanced-bidirectional-link"
 }

--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/variables.tf
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/variables.tf
@@ -1,0 +1,66 @@
+variable "oauth_external_token_url" {
+  description = "The OAuth token URL from external identity provider"
+  type        = string
+  default     = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+}
+
+variable "oauth_external_client_id" {
+  description = "The OAuth token client id from external identity provider"
+  type        = string
+  default     = "0oaod69tu7yYnbrMn697"
+}
+
+variable "oauth_external_client_secret" {
+  description = "The OAuth token client secret from external identity provider"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "oauth_identity_pool_id" {
+  description = "The OAuth identity pool id from external identity provider, registered with Confluent Cloud"
+  type        = string
+  default     = "pool-W5Qe"
+}
+
+variable "west_kafka_cluster_id" {
+  description = "ID of the 'west' Kafka Cluster (Public)"
+  type        = string
+  default     = "lkc-w359pg"
+}
+
+variable "west_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the 'west' Kafka Cluster (Public) belongs to"
+  type        = string
+  default     = "env-y2omyj"
+}
+
+variable "east_kafka_cluster_id" {
+  description = "ID of the 'east' Kafka Cluster (Private)"
+  type        = string
+  default     = "lkc-rxd15k"
+}
+
+variable "east_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the 'east' Kafka Cluster (Private) belongs to"
+  type        = string
+  default     = "env-8y1wv7"
+}
+
+variable "east_topic_name" {
+  description = "Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for"
+  type        = string
+  default     = "public.topic-on-east"
+}
+
+variable "west_topic_name" {
+  description = "Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for"
+  type        = string
+  default     = "public.topic-on-west"
+}
+
+variable "cluster_link_name" {
+  description = "Name of the Cluster Link to create"
+  type        = string
+  default     = "advanced-bidirectional-link"
+}

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_providers {
+    confluent = {
+      # source  = "confluentinc/confluent"
+      # version = "2.35.0"
+      source = "terraform.confluent.io/confluentinc/confluent"
+    }
+  }
+}
+
+provider "confluent" {
+  oauth {
+    oauth_external_token_url = var.oauth_external_token_url
+    oauth_external_client_id  = var.oauth_external_client_id
+    oauth_external_client_secret = var.oauth_external_client_secret
+    oauth_identity_pool_id = var.oauth_identity_pool_id
+  }
+}
+
+data "confluent_environment" "source" {
+  id = var.source_kafka_cluster_environment_id
+}
+
+data "confluent_environment" "destination" {
+  id = var.destination_kafka_cluster_environment_id
+}
+
+data "confluent_kafka_cluster" "source" {
+  id = var.source_kafka_cluster_id
+  environment {
+    id = var.source_kafka_cluster_environment_id
+  }
+}
+
+data "confluent_kafka_cluster" "destination" {
+  id = var.destination_kafka_cluster_id
+  environment {
+    id = var.destination_kafka_cluster_environment_id
+  }
+}
+
+resource "confluent_cluster_link" "destination-outbound" {
+  link_name = "destination-initiated-terraform-using-oauth"
+  source_kafka_cluster {
+    id                 = data.confluent_kafka_cluster.source.id
+    bootstrap_endpoint = data.confluent_kafka_cluster.source.bootstrap_endpoint
+  }
+
+  destination_kafka_cluster {
+    id            = data.confluent_kafka_cluster.destination.id
+    rest_endpoint = data.confluent_kafka_cluster.destination.rest_endpoint
+  }
+}
+
+resource "confluent_kafka_mirror_topic" "test" {
+  source_kafka_topic {
+    topic_name = var.source_topic_name
+  }
+  cluster_link {
+    link_name = confluent_cluster_link.destination-outbound.link_name
+  }
+  kafka_cluster {
+    id            = data.confluent_kafka_cluster.destination.id
+    rest_endpoint = data.confluent_kafka_cluster.destination.rest_endpoint
+  }
+}

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     confluent = {
-      # source  = "confluentinc/confluent"
-      # version = "2.35.0"
-      source = "terraform.confluent.io/confluentinc/confluent"
+      source  = "confluentinc/confluent"
+      version = "2.35.0"
     }
   }
 }
@@ -28,19 +27,19 @@ data "confluent_environment" "destination" {
 data "confluent_kafka_cluster" "source" {
   id = var.source_kafka_cluster_id
   environment {
-    id = var.source_kafka_cluster_environment_id
+    id = data.confluent_environment.source.id
   }
 }
 
 data "confluent_kafka_cluster" "destination" {
   id = var.destination_kafka_cluster_id
   environment {
-    id = var.destination_kafka_cluster_environment_id
+    id = data.confluent_environment.destination.id
   }
 }
 
 resource "confluent_cluster_link" "destination-outbound" {
-  link_name = "destination-initiated-terraform-using-oauth"
+  link_name = var.cluster_link_name
   source_kafka_cluster {
     id                 = data.confluent_kafka_cluster.source.id
     bootstrap_endpoint = data.confluent_kafka_cluster.source.bootstrap_endpoint

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.35.0"
+      version = "2.36.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
@@ -1,0 +1,30 @@
+# The OAuth 2.0 token endpoint from external identity provider
+oauth_external_token_url = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+
+# The Application (client) ID registered in external identity provider for OAuth purpose
+oauth_external_client_id = "0oaod69tu7yYnbrMn697"
+
+# The Application (client) ID registered in external identity provider for OAuth purpose
+oauth_external_client_secret = "QN83b_1JscAAep7JTEdXvdloEUqKBXwk4_K00VyzXnYYBVFbCxdZN4Vy6NUDdo04"
+
+# The OAuth identity pool id with external identity provider, registered with Confluent Cloud
+# https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/identity-providers.html
+oauth_identity_pool_id = "pool-W5Qe"
+
+# ID of the destination Kafka Cluster
+destination_kafka_cluster_id = "lkc-x81kwg"
+
+# ID of the Environment that the destination Kafka Cluster belongs to
+destination_kafka_cluster_environment_id = "env-y2omyj"
+
+# ID of the source Kafka Cluster
+source_kafka_cluster_id = "lkc-og066y"
+
+# ID of the Environment that the source Kafka Cluster belongs to
+source_kafka_cluster_environment_id = "env-8y1wv7"
+
+# Name of the Topic on the source Kafka Cluster to create a Mirror Topic for
+source_topic_name = "cluster_link_topic_test1"
+
+# Name of the Cluster Link to create
+cluster_link_name = "destination-initiated-terraform-using-oauth"

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
@@ -4,7 +4,7 @@ oauth_external_token_url = ""
 # The Application (client) ID registered in external identity provider for OAuth purpose
 oauth_external_client_id = ""
 
-# The Application (client) ID registered in external identity provider for OAuth purpose
+# The Application (client) secret registered in external identity provider for OAuth purpose
 oauth_external_client_secret = ""
 
 # The OAuth identity pool id with external identity provider, registered with Confluent Cloud

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/terraform.tfvars
@@ -1,30 +1,30 @@
 # The OAuth 2.0 token endpoint from external identity provider
-oauth_external_token_url = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+oauth_external_token_url = ""
 
 # The Application (client) ID registered in external identity provider for OAuth purpose
-oauth_external_client_id = "0oaod69tu7yYnbrMn697"
+oauth_external_client_id = ""
 
 # The Application (client) ID registered in external identity provider for OAuth purpose
-oauth_external_client_secret = "QN83b_1JscAAep7JTEdXvdloEUqKBXwk4_K00VyzXnYYBVFbCxdZN4Vy6NUDdo04"
+oauth_external_client_secret = ""
 
 # The OAuth identity pool id with external identity provider, registered with Confluent Cloud
 # https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/identity-providers.html
-oauth_identity_pool_id = "pool-W5Qe"
+oauth_identity_pool_id = ""
 
 # ID of the destination Kafka Cluster
-destination_kafka_cluster_id = "lkc-x81kwg"
+destination_kafka_cluster_id = ""
 
 # ID of the Environment that the destination Kafka Cluster belongs to
-destination_kafka_cluster_environment_id = "env-y2omyj"
+destination_kafka_cluster_environment_id = ""
 
 # ID of the source Kafka Cluster
-source_kafka_cluster_id = "lkc-og066y"
+source_kafka_cluster_id = ""
 
 # ID of the Environment that the source Kafka Cluster belongs to
-source_kafka_cluster_environment_id = "env-8y1wv7"
+source_kafka_cluster_environment_id = ""
 
 # Name of the Topic on the source Kafka Cluster to create a Mirror Topic for
-source_topic_name = "cluster_link_topic_test1"
+source_topic_name = ""
 
 # Name of the Cluster Link to create
-cluster_link_name = "destination-initiated-terraform-using-oauth"
+cluster_link_name = ""

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/variables.tf
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/variables.tf
@@ -1,0 +1,54 @@
+variable "oauth_external_token_url" {
+  description = "The OAuth token URL from external identity provider"
+  type        = string
+  default     = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+}
+
+variable "oauth_external_client_id" {
+  description = "The OAuth token client id from external identity provider"
+  type        = string
+  default     = "0oaod69tu7yYnbrMn697"
+}
+
+variable "oauth_external_client_secret" {
+  description = "The OAuth token client secret from external identity provider"
+  type        = string
+  sensitive   = true
+  default     = "QN83b_1JscAAep7JTEdXvdloEUqKBXwk4_K00VyzXnYYBVFbCxdZN4Vy6NUDdo04"
+}
+
+variable "oauth_identity_pool_id" {
+  description = "The OAuth identity pool id from external identity provider, registered with Confluent Cloud"
+  type        = string
+  default     = "pool-W5Qe"
+}
+
+variable "destination_kafka_cluster_id" {
+  description = "ID of the Destination Kafka Cluster"
+  type        = string
+  default     = "lkc-x81kwg"
+}
+
+variable "destination_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the Destination Kafka Cluster belongs to"
+  type        = string
+  default     = "env-y2omyj"
+}
+
+variable "source_kafka_cluster_id" {
+  description = "ID of the Source Kafka Cluster"
+  type        = string
+  default     = "lkc-og066y"
+}
+
+variable "source_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the Source Kafka Cluster belongs to"
+  type        = string
+  default     = "env-8y1wv7"
+}
+
+variable "source_topic_name" {
+  description = "Name of the Topic on the Source Kafka Cluster to create a Mirror Topic for"
+  type        = string
+  default     = "cluster_link_topic_test1"
+}

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    confluent = {
+      source  = "confluentinc/confluent"
+      version = "2.35.0"
+    }
+  }
+}
+
+provider "confluent" {
+  oauth {
+    oauth_external_token_url = var.oauth_external_token_url
+    oauth_external_client_id  = var.oauth_external_client_id
+    oauth_external_client_secret = var.oauth_external_client_secret
+    oauth_identity_pool_id = var.oauth_identity_pool_id
+  }
+}
+
+data "confluent_environment" "east" {
+  id = var.east_kafka_cluster_environment_id
+}
+
+data "confluent_environment" "west" {
+  id = var.west_kafka_cluster_environment_id
+}
+
+data "confluent_kafka_cluster" "east" {
+  id = var.east_kafka_cluster_id
+  environment {
+    id = data.confluent_environment.east.id
+  }
+}
+
+data "confluent_kafka_cluster" "west" {
+  id = var.west_kafka_cluster_id
+  environment {
+    id = data.confluent_environment.west.id
+  }
+}
+
+resource "confluent_cluster_link" "east-to-west" {
+  link_name = var.cluster_link_name
+  link_mode = "BIDIRECTIONAL"
+  local_kafka_cluster {
+    id            = data.confluent_kafka_cluster.east.id
+    rest_endpoint = data.confluent_kafka_cluster.east.rest_endpoint
+  }
+
+  remote_kafka_cluster {
+    id                 = data.confluent_kafka_cluster.west.id
+    bootstrap_endpoint = data.confluent_kafka_cluster.west.bootstrap_endpoint
+  }
+}
+
+resource "confluent_cluster_link" "west-to-east" {
+  link_name = var.cluster_link_name
+  link_mode = "BIDIRECTIONAL"
+  local_kafka_cluster {
+    id            = data.confluent_kafka_cluster.west.id
+    rest_endpoint = data.confluent_kafka_cluster.west.rest_endpoint
+  }
+
+  remote_kafka_cluster {
+    id                 = data.confluent_kafka_cluster.east.id
+    bootstrap_endpoint = data.confluent_kafka_cluster.east.bootstrap_endpoint
+  }
+
+  // Make sure confluent_cluster_link.east-to-west is created first to avoid a race condition in the backend
+  // if confluent_cluster_link.west-to-east and confluent_cluster_link.east-to-west are created simultaneously,
+  // which can cause the cluster link IDs to differ.
+  depends_on = [
+    confluent_cluster_link.east-to-west
+  ]
+}
+
+resource "confluent_kafka_mirror_topic" "from-east" {
+  source_kafka_topic {
+    topic_name = var.east_topic_name
+  }
+  cluster_link {
+    link_name = confluent_cluster_link.east-to-west.link_name
+  }
+  kafka_cluster {
+    id            = data.confluent_kafka_cluster.west.id
+    rest_endpoint = data.confluent_kafka_cluster.west.rest_endpoint
+  }
+
+  depends_on = [
+    confluent_cluster_link.east-to-west,
+    confluent_cluster_link.west-to-east,
+  ]
+}
+
+resource "confluent_kafka_mirror_topic" "from-west" {
+  source_kafka_topic {
+    topic_name = var.west_topic_name
+  }
+  cluster_link {
+    link_name = confluent_cluster_link.west-to-east.link_name
+  }
+  kafka_cluster {
+    id            = data.confluent_kafka_cluster.east.id
+    rest_endpoint = data.confluent_kafka_cluster.east.rest_endpoint
+  }
+
+  depends_on = [
+    confluent_cluster_link.east-to-west,
+    confluent_cluster_link.west-to-east,
+  ]
+}

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.35.0"
+      version = "2.36.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/terraform.tfvars
@@ -1,0 +1,33 @@
+# The OAuth 2.0 token endpoint from external identity provider
+oauth_external_token_url = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+
+# The Application (client) ID registered in external identity provider for OAuth purpose
+oauth_external_client_id = "0oaod69tu7yYnbrMn697"
+
+# The Application (client) ID registered in external identity provider for OAuth purpose
+oauth_external_client_secret = "QN83b_1JscAAep7JTEdXvdloEUqKBXwk4_K00VyzXnYYBVFbCxdZN4Vy6NUDdo04"
+
+# The OAuth identity pool id with external identity provider, registered with Confluent Cloud
+# https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/identity-providers.html
+oauth_identity_pool_id = "pool-W5Qe"
+
+# ID of the 'west' Kafka Cluster
+west_kafka_cluster_id = "lkc-mo3j77"
+
+# ID of the Environment that the 'west' Kafka Cluster belongs to
+west_kafka_cluster_environment_id = "env-y2omyj"
+
+# Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for
+west_topic_name = "public.topic-on-west"
+
+# ID of the 'east' Kafka Cluster
+east_kafka_cluster_id = "lkc-og118j"
+
+# ID of the Environment that the 'east' Kafka Cluster belongs to
+east_kafka_cluster_environment_id = "env-8y1wv7"
+
+# Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for
+east_topic_name = "public.topic-on-east"
+
+# Name of the Cluster Link to create
+cluster_link_name = "bidirectional-link"

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/terraform.tfvars
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/terraform.tfvars
@@ -1,33 +1,33 @@
 # The OAuth 2.0 token endpoint from external identity provider
-oauth_external_token_url = "https://ccloud-sso-sandbox.okta.com/oauth2/ausod37qoaxy2xfjI697/v1/token"
+oauth_external_token_url = ""
 
 # The Application (client) ID registered in external identity provider for OAuth purpose
-oauth_external_client_id = "0oaod69tu7yYnbrMn697"
+oauth_external_client_id = ""
 
 # The Application (client) ID registered in external identity provider for OAuth purpose
-oauth_external_client_secret = "QN83b_1JscAAep7JTEdXvdloEUqKBXwk4_K00VyzXnYYBVFbCxdZN4Vy6NUDdo04"
+oauth_external_client_secret = ""
 
 # The OAuth identity pool id with external identity provider, registered with Confluent Cloud
 # https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/identity-providers.html
-oauth_identity_pool_id = "pool-W5Qe"
+oauth_identity_pool_id = ""
 
 # ID of the 'west' Kafka Cluster
-west_kafka_cluster_id = "lkc-mo3j77"
+west_kafka_cluster_id = ""
 
 # ID of the Environment that the 'west' Kafka Cluster belongs to
-west_kafka_cluster_environment_id = "env-y2omyj"
+west_kafka_cluster_environment_id = ""
 
 # Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for
-west_topic_name = "public.topic-on-west"
+west_topic_name = ""
 
 # ID of the 'east' Kafka Cluster
-east_kafka_cluster_id = "lkc-og118j"
+east_kafka_cluster_id = ""
 
 # ID of the Environment that the 'east' Kafka Cluster belongs to
-east_kafka_cluster_environment_id = "env-8y1wv7"
+east_kafka_cluster_environment_id = ""
 
 # Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for
-east_topic_name = "public.topic-on-east"
+east_topic_name = ""
 
 # Name of the Cluster Link to create
-cluster_link_name = "bidirectional-link"
+cluster_link_name = ""

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/variables.tf
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/variables.tf
@@ -19,28 +19,33 @@ variable "oauth_identity_pool_id" {
   type        = string
 }
 
-variable "destination_kafka_cluster_id" {
-  description = "ID of the Destination Kafka Cluster"
+variable "west_kafka_cluster_id" {
+  description = "ID of the 'west' Kafka Cluster"
   type        = string
 }
 
-variable "destination_kafka_cluster_environment_id" {
-  description = "ID of the Environment that the Destination Kafka Cluster belongs to"
+variable "west_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the 'west' Kafka Cluster belongs to"
   type        = string
 }
 
-variable "source_kafka_cluster_id" {
-  description = "ID of the Source Kafka Cluster"
+variable "east_kafka_cluster_id" {
+  description = "ID of the 'east' Kafka Cluster"
   type        = string
 }
 
-variable "source_kafka_cluster_environment_id" {
-  description = "ID of the Environment that the Source Kafka Cluster belongs to"
+variable "east_kafka_cluster_environment_id" {
+  description = "ID of the Environment that the 'east' Kafka Cluster belongs to"
   type        = string
 }
 
-variable "source_topic_name" {
-  description = "Name of the Topic on the Source Kafka Cluster to create a Mirror Topic for"
+variable "east_topic_name" {
+  description = "Name of the Topic on the 'east' Kafka Cluster to create a Mirror Topic for"
+  type        = string
+}
+
+variable "west_topic_name" {
+  description = "Name of the Topic on the 'west' Kafka Cluster to create a Mirror Topic for"
   type        = string
 }
 

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/schema-registry v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1
-	github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.2.0
 	github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2
+	github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.2.0
 	github.com/dghubble/sling v1.4.1
 	github.com/docker/go-connections v0.5.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/confluentinc/ccloud-sdk-go-v2/ccpm v0.0.1 h1:q++EceNVxARLSE5J9FO3Vbp9
 github.com/confluentinc/ccloud-sdk-go-v2/ccpm v0.0.1/go.mod h1:toZWg8FVpQZ/80az0XTB4Fv22E5HJtEiMXxt4rU1JoI=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2 h1:stsiO1JIRX6ITdw4DCsidQ0w7uhsyKDsYXwzxvi14GI=
 github.com/confluentinc/ccloud-sdk-go-v2/certificate-authority v0.0.2/go.mod h1:OU1RGuP2y5l54jX5rA++QBAKeRvSa7GmkfNgJvB9J6M=
-github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0 h1:ioG3TsP8FwskPtwitfGfvBgTdprYKutHB0oxG5F4Dj8=
-github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.21.0/go.mod h1:WndyhYUqeH7usVOfh+3g9CpVPqHWxIkJqopSISD0pGg=
 github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.25.0 h1:EdZzQZ4SI5q+f0DQPjH3lWpygz1wYz7IE0K62Mv06bY=
 github.com/confluentinc/ccloud-sdk-go-v2/cmk v0.25.0/go.mod h1:FSSO9mkNPJKMa7Ky66IlXEG7o5H6cpyuKKClvRf9y+0=
 github.com/confluentinc/ccloud-sdk-go-v2/connect v0.7.0 h1:ISrVOX9qJ2Sxiu/fGBqqHeaA0SRJQujc8yP7qAZRL3Y=
@@ -133,8 +131,6 @@ github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1 h1:WZJYfgXJrvTIYQpCFps/qHF7T
 github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1/go.mod h1:kB+MXWYYg9ohrTCb27LlfpTbuexAzyYAmum105ow0ho=
 github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2 h1:QjHlqfA0nMOz4moHZxxWhggUfu2Hnq9PfnI/1H62wEs=
 github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2/go.mod h1:j+A/YgmDq0P9kvemjbpVofWv6ZMuL4nFNZOr0YxZJSM=
-github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.1.0 h1:dNpNo4hUrZ5v3L+gJp00aa1VvuPaIANPR6BV0MFCb8A=
-github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.1.0/go.mod h1:s76DpQdEVXWWk3K97xrUUFqCWBHyp9fIbOa/rdWmGzk=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.2.0 h1:ALDmQhIbzKjOz8xVgOx0ud89P3YFiOWff6IpXggkEdc=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.2.0/go.mod h1:9eUl1KxQurBT6HgO/Whd7v2mfCBeqkA7FV8IGAjCOPY=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -594,12 +594,12 @@ func constructCloudConfigForBidirectionalOutboundMode(localApiKey, localKafkaApi
 		tokenEndpoint := meta.(*Client).oauthToken.TokenUrl
 
 		// Local Kafka cluster configuration
-		// TODO: not sure everything regarding local Kafka cluster is correct here, check with real examples
 		config[localSaslMechanismConfigKey] = "OAUTHBEARER"
 		config[localSaslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
 		config[localSaslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
 		config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, localKafkaClusterId, identityPoolId)
 
+		// Remote Kafka cluster configuration
 		config[saslMechanismConfigKey] = "OAUTHBEARER"
 		config[saslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
 		config[saslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
@@ -684,13 +684,13 @@ func constructCloudConfigForSourceOutboundMode(sourceKafkaApiKey, sourceKafkaApi
 		scope := meta.(*Client).oauthToken.Scope
 		tokenEndpoint := meta.(*Client).oauthToken.TokenUrl
 
-		// Source(Local) Kafka cluster configuration
-		// TODO: not sure everything regarding local Kafka cluster is correct here, check with real examples
+		// Source Kafka cluster configuration
 		config[localSaslMechanismConfigKey] = "OAUTHBEARER"
 		config[localSaslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
 		config[localSaslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
 		config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, sourceKafkaClusterId, identityPoolId)
 
+		// Destination Kafka cluster configuration
 		config[saslMechanismConfigKey] = "OAUTHBEARER"
 		config[saslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
 		config[saslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -42,20 +42,25 @@ const (
 	bootstrapServersConfigKey = "bootstrap.servers"
 	securityProtocolConfigKey = "security.protocol"
 
-	saslMechanismConfigKey  = "sasl.mechanism"
-	saslJaasConfigConfigKey = "sasl.jaas.config"
+	saslMechanismConfigKey                   = "sasl.mechanism"
+	saslJaasConfigConfigKey                  = "sasl.jaas.config"
+	saslLoginCallbackHandlerClassConfigKey   = "sasl.login.callback.handler.class"
+	saslOAuthBearerTokenEndpointUrlConfigKey = "sasl.oauthbearer.token.endpoint.url"
 
-	localSecurityProtocolConfigKey = "local.security.protocol"
-	localSaslMechanismConfigKey    = "local.sasl.mechanism"
-	localSaslJaasConfigConfigKey   = "local.sasl.jaas.config"
-	connectionModeConfigKey        = "connection.mode"
-	linkModeConfigKey              = "link.mode"
-	remoteLinkConnectionMode       = "remote.link.connection.mode"
-	linkModeDestination            = "DESTINATION"
-	linkModeSource                 = "SOURCE"
-	linkModeBidirectional          = "BIDIRECTIONAL"
-	connectionModeInbound          = "INBOUND"
-	connectionModeOutbound         = "OUTBOUND"
+	localSecurityProtocolConfigKey                = "local.security.protocol"
+	localSaslMechanismConfigKey                   = "local.sasl.mechanism"
+	localSaslJaasConfigConfigKey                  = "local.sasl.jaas.config"
+	localSaslLoginCallbackHandlerClassConfigKey   = "local.sasl.login.callback.handler.class"
+	localSaslOAuthBearerTokenEndpointUrlConfigKey = "local.sasl.oauthbearer.token.endpoint.url"
+
+	connectionModeConfigKey  = "connection.mode"
+	linkModeConfigKey        = "link.mode"
+	remoteLinkConnectionMode = "remote.link.connection.mode"
+	linkModeDestination      = "DESTINATION"
+	linkModeSource           = "SOURCE"
+	linkModeBidirectional    = "BIDIRECTIONAL"
+	connectionModeInbound    = "INBOUND"
+	connectionModeOutbound   = "OUTBOUND"
 
 	importSourceKafkaRestEndpointEnvVar           = "IMPORT_SOURCE_KAFKA_REST_ENDPOINT"
 	importSourceKafkaBootstrapEndpointEnvVar      = "IMPORT_SOURCE_KAFKA_BOOTSTRAP_ENDPOINT"
@@ -155,7 +160,7 @@ func clusterLinkResource() *schema.Resource {
 
 func clusterLinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// TODO: update validateClusterLinkInput to accept BIDIRECTIONAL link mode
-	err := validateClusterLinkInput(d)
+	err := validateClusterLinkInput(d, meta.(*Client).isOAuthEnabled)
 	if err != nil {
 		return diag.Errorf("error creating Cluster Link: %s", createDescriptiveError(err))
 	}
@@ -165,7 +170,7 @@ func clusterLinkCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	linkName := d.Get(paramLinkName).(string)
 
-	createClusterLinkRequest, err := constructClusterLinkRequest(d)
+	createClusterLinkRequest, err := constructClusterLinkRequest(d, meta)
 	if err != nil {
 		return diag.Errorf("error creating Cluster Link: %s", createDescriptiveError(err))
 	}
@@ -315,10 +320,7 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 			paramId:                clusterLinkMetadata.localClusterId,
 			paramRestEndpoint:      clusterLinkMetadata.localRestEndpoint,
 			paramBootStrapEndpoint: clusterLinkMetadata.localBootstrapEndpoint,
-			paramCredentials: []interface{}{map[string]interface{}{
-				paramKey:    clusterLinkMetadata.localClusterApiKey,
-				paramSecret: clusterLinkMetadata.localClusterApiSecret,
-			}},
+			paramCredentials:       buildOptionalCredentialBlock(clusterLinkMetadata.localClusterApiKey, clusterLinkMetadata.localClusterApiSecret),
 		}}); err != nil {
 			return nil, err
 		}
@@ -335,10 +337,7 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 				paramId:                clusterLinkMetadata.remoteClusterId,
 				paramRestEndpoint:      clusterLinkMetadata.remoteRestEndpoint,
 				paramBootStrapEndpoint: clusterLinkMetadata.remoteBootstrapEndpoint,
-				paramCredentials: []interface{}{map[string]interface{}{
-					paramKey:    clusterLinkMetadata.remoteClusterApiKey,
-					paramSecret: clusterLinkMetadata.remoteClusterApiSecret,
-				}},
+				paramCredentials:       buildOptionalCredentialBlock(clusterLinkMetadata.remoteClusterApiKey, clusterLinkMetadata.remoteClusterApiSecret),
 			}}); err != nil {
 				return nil, err
 			}
@@ -348,10 +347,7 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 			paramId:                clusterLinkMetadata.destinationClusterId,
 			paramRestEndpoint:      clusterLinkMetadata.destinationRestEndpoint,
 			paramBootStrapEndpoint: clusterLinkMetadata.destinationBootstrapEndpoint,
-			paramCredentials: []interface{}{map[string]interface{}{
-				paramKey:    clusterLinkMetadata.destinationClusterApiKey,
-				paramSecret: clusterLinkMetadata.destinationClusterApiSecret,
-			}},
+			paramCredentials:       buildOptionalCredentialBlock(clusterLinkMetadata.destinationClusterApiKey, clusterLinkMetadata.destinationClusterApiSecret),
 		}}); err != nil {
 			return nil, err
 		}
@@ -368,10 +364,7 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 				paramId:                clusterLinkMetadata.sourceClusterId,
 				paramRestEndpoint:      clusterLinkMetadata.sourceRestEndpoint,
 				paramBootStrapEndpoint: clusterLinkMetadata.sourceBootstrapEndpoint,
-				paramCredentials: []interface{}{map[string]interface{}{
-					paramKey:    clusterLinkMetadata.sourceClusterApiKey,
-					paramSecret: clusterLinkMetadata.sourceClusterApiSecret,
-				}},
+				paramCredentials:       buildOptionalCredentialBlock(clusterLinkMetadata.sourceClusterApiKey, clusterLinkMetadata.sourceClusterApiSecret),
 			}}); err != nil {
 				return nil, err
 			}
@@ -388,6 +381,17 @@ func setClusterLinkAttributes(ctx context.Context, d *schema.ResourceData, c *Ka
 
 	d.SetId(createClusterLinkCompositeId(c.clusterId, clusterLink.LinkName))
 	return d, nil
+}
+
+// Function to optionally bypass setting credentials for source, destination, local and remote Kafka clusters if OAuth is enabled
+func buildOptionalCredentialBlock(credentialKey, credentialSecret string) []interface{} {
+	if credentialKey == "" && credentialSecret == "" {
+		return nil
+	}
+	return []interface{}{map[string]interface{}{
+		paramKey:    credentialKey,
+		paramSecret: credentialSecret,
+	}}
 }
 
 func clusterLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -569,18 +573,44 @@ func convertToConfigData(configs map[string]interface{}) []v3.ConfigData {
 }
 
 func constructCloudConfigForBidirectionalOutboundMode(localApiKey, localKafkaApiSecret,
-	remoteKafkaBootstrapEndpoint, remoteKafkaApiKey, remoteKafkaApiSecret string) map[string]interface{} {
+	remoteKafkaBootstrapEndpoint, remoteKafkaApiKey, remoteKafkaApiSecret string, localKafkaClusterId, remoteKafkaClusterId string, meta interface{}) map[string]interface{} {
 	config := make(map[string]interface{})
+
+	// Common configurations for both OAuth and PLAIN API key/secret authentication
 	config[connectionModeConfigKey] = connectionModeOutbound
 	config[remoteLinkConnectionMode] = connectionModeInbound
 	config[linkModeConfigKey] = linkModeBidirectional
+	config[bootstrapServersConfigKey] = remoteKafkaBootstrapEndpoint
 	config[localSecurityProtocolConfigKey] = "SASL_SSL"
+	config[securityProtocolConfigKey] = "SASL_SSL"
+
+	// OAuth specific configurations
+	if meta.(*Client).isOAuthEnabled {
+		// Extract OAuth token details from the meta client
+		identityPoolId := meta.(*Client).oauthToken.IdentityPoolId
+		clientId := meta.(*Client).oauthToken.ClientId
+		clientSecret := meta.(*Client).oauthToken.ClientSecret
+		scope := meta.(*Client).oauthToken.Scope
+		tokenEndpoint := meta.(*Client).oauthToken.TokenUrl
+
+		// Local Kafka cluster configuration
+		// TODO: not sure everything regarding local Kafka cluster is correct here, check with real examples
+		config[localSaslMechanismConfigKey] = "OAUTHBEARER"
+		config[localSaslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
+		config[localSaslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+		config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, localKafkaClusterId, identityPoolId)
+
+		config[saslMechanismConfigKey] = "OAUTHBEARER"
+		config[saslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
+		config[saslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+		config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, remoteKafkaClusterId, identityPoolId)
+
+		return config
+	}
+
+	// PLAIN API key/secret specific configurations
 	config[localSaslMechanismConfigKey] = "PLAIN"
 	config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";", localApiKey, localKafkaApiSecret)
-
-	// TODO: use constructCloudConfigForDestinationOutboundMode and merge 2 configs
-	config[bootstrapServersConfigKey] = remoteKafkaBootstrapEndpoint
-	config[securityProtocolConfigKey] = "SASL_SSL"
 	config[saslMechanismConfigKey] = "PLAIN"
 	config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";", remoteKafkaApiKey, remoteKafkaApiSecret)
 
@@ -595,12 +625,32 @@ func constructCloudConfigForBidirectionalInboundMode(bootstrapEndpoint string) m
 	return config
 }
 
-func constructCloudConfigForDestinationOutboundMode(bootstrapEndpoint, kafkaApiKey, kafkaApiSecret string) map[string]interface{} {
+func constructCloudConfigForDestinationOutboundMode(sourceClusterBootstrapEndpoint, sourceClusterId, kafkaApiKey, kafkaApiSecret string, meta interface{}) map[string]interface{} {
 	config := make(map[string]interface{})
+
+	// Common configurations for both OAuth and PLAIN API key/secret authentication
 	config[connectionModeConfigKey] = connectionModeOutbound
 	config[linkModeConfigKey] = linkModeDestination
-	config[bootstrapServersConfigKey] = bootstrapEndpoint
+	config[bootstrapServersConfigKey] = sourceClusterBootstrapEndpoint
 	config[securityProtocolConfigKey] = "SASL_SSL"
+
+	// OAuth specific configurations
+	if meta.(*Client).isOAuthEnabled {
+		// Extract OAuth token details from the meta client
+		identityPoolId := meta.(*Client).oauthToken.IdentityPoolId
+		clientId := meta.(*Client).oauthToken.ClientId
+		clientSecret := meta.(*Client).oauthToken.ClientSecret
+		scope := meta.(*Client).oauthToken.Scope
+		tokenEndpoint := meta.(*Client).oauthToken.TokenUrl
+
+		config[saslMechanismConfigKey] = "OAUTHBEARER"
+		config[saslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
+		config[saslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+		config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, sourceClusterId, identityPoolId)
+		return config
+	}
+
+	// PLAIN API key/secret specific configurations
 	config[saslMechanismConfigKey] = "PLAIN"
 	config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";", kafkaApiKey, kafkaApiSecret)
 	return config
@@ -615,17 +665,44 @@ func constructCloudConfigForDestinationInboundMode(bootstrapEndpoint string) map
 }
 
 func constructCloudConfigForSourceOutboundMode(sourceKafkaApiKey, sourceKafkaApiSecret,
-	destinationKafkaBootstrapEndpoint, destinationKafkaApiKey, destinationKafkaApiSecret string) map[string]interface{} {
+	destinationKafkaBootstrapEndpoint, destinationKafkaApiKey, destinationKafkaApiSecret string, sourceKafkaClusterId, destKafkaClusterId string, meta interface{}) map[string]interface{} {
 	config := make(map[string]interface{})
+
+	// Common configurations for both OAuth and PLAIN API key/secret authentication
 	config[connectionModeConfigKey] = connectionModeOutbound
 	config[linkModeConfigKey] = linkModeSource
 	config[localSecurityProtocolConfigKey] = "SASL_SSL"
+	config[securityProtocolConfigKey] = "SASL_SSL"
+	config[bootstrapServersConfigKey] = destinationKafkaBootstrapEndpoint
+
+	// OAuth specific configurations
+	if meta.(*Client).isOAuthEnabled {
+		// Extract OAuth token details from the meta client
+		identityPoolId := meta.(*Client).oauthToken.IdentityPoolId
+		clientId := meta.(*Client).oauthToken.ClientId
+		clientSecret := meta.(*Client).oauthToken.ClientSecret
+		scope := meta.(*Client).oauthToken.Scope
+		tokenEndpoint := meta.(*Client).oauthToken.TokenUrl
+
+		// Source(Local) Kafka cluster configuration
+		// TODO: not sure everything regarding local Kafka cluster is correct here, check with real examples
+		config[localSaslMechanismConfigKey] = "OAUTHBEARER"
+		config[localSaslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
+		config[localSaslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+		config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, sourceKafkaClusterId, identityPoolId)
+
+		config[saslMechanismConfigKey] = "OAUTHBEARER"
+		config[saslOAuthBearerTokenEndpointUrlConfigKey] = tokenEndpoint
+		config[saslLoginCallbackHandlerClassConfigKey] = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+		config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='%s' scope='%s' clientSecret='%s' extension_logicalCluster='%s' extension_identityPoolId='%s';", clientId, scope, clientSecret, destKafkaClusterId, identityPoolId)
+
+		return config
+	}
+
+	// PLAIN API key/secret specific configurations
 	config[localSaslMechanismConfigKey] = "PLAIN"
 	config[localSaslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";", sourceKafkaApiKey, sourceKafkaApiSecret)
 
-	// TODO: use constructCloudConfigForDestinationOutboundMode and merge 2 configs
-	config[bootstrapServersConfigKey] = destinationKafkaBootstrapEndpoint
-	config[securityProtocolConfigKey] = "SASL_SSL"
 	config[saslMechanismConfigKey] = "PLAIN"
 	config[saslJaasConfigConfigKey] = fmt.Sprintf("org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";", destinationKafkaApiKey, destinationKafkaApiSecret)
 
@@ -663,20 +740,21 @@ func createKafkaRestClientForClusterLink(d *schema.ResourceData, meta interface{
 	}
 }
 
-func constructClusterLinkRequest(d *schema.ResourceData) (v3.CreateLinkRequestData, error) {
+func constructClusterLinkRequest(d *schema.ResourceData, meta interface{}) (v3.CreateLinkRequestData, error) {
 	linkMode := d.Get(paramLinkMode).(string)
 	connectionMode := d.Get(paramConnectionMode).(string)
 	clusterLinkSettings := extractClusterLinkConfigsConfigData(d.Get(paramConfigs).(map[string]interface{}))
 
 	if linkMode == linkModeBidirectional {
 		if connectionMode == connectionModeOutbound {
+			localKafkaClusterId := extractStringValueFromBlock(d, paramLocalKafkaCluster, paramId)
 			localKafkaClusterApiKey := extractStringValueFromNestedBlock(d, paramLocalKafkaCluster, paramCredentials, paramKey)
 			localKafkaClusterApiSecret := extractStringValueFromNestedBlock(d, paramLocalKafkaCluster, paramCredentials, paramSecret)
 			remoteKafkaClusterId := extractStringValueFromBlock(d, paramRemoteKafkaCluster, paramId)
 			remoteKafkaClusterApiKey := extractStringValueFromNestedBlock(d, paramRemoteKafkaCluster, paramCredentials, paramKey)
 			remoteKafkaClusterApiSecret := extractStringValueFromNestedBlock(d, paramRemoteKafkaCluster, paramCredentials, paramSecret)
 			remoteKafkaClusterBootstrapEndpoint := extractStringValueFromBlock(d, paramRemoteKafkaCluster, paramBootStrapEndpoint)
-			configs := convertToConfigData(constructCloudConfigForBidirectionalOutboundMode(localKafkaClusterApiKey, localKafkaClusterApiSecret, remoteKafkaClusterBootstrapEndpoint, remoteKafkaClusterApiKey, remoteKafkaClusterApiSecret))
+			configs := convertToConfigData(constructCloudConfigForBidirectionalOutboundMode(localKafkaClusterApiKey, localKafkaClusterApiSecret, remoteKafkaClusterBootstrapEndpoint, remoteKafkaClusterApiKey, remoteKafkaClusterApiSecret, localKafkaClusterId, remoteKafkaClusterId, meta))
 
 			// Add top level cluster link configs
 			configs = append(configs, clusterLinkSettings...)
@@ -705,7 +783,7 @@ func constructClusterLinkRequest(d *schema.ResourceData) (v3.CreateLinkRequestDa
 			sourceKafkaClusterBootstrapEndpoint := extractStringValueFromBlock(d, paramSourceKafkaCluster, paramBootStrapEndpoint)
 			sourceKafkaClusterApiKey := extractStringValueFromNestedBlock(d, paramSourceKafkaCluster, paramCredentials, paramKey)
 			sourceKafkaClusterApiSecret := extractStringValueFromNestedBlock(d, paramSourceKafkaCluster, paramCredentials, paramSecret)
-			configs := convertToConfigData(constructCloudConfigForDestinationOutboundMode(sourceKafkaClusterBootstrapEndpoint, sourceKafkaClusterApiKey, sourceKafkaClusterApiSecret))
+			configs := convertToConfigData(constructCloudConfigForDestinationOutboundMode(sourceKafkaClusterBootstrapEndpoint, sourceKafkaClusterId, sourceKafkaClusterApiKey, sourceKafkaClusterApiSecret, meta))
 
 			// Add top level cluster link configs
 			configs = append(configs, clusterLinkSettings...)
@@ -730,13 +808,14 @@ func constructClusterLinkRequest(d *schema.ResourceData) (v3.CreateLinkRequestDa
 		}
 	} else {
 		// linkMode = linkModeSource
+		sourceKafkaClusterId := extractStringValueFromBlock(d, paramSourceKafkaCluster, paramId)
 		sourceKafkaClusterApiKey := extractStringValueFromNestedBlock(d, paramSourceKafkaCluster, paramCredentials, paramKey)
 		sourceKafkaClusterApiSecret := extractStringValueFromNestedBlock(d, paramSourceKafkaCluster, paramCredentials, paramSecret)
 		destinationKafkaClusterId := extractStringValueFromBlock(d, paramDestinationKafkaCluster, paramId)
 		destinationKafkaClusterBootstrapEndpoint := extractStringValueFromBlock(d, paramDestinationKafkaCluster, paramBootStrapEndpoint)
 		destinationKafkaClusterApiKey := extractStringValueFromNestedBlock(d, paramDestinationKafkaCluster, paramCredentials, paramKey)
 		destinationKafkaClusterApiSecret := extractStringValueFromNestedBlock(d, paramDestinationKafkaCluster, paramCredentials, paramSecret)
-		configs := convertToConfigData(constructCloudConfigForSourceOutboundMode(sourceKafkaClusterApiKey, sourceKafkaClusterApiSecret, destinationKafkaClusterBootstrapEndpoint, destinationKafkaClusterApiKey, destinationKafkaClusterApiSecret))
+		configs := convertToConfigData(constructCloudConfigForSourceOutboundMode(sourceKafkaClusterApiKey, sourceKafkaClusterApiSecret, destinationKafkaClusterBootstrapEndpoint, destinationKafkaClusterApiKey, destinationKafkaClusterApiSecret, sourceKafkaClusterId, destinationKafkaClusterId, meta))
 
 		// Add top level cluster link configs
 		configs = append(configs, clusterLinkSettings...)
@@ -780,7 +859,7 @@ func clusterLinkKafkaClusterBlockSchema(blockName string) *schema.Schema {
 					Type:        schema.TypeString,
 					Optional:    true,
 					ForceNew:    true,
-					Description: "The bootstrap endpoint used by Kafka clients to connect to the Kafka cluster. (e.g., `SASL_SSL://pkc-00000.us-central1.gcp.confluent.cloud:9092` or pkc-00000.us-central1.gcp.confluent.cloud:9092`).",
+					Description: "The bootstrap endpoint used by Kafka clients to connect to the Kafka cluster. (e.g., `SASL_SSL://pkc-00000.us-central1.gcp.confluent.cloud:9092` or `pkc-00000.us-central1.gcp.confluent.cloud:9092`).",
 					// A user should provide a value for either "paramRestEndpoint" or "paramBootStrapEndpoint" attribute
 					ExactlyOneOf: oneOfEndpointsKeys,
 				},
@@ -846,9 +925,9 @@ func extractRemoteClusterApiKeyAndApiSecret() (string, string) {
 	return clusterApiKey, clusterApiSecret
 }
 
-func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData, linkMode, connectionMode string) error {
+func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData, linkMode, connectionMode string, isOAuthEnabled bool) error {
 	if linkMode == linkModeBidirectional {
-		if d.Get(localKafkaCredentialsBlockKey).(int) == 0 {
+		if !isOAuthEnabled && d.Get(localKafkaCredentialsBlockKey).(int) == 0 {
 			return fmt.Errorf("%q must be specified for %q", paramCredentials, paramLocalKafkaCluster)
 		}
 		// Expect
@@ -863,7 +942,7 @@ func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData,
 		return nil
 	}
 
-	if d.Get(destinationKafkaCredentialsBlockKey).(int) == 0 {
+	if !isOAuthEnabled && d.Get(destinationKafkaCredentialsBlockKey).(int) == 0 {
 		return fmt.Errorf("%q must be specified for %q", paramCredentials, paramDestinationKafkaCluster)
 	}
 	if linkMode == linkModeDestination {
@@ -877,7 +956,7 @@ func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData,
 			return fmt.Errorf("%q must be specified for %q", paramRestEndpoint, paramDestinationKafkaCluster)
 		}
 		if connectionMode == connectionModeOutbound {
-			if d.Get(sourceKafkaCredentialsBlockKey).(int) == 0 {
+			if !isOAuthEnabled && d.Get(sourceKafkaCredentialsBlockKey).(int) == 0 {
 				return fmt.Errorf("%q must be specified for %q", paramCredentials, paramSourceKafkaCluster)
 			}
 		} else {
@@ -896,7 +975,7 @@ func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData,
 			if d.Get(fmt.Sprintf("%s.0.%s", paramDestinationKafkaCluster, paramBootStrapEndpoint)).(string) == "" {
 				return fmt.Errorf("%q must be specified for %q", paramBootStrapEndpoint, paramDestinationKafkaCluster)
 			}
-			if d.Get(sourceKafkaCredentialsBlockKey).(int) == 0 {
+			if !isOAuthEnabled && d.Get(sourceKafkaCredentialsBlockKey).(int) == 0 {
 				return fmt.Errorf("%q must be specified for %q", paramCredentials, paramSourceKafkaCluster)
 			}
 		} else {
@@ -906,10 +985,10 @@ func validateClusterLinkInputByLinkModeAndConnectionMode(d *schema.ResourceData,
 	return nil
 }
 
-func validateClusterLinkInput(d *schema.ResourceData) error {
+func validateClusterLinkInput(d *schema.ResourceData, isOAuthEnabled bool) error {
 	linkMode := d.Get(paramLinkMode).(string)
 	connectionMode := d.Get(paramConnectionMode).(string)
-	return validateClusterLinkInputByLinkModeAndConnectionMode(d, linkMode, connectionMode)
+	return validateClusterLinkInputByLinkModeAndConnectionMode(d, linkMode, connectionMode, isOAuthEnabled)
 }
 
 func loadClusterLinkConfigs(ctx context.Context, d *schema.ResourceData, c *KafkaRestClient, linkName string) (map[string]string, error) {

--- a/internal/provider/resource_kafka_mirror_topic.go
+++ b/internal/provider/resource_kafka_mirror_topic.go
@@ -185,10 +185,7 @@ func setKafkaMirrorTopicAttributes(d *schema.ResourceData, c *KafkaRestClient, k
 	if err := d.Set(paramKafkaCluster, []interface{}{map[string]interface{}{
 		paramId:           c.clusterId,
 		paramRestEndpoint: c.restEndpoint,
-		paramCredentials: []interface{}{map[string]interface{}{
-			paramKey:    c.clusterApiKey,
-			paramSecret: c.clusterApiSecret,
-		}},
+		paramCredentials:  buildOptionalCredentialBlock(c.clusterApiKey, c.clusterApiSecret),
 	}}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Added OAuth support for `confluent_cluster_link` resource and data-source.

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- Added 3 OAuth examples for `confluent_cluster_link` resource, `destination-initiated` type, `regular-bidirectional` type, and the `advanced-bidirectional` type.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
This PR involves a code refactoring to update the SASL configuration to support `OAUTHBEARER` as the SASL mechanism.

3 examples `destination-initiated` type, `regular-bidirectional` type, and the `advanced-bidirectional` type have been validated and added to example folder to help users bringing up the OAuth feature.

Previous implementation always assumes the API key/secret exists, and for users with OAuth, this assumption is not true anymore, added a simple logic to bypass the setting of API key/secret to the TF state file, which triggers a Terraform drift.

```
// Function to optionally bypass setting credentials for source, destination, local and remote Kafka clusters if OAuth is enabled
func buildOptionalCredentialBlock(credentialKey, credentialSecret string) []interface{} {
	if credentialKey == "" && credentialSecret == "" {
		return nil
	}
	return []interface{}{map[string]interface{}{
		paramKey:    credentialKey,
		paramSecret: credentialSecret,
	}}
}
```

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Customers using OAuth to authenticate to Confluent Cloud to manage the `confluent_cluster_link` resources and data-source may get impacted.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
JIRA ticket:
https://confluentinc.atlassian.net/browse/CLI-3586

Relevant PR:
https://github.com/confluentinc/terraform-provider-confluent/pull/765

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
The overall validation result, including both resource and data-source, can be found:
https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/4584210922/TF+Provider+-+OAuth+GA+Design+And+Implementations
