### PR TITLE
APIE-482: Add disable_wait_for_ready attribute to disable readiness checks for confluent_tag_binding resource 

### DIFF
--- a/docs/resources/confluent_tag_binding.md
+++ b/docs/resources/confluent_tag_binding.md
@@ -86,6 +86,7 @@ The following arguments are supported:
 - `tag_name` - (Required String) The name of the tag to be applied, for example, `PII`. The name must not be empty and consist of a letter followed by a sequence of letter, number, space, or _ characters.
 - `entity_name` - (Required String) The qualified name of the entity, for example, `${data.confluent_schema_registry_cluster.essentials.id}:.:${confluent_schema.purchase.schema_identifier}`, `${data.confluent_schema_registry_cluster.essentials.id}:${confluent_kafka_cluster.basic.id}:${confluent_kafka_topic.purchase.topic_name}`. Refer to the [Examples of qualified names](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#examples-of-qualified-names) to see the full list of supported values for the `entity_name` attribute.
 - `entity_type` - (Required String) The entity type, for example, `sr_schema`. Refer to the [Entity types](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#entity-types) to learn more about entity types.
+- `disable_wait_for_ready` - (Optional Boolean) An optional flag to disable wait-for-readiness on create. Must be unset when importing. Defaults to `false`.
 
 -> **Note:** A Schema Registry API key consists of a key and a secret. Schema Registry API keys are required to interact with Schema Registry clusters in Confluent Cloud. Each Schema Registry API key is valid for one specific Schema Registry cluster.
 

--- a/internal/provider/data_source_tag_binding.go
+++ b/internal/provider/data_source_tag_binding.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	dc "github.com/confluentinc/ccloud-sdk-go-v2/data-catalog/v1"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -107,9 +108,23 @@ func tagBindingDataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Fetched Tag Binding %q: %s", tagBindingId, tagBindingJson), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
 
-	if _, err := setTagBindingAttributes(d, clusterId, tagBinding); err != nil {
+	if _, err := setTagBindingDataSourceAttributes(d, clusterId, tagBinding); err != nil {
 		return diag.FromErr(createDescriptiveError(err))
 	}
 
 	return nil
+}
+
+func setTagBindingDataSourceAttributes(d *schema.ResourceData, clusterId string, tagBinding dc.TagResponse) (*schema.ResourceData, error) {
+	if err := d.Set(paramTagName, tagBinding.GetTypeName()); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramEntityName, tagBinding.GetEntityName()); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramEntityType, tagBinding.GetEntityType()); err != nil {
+		return nil, err
+	}
+	d.SetId(createTagBindingId(clusterId, tagBinding.GetTypeName(), tagBinding.GetEntityName(), tagBinding.GetEntityType()))
+	return d, nil
 }

--- a/internal/provider/resource_tag_binding.go
+++ b/internal/provider/resource_tag_binding.go
@@ -78,6 +78,11 @@ func tagBindingResource() *schema.Resource {
 				Description:  "The entity type.",
 				ForceNew:     true,
 			},
+			paramDisableWaitForReady: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 		CustomizeDiff: customdiff.Sequence(resourceCredentialBlockValidationWithOAuth),
 	}
@@ -100,6 +105,7 @@ func tagBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	tagName := d.Get(paramTagName).(string)
 	entityName := d.Get(paramEntityName).(string)
 	entityType := d.Get(paramEntityType).(string)
+	skipSync := d.Get(paramDisableWaitForReady).(bool)
 	tagBindingId := createTagBindingId(clusterId, tagName, entityName, entityType)
 
 	catalogRestClient := meta.(*Client).catalogRestClientFactory.CreateCatalogRestClient(restEndpoint, clusterId, clusterApiKey, clusterApiSecret, meta.(*Client).isSchemaRegistryMetadataSet, meta.(*Client).oauthToken)
@@ -108,9 +114,11 @@ func tagBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	tagBindingRequest.SetEntityType(entityType)
 	tagBindingRequest.SetTypeName(tagName)
 
