### PR TITLE
fix(docs): confluent private link attachment

### DIFF
--- a/docs/data-sources/confluent_private_link_attachment.md
+++ b/docs/data-sources/confluent_private_link_attachment.md
@@ -51,7 +51,7 @@ In addition to the preceding arguments, the following attributes are exported:
     - `private_link_service_alias ` - (Required String) Azure Private Link service alias for the availability zone.
     - `private_link_service_resource_id` - (Required String) Azure Private Link service resource id for the availability zone.
 - `gcp` - (Optional Configuration Block) supports the following:
-  - `private_service_connect_connection_id` - (Required String) GCP Private Service Connect ID used to establish connections for all zones.
+  - `private_service_connect_service_attachment` - (Required String) GCP Private Service Connect ID used to establish connections for all zones.
 
 ## Getting Started
 The following end-to-end examples might help to get started with `confluent_private_link_attachment` data source:

--- a/docs/resources/confluent_private_link_attachment.md
+++ b/docs/resources/confluent_private_link_attachment.md
@@ -53,7 +53,7 @@ In addition to the preceding arguments, the following attributes are exported:
   - `private_link_service_alias ` - (Required String) Azure Private Link service alias for the availability zone.
   - `private_link_service_resource_id` - (Required String) Azure Private Link service resource id for the availability zone.
 - `gcp` - (Optional Configuration Block) supports the following:
-  - `private_service_connect_connection_id` - (Required String) GCP Private Service Connect ID used to establish connections for all zones.
+  - `private_service_connect_service_attachment` - (Required String) GCP Private Service Connect ID used to establish connections for all zones.
 
 ## Import
 


### PR DESCRIPTION


Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

Bug Fixes
- The docs for `confluent_private_link_attachment` incorrectly state that the GCP parameter is `private_service_connect_connection_id`, the correct parameter name for GCP is `private_service_connect_service_attachment`

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Update the docs for `confluent_private_link_attachment` resource and datasource.
The wrong parameter leads to confusion and wasted time
Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
