### PR TITLE
[APIE-553] Fix auto bump for tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ GIT_MESSAGES := $(shell git log --pretty='%s' v$(CLEAN_VERSION)...HEAD 2>/dev/nu
 # If auto bump enabled, search git messages for bump hash
 ifeq ($(BUMP),auto)
 _auto_bump_msg := \(auto\)
-ifneq (,$(findstring \#major,$(GIT_MESSAGES)))
+ifneq (,$(findstring #major,$(GIT_MESSAGES)))
 BUMP := major
-else ifneq (,$(findstring \#minor,$(GIT_MESSAGES)))
+else ifneq (,$(findstring #minor,$(GIT_MESSAGES)))
 BUMP := minor
-else ifneq (,$(findstring \#patch,$(GIT_MESSAGES)))
+else ifneq (,$(findstring #patch,$(GIT_MESSAGES)))
 BUMP := patch
 else
 BUMP := $(DEFAULT_BUMP)


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`findstring` is trying to find the literal strings `\#major` `\#minor` and `\#patch` instead of treating the `\` as an escape character. This is causing `BUMP` to always end up as `DEFAULT_BUMP`.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Tested in an Ubuntu docker image using the following debugging make target:
```
.PHONY: print-versions
print-versions:
       @echo "VERSION: $(VERSION)"
       @echo "CLEAN_VERSION: $(CLEAN_VERSION)"
       @echo "GIT_MESSAGES: $(GIT_MESSAGES)"
       @echo "BUMP: $(BUMP)"
       @echo "BUMPED_CLEAN_VERSION: $(BUMPED_CLEAN_VERSION)"
       @echo "BUMPED_VERSION: $(BUMPED_VERSION)"
```
and the dummy commit:
```
git commit --allow-empty -m "#minor Prepare for v2.38.0 release"
```

Without this change:
```
make print-versions
VERSION: v2.37.0
CLEAN_VERSION: 2.37.0
GIT_MESSAGES: #minor Prepare for v2.38.0 release Revert DEFAULT_BUMP to patch (#782) chore: minor version bump v2.38.0 [APIT-2775] Type conversion in CRN triggers force replacement  (#779) 
BUMP: patch
BUMPED_CLEAN_VERSION: 2.37.1
BUMPED_VERSION: v2.37.1
```
with this change:
```
make print-versions
VERSION: v2.37.0
CLEAN_VERSION: 2.37.0
GIT_MESSAGES: #minor Prepare for v2.38.0 release Revert DEFAULT_BUMP to patch (#782) chore: minor version bump v2.38.0 [APIT-2775] Type conversion in CRN triggers force replacement  (#779) 
BUMP: minor
BUMPED_CLEAN_VERSION: 2.38.0
BUMPED_VERSION: v2.38.0
```