### PR TITLE
[APIT-2775] Type conversion in CRN triggers force replacement 

### DIFF
--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -64,7 +64,7 @@ func roleBindingResource() *schema.Resource {
 				ForceNew:     true,
 				Description:  "A CRN that specifies the scope and resource patterns necessary for the role to bind.",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^crn://"), "the CRN must be of the form 'crn://'"),
-                DiffSuppressFunc: suppressSameCrnPattern,
+				DiffSuppressFunc: suppressSameCrnPattern,
 			},
 			paramDisableWaitForReady: {
 				Type:     schema.TypeBool,
@@ -78,7 +78,7 @@ func roleBindingResource() *schema.Resource {
 // suppresses diffs when the only difference is encoding (':' vs '%3A') 
 // so that logically same CRNs do not trigger force replacement 
 func suppressSameCrnPattern(k, old, new string, d *schema.ResourceData) bool {
-    return normalizeCrn(old) == normalizeCrn(new)
+	return normalizeCrn(old) == normalizeCrn(new)
 }
 
 func roleBindingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1084,10 +1084,10 @@ func convertToStringStringListMap(data []interface{}) map[string][]string {
 }
 
 func normalizeCrn(crn string) string {
-    if v, err := url.PathUnescape(crn); err == nil {
-        return v
-    }
-    return crn
+	if v, err := url.PathUnescape(crn); err == nil {
+		return v
+	}
+	return crn
 }
 
 func ptr(s string) *string {

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -765,50 +765,50 @@ func TestBuildConnectorClass(t *testing.T) {
 }
 
 func TestNormalizeCrn(t *testing.T) {
-    tests := []struct{
-        name string
-        a    string
-        b    string
-        equal bool
-    }{
-        {
-            name:  "Identical CRN 1",
-            a:     "crn://confluent.cloud/organization=org-123/environment=env-abc",
-            b:     "crn://confluent.cloud/organization=org-123/environment=env-abc",
-            equal: true,
-        },
+	tests := []struct{
+		name string
+		a    string
+		b    string
+		equal bool
+	}{
 		{
-            name:  "Identical CRN 2",
-            a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/cloud-cluster=lkc-123/kafka=lkc-123/topic=my.topic",
-            b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/cloud-cluster=lkc-123/kafka=lkc-123/topic=my.topic",
-            equal: true,
-        },
-        {
-            name:  "Logically equivalent CRN",
-            a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
-            b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=%3A.context%3Asubject.v1",
-            equal: true,
-        },
-        {
-            name:  "CRN with different SRs",
-            a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
-            b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-456/subject=:.context:subject.v1",
-            equal: false,
-        },
+			name:  "Identical CRN 1",
+			a:     "crn://confluent.cloud/organization=org-123/environment=env-abc",
+			b:     "crn://confluent.cloud/organization=org-123/environment=env-abc",
+			equal: true,
+		},
 		{
-            name:  "CRN with different subjects",
-            a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
-            b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=subject.v1",
-            equal: false,
-        },
-    }
+			name:  "Identical CRN 2",
+			a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/cloud-cluster=lkc-123/kafka=lkc-123/topic=my.topic",
+			b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/cloud-cluster=lkc-123/kafka=lkc-123/topic=my.topic",
+			equal: true,
+		},
+		{
+			name:  "Logically equivalent CRN",
+			a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
+			b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=%3A.context%3Asubject.v1",
+			equal: true,
+		},
+		{
+			name:  "CRN with different SRs",
+			a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
+			b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-456/subject=:.context:subject.v1",
+			equal: false,
+		},
+		{
+			name:  "CRN with different subjects",
+			a:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=:.context:subject.v1",
+			b:     "crn://confluent.cloud/organization=org-123/environment=env-abc/schema-registry=lsrc-123/subject=subject.v1",
+			equal: false,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            got := normalizeCrn(tt.a) == normalizeCrn(tt.b)
-            if got != tt.equal {
-                t.Fatalf("Unexpected error: %v expected %v, got %v", tt.name, tt.equal, got)
-            }
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCrn(tt.a) == normalizeCrn(tt.b)
+			if got != tt.equal {
+				t.Fatalf("Unexpected error: %v expected %v, got %v", tt.name, tt.equal, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- This change fixes the issue described in [#299](https://github.com/confluentinc/terraform-provider-confluent/issues/299) where in the case of a colon (:) character is present in `crn_pattern` attribute in `confluent_role_binding` resource, Terraform wants to replaces (:) with %3A when comparing the plan with the state, causing terraform to want to recreate the resource. 

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
--> 
This PR adds in a bug fix to remove the TF force replacement/recreation behaviour in case of a colon (:) character is present in `crn_pattern` attribute in `confluent_role_binding` resource. 

It is confirmed that this TF false detection is due to crn parser library handling behaviour on the RBAC API side (ref: [Slack thread](https://confluent.slack.com/archives/C04JYGDUDA8/p1737104577791809?thread_ts=1737054999.810989&cid=C04JYGDUDA8 )). After internal discussion, we decide to fix this issue by updating Terraform instead of RBAC API, given that this API has been in GA for over two years, and updating the API might incur potential risks. 

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
--> 
Confluent Cloud customers who are using `confluent_role_binding` resource will be blocked.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Reproduce Customer Issue 
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # confluent_role_binding.sr_subject_colon_test must be replaced
-/+ resource "confluent_role_binding" "sr_subject_colon_test" {
      ~ crn_pattern            = "crn://confluent.cloud/organization=8d1593fe-75ef-4baa-87d6-f7f26bb74951/environment=env-k6op9v/schema-registry=lsrc-5xzkmg/subject=%3A.context%3Asubject.v1" -> "crn://confluent.cloud/organization=8d1593fe-75ef-4baa-87d6-f7f26bb74951/environment=env-k6op9v/schema-registry=lsrc-5xzkmg/subject=:.context:subject.v1" # forces replacement
      ~ id                     = "rb-rNEymq" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

After the Fix: 
no force replacement is triggered when `confluent_role_binding` has "crn_pattern": "crn://confluent.cloud/organization=8d1593fe-75ef-4baa-87d6-f7f26bb74951/environment=env-k6op9v/schema-registry=lsrc-5xzkmg/subject=%3A.context%3Asubject.v1"
```
confluent_role_binding.sr_subject_colon_test: Refreshing state... [id=rb-rNEymq]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed
```

Verify ACC Tests 
```
❯ TF_ACC=1 go test ./... -v -timeout 5m -run='TestAccRoleBinding'
?       github.com/confluentinc/terraform-provider-confluent    [no test files]
=== RUN   TestAccRoleBinding
2025/08/12 14:48:59 github.com/testcontainers/testcontainers-go - Connected to docker: 
...
2025/08/12 14:49:07 🚫 Container terminated: 6e7faf963305
--- PASS: TestAccRoleBinding (8.00s)
PASS
ok      github.com/confluentinc/terraform-provider-confluent/internal/provider8.622s

Add & Verify Unit Test: 
```
❯ TF_ACC=1 go test ./... -v -timeout 5m -run='TestNormalizeCrn'

?       github.com/confluentinc/terraform-provider-confluent    [no test files]
=== RUN   TestNormalizeCrn
=== RUN   TestNormalizeCrn/Identical_CRN_1
=== RUN   TestNormalizeCrn/Identical_CRN_2
=== RUN   TestNormalizeCrn/Logically_equivalent_CRN
=== RUN   TestNormalizeCrn/CRN_with_different_SRs
=== RUN   TestNormalizeCrn/CRN_with_different_subjects
--- PASS: TestNormalizeCrn (0.00s)
    --- PASS: TestNormalizeCrn/Identical_CRN_1 (0.00s)
    --- PASS: TestNormalizeCrn/Identical_CRN_2 (0.00s)
    --- PASS: TestNormalizeCrn/Logically_equivalent_CRN (0.00s)
    --- PASS: TestNormalizeCrn/CRN_with_different_SRs (0.00s)
    --- PASS: TestNormalizeCrn/CRN_with_different_subjects (0.00s)
PASS
ok      github.com/confluentinc/terraform-provider-confluent/internal/provider0.628s
```