### PR TITLE
APIE-593: Fix confluent_tf_importer's timeout issues when importing huge number of resources

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -63,7 +63,8 @@ blocks:
             - rm temp.txt
             - echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
             - echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-            - gpgconf --kill gpg-agent && gpgconf --launch gpg-agent
+            - gpgconf --kill gpg-agent
+            - gpgconf --launch gpg-agent
             # Clean up git state
             - git clean -fx
             # Install deps for compiling for linux/arm64 from linux/amd64

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -61,6 +61,9 @@ blocks:
             - echo "foo" > temp.txt
             - gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${PASSPHRASE}" temp.txt
             - rm temp.txt
+            - echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+            - echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+            - gpgconf --kill gpg-agent && gpgconf --launch gpg-agent
             # Clean up git state
             - git clean -fx
             # Install deps for compiling for linux/arm64 from linux/amd64

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -61,10 +61,6 @@ blocks:
             - echo "foo" > temp.txt
             - gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${PASSPHRASE}" temp.txt
             - rm temp.txt
-            - echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-            - echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-            - gpgconf --kill gpg-agent
-            - gpgconf --launch gpg-agent
             # Clean up git state
             - git clean -fx
             # Install deps for compiling for linux/arm64 from linux/amd64

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -353,10 +353,6 @@ func commandWithResolvedSymlink(ctx context.Context, commandName string) (*exec.
 }
 
 func loadInstances(ctx context.Context, resourceName string, importer *Importer, fakeProvider *schema.Provider, meta interface{}) ([]instanceData, diag.Diagnostics) {
-	tflog.Debug(ctx, fmt.Sprintf("Loading instances for %s", resourceName), map[string]interface{}{
-		"resource_name":  resourceName,
-		"instance_count": len(importer.InstanceIdMap),
-	})
 	resourceSchema := fakeProvider.ResourcesMap[resourceName]
 	if resourceSchema == nil {
 		return nil, diag.Errorf("Resource type %s not defined", resourceName)
@@ -381,16 +377,6 @@ func loadInstances(ctx context.Context, resourceName string, importer *Importer,
 		}
 
 		instanceState, err := getInstanceState(ctx, resourceSchema, instanceId, meta)
-		// Log time remaining for both success and error cases
-		if deadline, ok := ctx.Deadline(); ok {
-			timeRemaining := time.Until(deadline)
-			if err != nil {
-				tflog.Error(ctx, fmt.Sprintf("Failed to get state for %s instance %s, time remaining: %v", resourceName, instanceId, timeRemaining))
-			} else {
-				tflog.Debug(ctx, fmt.Sprintf("Successfully got state for %s instance %s, time remaining: %v", resourceName, instanceId, timeRemaining))
-			}
-		}
-
 		if err != nil {
 			return nil, diag.Errorf("Failed to get state for %s instance %s: %v", resourceName, instanceId, err)
 		}

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -57,6 +57,8 @@ const (
 	SchemaRegistry
 )
 
+const importerCreateTimeout = 24 * time.Hour
+
 var ImportableResources = []string{
 	// Cloud
 	"confluent_service_account",
@@ -98,6 +100,9 @@ func tfImporterResource() *schema.Resource {
 				Default:  defaultOutputPath,
 			},
 			// TODO: add paramFormat = HCL (default) | JSON?
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(importerCreateTimeout),
 		},
 	}
 }
