### PR TITLE
Add `confluent.schema.validation.context.name` as editable topic setting

### DIFF
--- a/docs/resources/confluent_kafka_topic.md
+++ b/docs/resources/confluent_kafka_topic.md
@@ -91,7 +91,7 @@ The following arguments are supported:
              `confluent.key.schema.validation`, `confluent.value.schema.validation`, `confluent.key.subject.name.strategy`, `confluent.value.subject.name.strategy`.
 
 -> **Note:** Schema Validation Configuration topic settings:
-             `confluent.key.schema.validation`, `confluent.value.schema.validation`, `confluent.key.subject.name.strategy`, `confluent.value.subject.name.strategy`
+             `confluent.key.schema.validation`, `confluent.value.schema.validation`, `confluent.key.subject.name.strategy`, `confluent.value.subject.name.strategy`, `confluent.schema.validation.context.name
              are only [available](https://docs.confluent.io/cloud/current/sr/broker-side-schema-validation.html#prerequisites) on [dedicated clusters](https://docs.confluent.io/cloud/current/clusters/cluster-types.html#dedicated-cluster).
 
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_kafka_topic` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.

--- a/internal/provider/resource_kafka_topic.go
+++ b/internal/provider/resource_kafka_topic.go
@@ -49,7 +49,7 @@ var editableTopicSettings = []string{"cleanup.policy", "delete.retention.ms", "m
 	"message.timestamp.difference.max.ms", "message.timestamp.before.max.ms", "message.timestamp.after.max.ms",
 	"message.timestamp.type", "min.compaction.lag.ms", "min.insync.replicas",
 	"retention.bytes", "retention.ms", "segment.bytes", "segment.ms", "confluent.key.schema.validation", "confluent.value.schema.validation",
-	"confluent.key.subject.name.strategy", "confluent.value.subject.name.strategy"}
+	"confluent.key.subject.name.strategy", "confluent.value.subject.name.strategy", "confluent.schema.validation.context.name"}
 
 // Read-only topic settings
 var ignoredTopicSettings = []string{


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Adds `confluent.schema.validation.context.name` to editable topic settings

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
This PR adds the `confluent.schema.validation.context.name` configuration property to the list of editable topic settings. This property is added via the Confluent Cloud UI if you edit topic settings manually, which will later cause terraform apply to fail since its not possible to remove this property or configure to prevent terraform from updating it.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
I do not expect negative effects since this pr only allows an additional setting to be configured

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
Resolves #771 

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->

Terraform Plan & Apply Output:

```hcl
Terraform will perform the following actions:
 
 # module.<redacted>.confluent_kafka_topic.topic["<redacted>"] will be updated in-place

  ~ resource "confluent_kafka_topic" "topic" {
      ~ config           = {
          + "confluent.schema.validation.context.name" = "default"
            # (18 unchanged elements hidden)
        }
        id               = "lkc-<redacted>/<redacted>"
        # (3 unchanged attributes hidden)

       # (2 unchanged blocks hidden)
    }
 
Plan: 0 to add, 1 to change, 0 to destroy.
```


```hcl
module.<redacted>.confluent_kafka_topic.topic["<redacted>"]: Modifying... [id=lkc-<redacted>/<redacted>]
module.<redacted>.confluent_kafka_topic.topic["<redacted>"]: Still modifying... [id=lkc-<redacted>/<redacted>, 10s elapsed]
module.<redacted>.confluent_kafka_topic.topic["<redacted>"]: Modifications complete after 10s [id=lkc-<redacted>/<redacted>]

Releasing state lock. This may take a few moments...
 
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```