### PR TITLE
[CLI-3511] Replace the raw STS token exchange HTTP request with public SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/confluentinc/terraform-provider-confluent
 go 1.24.4
 
 require (
-	github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/cam v0.3.0
@@ -33,6 +32,7 @@ require (
 	github.com/confluentinc/ccloud-sdk-go-v2/schema-registry v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3
 	github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1
+	github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.1.0
 	github.com/dghubble/sling v1.4.1
 	github.com/docker/go-connections v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/confluentinc/terraform-provider-confluent
 go 1.24.4
 
 require (
+	github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0
 	github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2
 	github.com/confluentinc/ccloud-sdk-go-v2/cam v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2 h1:IeODBHWTbZVVhhZ2zMtbq9Dgw+Xe1amFZPTsoDXQiXM=
-github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2/go.mod h1:USSNq5nrlwvjNzB3H6b4UPjX1iL5xe3klRnd4pSzR3k=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0/go.mod h1:wNa9Qg2e2v/+PQsUyKh+qB22hhLkPR6Ahy6rP+1jmGI=
 github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2 h1:BV/dPTFVovJPylrcr9lcSmukCVxBxyUeHBr6hp7zUNk=
@@ -129,6 +127,8 @@ github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3 h1:ozdDSJHruQIgtxS5hwz8Rp8p
 github.com/confluentinc/ccloud-sdk-go-v2/srcm v0.7.3/go.mod h1:cD0AeCMBAWBesmWxWCMgVYNABYgHJ/ahCj7b4HP2R2I=
 github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1 h1:WZJYfgXJrvTIYQpCFps/qHF7T8ekgPlX/SFqx4EY2zQ=
 github.com/confluentinc/ccloud-sdk-go-v2/sso v0.0.1/go.mod h1:kB+MXWYYg9ohrTCb27LlfpTbuexAzyYAmum105ow0ho=
+github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2 h1:QjHlqfA0nMOz4moHZxxWhggUfu2Hnq9PfnI/1H62wEs=
+github.com/confluentinc/ccloud-sdk-go-v2/sts v0.0.2/go.mod h1:j+A/YgmDq0P9kvemjbpVofWv6ZMuL4nFNZOr0YxZJSM=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.1.0 h1:dNpNo4hUrZ5v3L+gJp00aa1VvuPaIANPR6BV0MFCb8A=
 github.com/confluentinc/ccloud-sdk-go-v2/tableflow v0.1.0/go.mod h1:s76DpQdEVXWWk3K97xrUUFqCWBHyp9fIbOa/rdWmGzk=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2 h1:IeODBHWTbZVVhhZ2zMtbq9Dgw+Xe1amFZPTsoDXQiXM=
+github.com/confluentinc/ccloud-sdk-go-v2-internal/sts v0.0.2/go.mod h1:USSNq5nrlwvjNzB3H6b4UPjX1iL5xe3klRnd4pSzR3k=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0 h1:8fWyLwMuy8ec0MVF5Avd54UvbIxhDFhZzanHBVwgxdw=
 github.com/confluentinc/ccloud-sdk-go-v2/apikeys v0.4.0/go.mod h1:wNa9Qg2e2v/+PQsUyKh+qB22hhLkPR6Ahy6rP+1jmGI=
 github.com/confluentinc/ccloud-sdk-go-v2/byok v0.0.2 h1:BV/dPTFVovJPylrcr9lcSmukCVxBxyUeHBr6hp7zUNk=

--- a/internal/provider/oauth.go
+++ b/internal/provider/oauth.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	sts "github.com/confluentinc/ccloud-sdk-go-v2-internal/sts/v1"
+	sts "github.com/confluentinc/ccloud-sdk-go-v2/sts/v1"
 )
 
 const (
@@ -59,7 +59,7 @@ type STSToken struct {
 	IssuedTokenType  string         `json:"issued_token_type"`
 	IdentityPoolId   string         `json:"identity_pool_id"`
 	ValidUntil       time.Time      `json:"valid_until"`
-	HTTPClient       *sts.APIClient `json:"http_client"`
+	STSClient        *sts.APIClient `json:"sts_client"`
 }
 
 func fetchSTSOAuthToken(ctx context.Context, subjectToken, identityPoolId, expiredInSeconds string, currToken *STSToken, stsClient *sts.APIClient) (*STSToken, error) {
@@ -112,9 +112,9 @@ func requestNewSTSOAuthToken(ctx context.Context, subjectToken, identityPoolId, 
 	if expiryDuration <= buffer {
 		buffer = expiryDuration / 2
 	}
-	result.ValidUntil = time.Now().Add(expiryDuration)
+	result.ValidUntil = time.Now().Add(expiryDuration - buffer)
 	result.IdentityPoolId = identityPoolId
-	result.HTTPClient = stsClient
+	result.STSClient = stsClient
 	return result, nil
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	sts "github.com/confluentinc/ccloud-sdk-go-v2-internal/sts/v1"
 	apikeys "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 	byok "github.com/confluentinc/ccloud-sdk-go-v2/byok/v1"
 	cam "github.com/confluentinc/ccloud-sdk-go-v2/cam/v1"
@@ -54,6 +53,7 @@ import (
 	pi "github.com/confluentinc/ccloud-sdk-go-v2/provider-integration/v1"
 	srcm "github.com/confluentinc/ccloud-sdk-go-v2/srcm/v3"
 	"github.com/confluentinc/ccloud-sdk-go-v2/sso/v2"
+	sts "github.com/confluentinc/ccloud-sdk-go-v2/sts/v1"
 )
 
 const (

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1103,7 +1103,7 @@ func (c *Client) fetchOrOverrideSTSOAuthTokenFromApiContext(ctx context.Context)
 	// Check if the current external OAuth token is still valid
 	// If valid, request a new STS token based on the current external OAuth token
 	if valid := validateCurrentExternalOAuthToken(ctx, currExternalToken); valid {
-		stsToken, err := requestNewSTSOAuthToken(ctx, currExternalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.HTTPClient)
+		stsToken, err := requestNewSTSOAuthToken(ctx, currExternalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.STSClient)
 		if err != nil {
 			return err
 		}
@@ -1119,7 +1119,7 @@ func (c *Client) fetchOrOverrideSTSOAuthTokenFromApiContext(ctx context.Context)
 	}
 	c.oauthToken = externalToken
 
-	stsToken, err := requestNewSTSOAuthToken(ctx, externalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.HTTPClient)
+	stsToken, err := requestNewSTSOAuthToken(ctx, externalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.STSClient)
 	if err != nil {
 		return err
 	}
@@ -1139,7 +1139,7 @@ func (c *TableflowRestClient) fetchOrOverrideSTSOAuthTokenFromApiContext(ctx con
 	// Check if the current external OAuth token is still valid
 	// If valid, request a new STS token based on the current external OAuth token
 	if valid := validateCurrentExternalOAuthToken(ctx, currExternalToken); valid {
-		stsToken, err := requestNewSTSOAuthToken(ctx, currExternalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.HTTPClient)
+		stsToken, err := requestNewSTSOAuthToken(ctx, currExternalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.STSClient)
 		if err != nil {
 			return err
 		}
@@ -1155,7 +1155,7 @@ func (c *TableflowRestClient) fetchOrOverrideSTSOAuthTokenFromApiContext(ctx con
 	}
 	c.oauthToken = externalToken
 
-	stsToken, err := requestNewSTSOAuthToken(ctx, externalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.HTTPClient)
+	stsToken, err := requestNewSTSOAuthToken(ctx, externalToken.AccessToken, currSTSToken.IdentityPoolId, currSTSToken.ExpiresInSeconds, currSTSToken.STSClient)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- For OAuth feature, replace the raw HTTP client with STS specific HTTP client from Confluent Cloud SDK to have standard HTTP request header.

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Previously, when sending POST request to STS service to exchange for a STS token, a raw HTTP client was used, which was less ideal as we should have a standard HTTP request header.

```    req, err := http.NewRequest(http.MethodPost, stsEndpoint, strings.NewReader(data.Encode()))
    if err != nil {
       return nil, err
    }
    req.Header.Set("content-type", "application/x-www-form-urlencoded")
    req.Header.Set("accept", "application/json")
```
Without a standard HTTP request header, some of the important information will be missing from observability dashboard when analyzing the OAuth feature usage information.

This PR replaces the raw HTTP client with the standard SDK for the STS token exchange request.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

Confluent Cloud customers who are using `oauth` feature to authenticate will be blocked.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
Background why this is needed:
https://confluent.slack.com/archives/C0152KH76BX/p1753244414531369?thread_ts=1752621104.236649&cid=C0152KH76BX

JIRA ticket:
https://confluentinc.atlassian.net/browse/CLI-3511

OAuth GA features, design and implementation:
https://confluentinc.atlassian.net/wiki/spaces/AEGI/pages/4584210922/TF+Provider+-+OAuth+GA+Design+And+Implementations

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
The test and verification can be found:
https://confluent.slack.com/archives/C08H9NWM0TG/p1753256977225179

We can see the desired HTTP headers in the Datadog trace:
<img width="1536" height="820" alt="Screenshot 2025-07-23 at 1 00 06 AM" src="https://github.com/user-attachments/assets/3d90296d-f0cd-40b8-bd15-d093d3bb56fe" />
