### PR TITLE
upgrade Semaphore macOS agent to 15

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -9,7 +9,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos-13-5-arm64
+          type: s1-macos-15-arm64-8
       jobs:
         - name: goreleaser-darwin-fips
           commands:


### PR DESCRIPTION
What
----
This upgrades the Semaphore agent used for macOS jobs to use macOS 15. macOS 13 is about to be EOL.

Test & Review
-------------
PR checks