### PR TITLE
APIE-585: Resolve failing live tests: TestAccKsqlClusterDataSourceLive, TestAccKsqlClusterLive

### DIFF
--- a/internal/provider/data_source_ksql_cluster_live_test.go
+++ b/internal/provider/data_source_ksql_cluster_live_test.go
@@ -72,10 +72,10 @@ func TestAccKsqlClusterDataSourceLive(t *testing.T) {
 					// Check the resource was created
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "display_name", ksqlClusterDisplayName),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "4"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", "env-zyg27z"),
-					
+
 					// Check the data source can find it
 					resource.TestCheckResourceAttrPair(
 						fmt.Sprintf("data.confluent_ksql_cluster.%s", ksqlClusterDataSourceLabel), "id",
@@ -109,7 +109,7 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 
 	resource "confluent_ksql_cluster" "%s" {
 		display_name = "%s"
-		csu          = 1
+		csu          = 4
 		kafka_cluster {
 			id = "%s"
 		}
@@ -142,4 +142,4 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 		}
 	}
 	`, endpoint, apiKey, apiSecret, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDataSourceLabel, ksqlClusterResourceLabel)
-} 
+}

--- a/internal/provider/resource_ksql_cluster_live_test.go
+++ b/internal/provider/resource_ksql_cluster_live_test.go
@@ -147,7 +147,7 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 
 	resource "confluent_ksql_cluster" "%s" {
 		display_name = "%s"
-		csu          = 1
+		csu          = 4
 		kafka_cluster {
 			id = "%s"
 		}
@@ -162,4 +162,4 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 		]
 	}
 	`, endpoint, apiKey, apiSecret, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId)
-} 
+}

--- a/internal/provider/resource_ksql_cluster_live_test.go
+++ b/internal/provider/resource_ksql_cluster_live_test.go
@@ -70,7 +70,7 @@ func TestAccKsqlClusterLive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKsqlClusterLiveExists(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "display_name", ksqlClusterDisplayName),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "4"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "use_detailed_processing_log", "true"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", "env-zyg27z"),


### PR DESCRIPTION
Release Notes
---------
N/A, as this PR resolves failing tests.

Checklist
---------
N/A, as we only updated test files:

- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR resolves failing live tests:
* FAIL: TestAccKsqlClusterDataSourceLive
* FAIL: TestAccKsqlClusterLive

by updating the csu number to a higher value to be the minimum supported amount:

> You select the number of CSUs for your cluster at provisioning time. You can configure CSUs as follows:
> 4 CSUs is the minimum.
> 28 CSUs is the maximum.
> Cluster sizes can be 4, 8, 12, 16, 20, 24, or 28 CSUs.
> source: https://docs.confluent.io/cloud/current/ksqldb/overview.html

```
error creating ksqlDB Cluster "": 400 Bad Request: Cluster configuration is invalid:01:09

      csu_min: Cluster creation failed. A minimum of 4 CSUs is required for new ksqlDB clusters.
```

Blast Radius
----
None, as this PR only updates test files.

References
----------
* https://semaphore.ci.confluent.io/jobs/87a63964-d940-407b-b34e-ea7fc1d53450
* https://confluentinc.atlassian.net/browse/APIE-585

Test & Review
-------------
We've triggered a live test manually:
<img width="1980" height="834" alt="image" src="https://github.com/user-attachments/assets/6a34047c-bb1a-4cc4-809b-b0bc1a9652d9" />
and then we could see both of these tests passed:
<img width="862" height="206" alt="image" src="https://github.com/user-attachments/assets/cc87c13a-14bf-42d9-9b86-abd79a26f072" />