@@ -348,6 +353,10 @@ func commandWithResolvedSymlink(ctx context.Context, commandName string) (*exec.
 }
 
 func loadInstances(ctx context.Context, resourceName string, importer *Importer, fakeProvider *schema.Provider, meta interface{}) ([]instanceData, diag.Diagnostics) {
+	tflog.Debug(ctx, fmt.Sprintf("Loading instances for %s", resourceName), map[string]interface{}{
+		"resource_name":  resourceName,
+		"instance_count": len(importer.InstanceIdMap),
+	})
 	resourceSchema := fakeProvider.ResourcesMap[resourceName]
 	if resourceSchema == nil {
 		return nil, diag.Errorf("Resource type %s not defined", resourceName)
@@ -372,6 +381,16 @@ func loadInstances(ctx context.Context, resourceName string, importer *Importer,
 		}
 
 		instanceState, err := getInstanceState(ctx, resourceSchema, instanceId, meta)
+		// Log time remaining for both success and error cases
+		if deadline, ok := ctx.Deadline(); ok {
+			timeRemaining := time.Until(deadline)
+			if err != nil {
+				tflog.Error(ctx, fmt.Sprintf("Failed to get state for %s instance %s, time remaining: %v", resourceName, instanceId, timeRemaining))
+			} else {
+				tflog.Debug(ctx, fmt.Sprintf("Successfully got state for %s instance %s, time remaining: %v", resourceName, instanceId, timeRemaining))
+			}
+		}
+
 		if err != nil {
 			return nil, diag.Errorf("Failed to get state for %s instance %s: %v", resourceName, instanceId, err)
 		}

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -57,7 +57,7 @@ const (
 	SchemaRegistry
 )
 
-const importerCreateTimeout = 24 * time.Hour
+const importerCreateTimeout = 8 * time.Hour
 
 var ImportableResources = []string{
 	// Cloud


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed confluent_tf_importer's timeout issues when importing huge number of resources (for example, 2'000+ Kafka topics).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Before this PR, users could experience timeout issues when trying to import a huge number of resources (2'000+ Kafka topics):
```
[20m23s elapsed]
confluent_tf_importer.example: Still creating... [20m33s elapsed]
confluent_tf_importer.example: Still creating... [20m43s elapsed]
confluent_tf_importer.example: Still creating... [20m53s elapsed]
╷
│ Error: Failed to get state for confluent_kafka_topic instance lkc-526pjn/topic_586: [{0 error reading Kafka Topic: Get "[https://pkc-921jm.us-east-2.aws.confluent.cloud:443/kafka/v3/clusters/lkc-526pjn/topics/topic_586](https://pkc-921jm.us-east-2.aws.confluent.cloud/kafka/v3/clusters/lkc-526pjn/topics/topic_586)": context deadline exceeded  []}]
│ 
│   with confluent_tf_importer.example,
│   on main.tf line 16, in resource "confluent_tf_importer" "example":
│   16: resource "confluent_tf_importer" "example" {
│ 
╵
terraform apply -auto-approve  3.52s user 2.77s system 0% cpu 21:03.23 total
```

After looking at the logs, we could see the issue happened roughly after 20 minutes which is the [default timeout](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) for creation a resource in TF Provider SDKv2.

After adding additional logging, we confirmed our suspicion: the importer reused the same timeout for all topics ([link](https://confluent.slack.com/archives/C02TG07V058/p1757936620918339?thread_ts=1757936614.446889&cid=C02TG07V058))

<img width="720" height="444" alt="image" src="https://github.com/user-attachments/assets/4e69f036-7409-4097-aed5-6679b68a5084" />

```
2025-09-15T04:38:12.229-0700 [DEBUG] provider.terraform-provider-confluent: Successfully got state for confluent_kafka_topic instance lkc-526pjn/topic_1045, time remaining: 19m52.9339085s: tf_provider_addr=provider tf_req_id=d284b409-6749-c0fd-ac85-cb4e6127c461 tf_resource_type=confluent_tf_importer tf_rpc=ApplyResourceChange @caller=/Users/klinou/work/terraform-provider-confluent/internal/provider/resource_tf_importer.go:385 @module=provider timestamp=2025-09-15T04:38:12.228-0700

...

2025-09-15T04:38:19.089-0700 [DEBUG] provider.terraform-provider-confluent: Successfully got state for confluent_kafka_topic instance lkc-526pjn/topic_1808, time remaining: 19m46.073118167s: @caller=/Users/klinou/work/terraform-provider-confluent/internal/provider/resource_tf_importer.go:385 @module=provider tf_provider_addr=provider tf_req_id=d284b409-6749-c0fd-ac85-cb4e6127c461 tf_resource_type=confluent_tf_importer tf_rpc=ApplyResourceChange timestamp=2025-09-15T04:38:19.089-0700
```

And then we figured that [overriding](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) the default creation timeout should help.


Blast Radius
----
- Confluent Cloud customers who are using `confluent_tf_importer` resource will experience blocking errors.

References
----------
* https://confluentinc.atlassian.net/browse/INC-4925

Test & Review
-------------
* https://confluent.slack.com/archives/C08H9NWM0TG/p1757946826089749

In short, we confirmed that importing 2,000 Kafka topics no longer triggers timeout issues and takes roughly two hours.