-	// sleep 60 seconds to wait for entity (resource) to sync to SR
-	// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "error creating Tag Binding 404 Not Found"
-	SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode)
+	if !skipSync {
+		// sleep 60 seconds to wait for entity (resource) to sync to SR
+		// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "error creating Tag Binding 404 Not Found"
+		SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode)
+	}
 
 	request := catalogRestClient.apiClient.EntityV1Api.CreateTags(catalogRestClient.dataCatalogApiContext(ctx))
 	request = request.Tag([]dc.Tag{tagBindingRequest})
@@ -137,8 +145,10 @@ func tagBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error waiting for Tag Binding %q to provision: %s", tagBindingId, createDescriptiveError(err))
 	}
 
-	// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "Root object was present, but now absent."
-	SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	if !skipSync {
+		// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "Root object was present, but now absent."
+		SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	}
 
 	createdTagBindingJson, err := json.Marshal(createdTagBinding)
 	if err != nil {
@@ -289,8 +299,8 @@ func tagBindingImport(ctx context.Context, d *schema.ResourceData, meta interfac
 }
 
 func tagBindingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramCredentials, paramEntityName) {
-		return diag.Errorf("error updating Tag Binding %q: only %q, %q blocks can be updated for Tag Bindings", d.Id(), paramCredentials, paramEntityName)
+	if d.HasChangesExcept(paramCredentials, paramEntityName, paramDisableWaitForReady) {
+		return diag.Errorf("error updating Tag Binding %q: only %q, %q blocks and %q attribute can be updated for Tag Bindings", d.Id(), paramCredentials, paramEntityName, paramDisableWaitForReady)
 	}
 	if d.HasChange(paramEntityName) {
 		entityType := d.Get(paramEntityType).(string)
@@ -300,6 +310,7 @@ func tagBindingUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 		if !canUpdateEntityName(entityType, oldEntityName, newEntityName) {
 			return diag.Errorf("error updating Tag Binding %q: schema_identifier in %q block can only be updated for Tag Bindings if entity type is %q, %q or %q", d.Id(), paramEntityName, schemaEntityType, recordEntityType, fieldEntityType)
 		}
+		// TODO: APIE-574
 		// entity_name will be silently updated
 	}
 	return tagBindingRead(ctx, d, meta)
@@ -318,6 +329,12 @@ func setTagBindingAttributes(d *schema.ResourceData, clusterId string, tagBindin
 	}
 	if err := d.Set(paramEntityType, tagBinding.GetEntityType()); err != nil {
 		return nil, err
+	}
+	// Explicitly set paramDisableWaitForReady to the default value if unset
+	if _, ok := d.GetOk(paramDisableWaitForReady); !ok {
+		if err := d.Set(paramDisableWaitForReady, d.Get(paramDisableWaitForReady)); err != nil {
+			return nil, createDescriptiveError(err)
+		}
 	}
 	d.SetId(createTagBindingId(clusterId, tagBinding.GetTypeName(), tagBinding.GetEntityName(), tagBinding.GetEntityType()))
 	return d, nil

--- a/internal/provider/resource_tag_binding_test.go
+++ b/internal/provider/resource_tag_binding_test.go
@@ -97,28 +97,30 @@ func TestAccTagBinding(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: tagBindingResourceConfig(mockServerUrl),
+				Config: tagBindingResourceConfig(mockServerUrl, testShouldDisableBefore),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tagBindingLabel, "tag_name", "tag1"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "entity_name", "lsrc-8wrx70:.:100001"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "entity_type", "sr_schema"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "id", "xxx/tag1/lsrc-8wrx70:.:100001/sr_schema"),
+					resource.TestCheckResourceAttr(tagBindingLabel, "disable_wait_for_ready", "false"),
 				),
 			},
 			{
-				Config: tagBindingResourceSchemaRegistryConfig(mockServerUrl),
+				Config: tagBindingResourceSchemaRegistryConfig(mockServerUrl, testShouldDisableAfter),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tagBindingLabel, "tag_name", "tag1"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "entity_name", "lsrc-8wrx70:.:100001"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "entity_type", "sr_schema"),
 					resource.TestCheckResourceAttr(tagBindingLabel, "id", "xxx/tag1/lsrc-8wrx70:.:100001/sr_schema"),
