### PR TITLE
APIE-578: Add request ID logging to HTTP transport for improved debugging

### DIFF
--- a/internal/provider/factory_utils.go
+++ b/internal/provider/factory_utils.go
@@ -300,7 +300,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	// 1. Call the original transport to do the actual HTTP work
 	resp, err := t.transport.RoundTrip(req)
 
-	// 2. Add our logging logic on top to output request_id HTTP requests
+	// 2. Add our logging logic on top to output request_id for HTTP requests
 	if err == nil && resp != nil && resp.Header != nil && req.URL != nil {
 		if requestID := resp.Header.Get("x-request-id"); requestID != "" {
 			tflog.Debug(t.ctx, "API request completed",


### PR DESCRIPTION
Release Notes
---------
N/A, as this PR does not introduce any user-facing changes. Instead, it improves TF logging which will be useful for debugging.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR adds automatic request ID logging to HTTP transport layer for improved debugging and request tracing. This enhancement captures the server-generated x-request-id header from API responses and logs it alongside request details, enabling easier correlation between Terraform operations and server-side logs.

Blast Radius
----
All users will be blocked if the HTTP transport wrapper fails, as this affects the primary HTTP client used for all API requests.

**Why it's safe**: The logging logic is minimal (just header extraction and debug logging) and follows standard Go HTTP patterns. The wrapper simply calls the original transport and adds non-intrusive logging on successful responses.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-578

Test & Review
-------------
**Manual Verification**: We compared logs between the current production version (2.36.0) and a development binary built from this PR. The validation confirmed successful extraction of request_id values from HTTP responses in the new version (the request_id was only present in the new logs), enabling end-to-end request tracing through our logging infrastructure. We tested it against both Control Plane APIs (that do return this header) and against Kafka REST API (that does not return this header).

**Traceability Validation**: Using the extracted request IDs, we successfully correlated Terraform provider operations with corresponding server-side traces, demonstrating the enhanced debugging capabilities this change provides.

See detailed testing logs and screenshots: https://confluent.slack.com/archives/C02TG07V058/p1756336549368279
