### PR TITLE
APIE-5943: Fix "gpg failed: exit status 2: gpg: Sorry, we are in batchmode - can't get input" GoReleaser error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,7 +119,7 @@ checksum:
 signs:
   - artifacts: checksum
     cmd: gpg
-    args: ['--batch', '--pinentry-mode', 'loopback', '-u', '{{ .Env.GPG_FINGERPRINT }}', '--output', '${signature}', '--detach-sign', '${artifact}']
+    args: ['--batch', '--pinentry-mode', 'loopback', '--passphrase-fd', '0', '-u', '{{ .Env.GPG_FINGERPRINT }}', '--output', '${signature}', '--detach-sign', '${artifact}']
     stdin: '{{ .Env.GPG_PASSWORD }}'
 
 changelog:

--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -59,7 +59,7 @@ blocks:
             # Import GPG private key
             - echo -e "${GPG_PRIVATE_KEY}" | gpg --import --batch --no-tty
             - echo "foo" > temp.txt
-            - gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${PASSPHRASE}" temp.txt
+            - gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${GPG_PASSWORD}" temp.txt
             - rm temp.txt
             - echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
             - echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf


### PR DESCRIPTION
Release Notes
---------
NA

Checklist
---------
NA

What
----
This PR cherry picks relevant changes from @cqin-confluent's https://github.com/confluentinc/terraform-provider-confluent/pull/813 to resolve "gpg failed: exit status 2: gpg: Sorry, we are in batchmode - can't get input" GoReleaser error.

* [failing Semaphore build](https://semaphore.ci.confluent.io/jobs/50edbb3e-7b4e-4655-8957-cfc91f1186dc)
* [successful Semaphore build](https://semaphore.ci.confluent.io/workflows/2c5380a3-38a2-4beb-9f32-2b08481625af?pipeline_id=7510565c-f96b-4b8c-9a9c-3bbb0af19ae0) (#813)

Blast Radius
----
N/A, as this PR doesn't update the code of the TF Provider.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-594

Test & Review
-------------
* [successful Semaphore build](https://semaphore.ci.confluent.io/workflows/2c5380a3-38a2-4beb-9f32-2b08481625af?pipeline_id=7510565c-f96b-4b8c-9a9c-3bbb0af19ae0) (#813)