### PR TITLE
Remove redundant references from ESKU PNI and Freight examples.

### DIFF
--- a/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
+++ b/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
@@ -427,7 +427,7 @@ resource "confluent_service_account" "app-manager" {
 resource "confluent_role_binding" "app-manager-kafka-cluster-admin" {
   principal = "User:${confluent_service_account.app-manager.id}"
   role_name = "CloudClusterAdmin"
-  crn_pattern = replace(confluent_kafka_cluster.enterprise.rbac_crn, "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = confluent_kafka_cluster.enterprise.rbac_crn
 }
 
 resource "confluent_api_key" "app-manager-kafka-api-key" {
@@ -494,7 +494,7 @@ resource "confluent_api_key" "app-consumer-kafka-api-key" {
 resource "confluent_role_binding" "app-producer-developer-write" {
   principal = "User:${confluent_service_account.app-producer.id}"
   role_name = "DeveloperWrite"
-  crn_pattern = replace("${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/topic=${local.topic_name}", "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = "${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/topic=${local.topic_name}"
 }
 
 resource "confluent_service_account" "app-producer" {
@@ -528,7 +528,7 @@ resource "confluent_api_key" "app-producer-kafka-api-key" {
 resource "confluent_role_binding" "app-consumer-developer-read-from-topic" {
   principal = "User:${confluent_service_account.app-consumer.id}"
   role_name = "DeveloperRead"
-  crn_pattern = replace("${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/topic=${local.topic_name}", "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = "${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/topic=${local.topic_name}"
 }
 
 resource "confluent_role_binding" "app-consumer-developer-read-from-group" {
@@ -537,5 +537,5 @@ resource "confluent_role_binding" "app-consumer-developer-read-from-group" {
   // The existing value of crn_pattern's suffix (group=confluent_cli_consumer_*) are set up to match Confluent CLI's default consumer group ID ("confluent_cli_consumer_<uuid>").
   // https://docs.confluent.io/confluent-cli/current/command-reference/kafka/topic/confluent_kafka_topic_consume.html
   // Update it to match your target consumer group ID.
-  crn_pattern = replace("${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/group=confluent_cli_consumer_*", "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = "${confluent_kafka_cluster.enterprise.rbac_crn}/kafka=${confluent_kafka_cluster.enterprise.id}/group=confluent_cli_consumer_*"
 }

--- a/examples/configurations/freight-aws-kafka-rbac/main.tf
+++ b/examples/configurations/freight-aws-kafka-rbac/main.tf
@@ -422,7 +422,7 @@ resource "confluent_service_account" "app-manager" {
 resource "confluent_role_binding" "app-manager-kafka-cluster-admin" {
   principal = "User:${confluent_service_account.app-manager.id}"
   role_name = "CloudClusterAdmin"
-  crn_pattern = replace(confluent_kafka_cluster.freight.rbac_crn, "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = confluent_kafka_cluster.freight.rbac_crn
 }
 
 resource "confluent_api_key" "app-manager-kafka-api-key" {
@@ -523,7 +523,7 @@ resource "confluent_api_key" "app-producer-kafka-api-key" {
 resource "confluent_role_binding" "app-consumer-developer-read-from-topic" {
   principal = "User:${confluent_service_account.app-consumer.id}"
   role_name = "DeveloperRead"
-  crn_pattern = replace("${confluent_kafka_cluster.freight.rbac_crn}/kafka=${confluent_kafka_cluster.freight.id}/topic=${local.topic_name}", "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = "${confluent_kafka_cluster.freight.rbac_crn}/kafka=${confluent_kafka_cluster.freight.id}/topic=${local.topic_name}"
 }
 
 resource "confluent_role_binding" "app-consumer-developer-read-from-group" {
@@ -532,5 +532,5 @@ resource "confluent_role_binding" "app-consumer-developer-read-from-group" {
   // The existing value of crn_pattern's suffix (group=confluent_cli_consumer_*) are set up to match Confluent CLI's default consumer group ID ("confluent_cli_consumer_<uuid>").
   // https://docs.confluent.io/confluent-cli/current/command-reference/kafka/topic/confluent_kafka_topic_consume.html
   // Update it to match your target consumer group ID.
-  crn_pattern = replace("${confluent_kafka_cluster.freight.rbac_crn}/kafka=${confluent_kafka_cluster.freight.id}/group=confluent_cli_consumer_*", "stag.cpdev.cloud", "confluent.cloud")
+  crn_pattern = "${confluent_kafka_cluster.freight.rbac_crn}/kafka=${confluent_kafka_cluster.freight.id}/group=confluent_cli_consumer_*"
 }


### PR DESCRIPTION
Release Notes
---------
Examples
- Updated enterprise-pni-aws-kafka-rbac example to remove redundant references.

Checklist
---------
NA

What
----
This PR updates enterprise-pni-aws-kafka-rbac and freight-aws-kafka-rbac examples to remove redundant references.

Blast Radius
----
None, as this PR doesn't update the code of TF Provider.

References
----------
NA

Test & Review
-------------
```
➜  enterprise-pni-aws-kafka-rbac git:(remove-stag-links) ✗ terraform validate
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - terraform.confluent.io/confluentinc/confluent in /Users/klinou/work/terraform-provider-confluent/bin/darwin-arm64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
Success! The configuration is valid, but there were some validation warnings as shown above.

---

➜  freight-aws-kafka-rbac git:(add-freight-example) ✗ terraform validate
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - terraform.confluent.io/confluentinc/confluent in /Users/klinou/work/terraform-provider-confluent/bin/darwin-arm64
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
Success! The configuration is valid, but there were some validation warnings as shown above.
```