+					resource.TestCheckResourceAttr(tagBindingLabel, "disable_wait_for_ready", "true"),
 				),
 			},
 		},
 	})
 }
 
-func tagBindingResourceConfig(mockServerUrl string) string {
+func tagBindingResourceConfig(mockServerUrl string, shouldDisable string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
  	  schema_registry_id = "xxx"
@@ -130,12 +132,13 @@ func tagBindingResourceConfig(mockServerUrl string) string {
       tag_name = "tag1"
 	  entity_name = "lsrc-8wrx70:.:100001"
 	  entity_type = "sr_schema"
+      disable_wait_for_ready = %s
 	}
 
- 	`, mockServerUrl)
+ 	`, mockServerUrl, shouldDisable)
 }
 
-func tagBindingResourceSchemaRegistryConfig(mockServerUrl string) string {
+func tagBindingResourceSchemaRegistryConfig(mockServerUrl string, shouldDisable string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
  	  schema_registry_id = "xxx"
@@ -147,7 +150,8 @@ func tagBindingResourceSchemaRegistryConfig(mockServerUrl string) string {
       tag_name = "tag1"
 	  entity_name = "lsrc-8wrx70:.:100001"
 	  entity_type = "sr_schema"
+      disable_wait_for_ready = %s
 	}
 
- 	`, mockServerUrl)
+ 	`, mockServerUrl, shouldDisable)
 }


### PR DESCRIPTION
Release Notes
---------
New Features
- Add `disable_wait_for_ready` attribute to disable readiness checks for `confluent_tag_binding` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_tag_binding).

Checklist
---------

- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR adds `disable_wait_for_ready` attribute to disable readiness checks for `confluent_tag_binding` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_tag_binding). The primary use case for using this flag is when you need to quickly provision a lot of tag bindings, if all the tags have already been provisioned before.

The implementation and the attribute naming were copied from the following PRs:

* https://github.com/confluentinc/terraform-provider-confluent-internal/pull/104 that adds `disable_wait_for_ready` attribute for the confluent_api_key resource
* https://github.com/confluentinc/terraform-provider-confluent/pull/657 that adds `disable_wait_for_ready` attribute for the confluent_tag_binding resource
* https://github.com/confluentinc/terraform-provider-confluent/pull/699/files

Blast Radius
----
- Confluent Cloud customers may run into issues when creating `confluent_tag_binding` resource.

References
----------
https://confluentinc.atlassian.net/browse/APIE-482

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1756271501389079

In short, we updated the acceptance tests and manually tested the following test cases:

1. TF drift verification when updating from the previous version of TF Provider.

2. Verified it still takes two minutes if you don't specify disable_wait_for_ready or specify disable_wait_for_ready = false.
```
terraform apply -auto-approve  0.46s user 0.35s system 0% cpu 2:03.63 total
```

3. Verified provisioning time is 3.5 seconds when using disable_wait_for_ready = true.
```
terraform apply -auto-approve  0.46s user 0.30s system 21% cpu 3.514 total
```
4. Verified in-place updates for disable_wait_for_ready = true <-> false.

5. Verified the confluent_tag_binding data source.

When testing all of the test cases, the subsequent plans show:
```
No changes. Your infrastructure matches the configuration.
```


* **Testing doc changes**:
<img width="1444" height="1024" alt="image" src="https://github.com/user-attachments/assets/cd3a0e20-27fd-431d-9e30-dfcb3142f5e2" />

Doc Preview Tool: https://registry.terraform.io/tools/doc-preview