### PR TITLE
APIE-608: Fix "panic: runtime error: invalid memory address or nil pointer dereference"

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -942,7 +942,7 @@ func createDescriptiveError(err error, resp ...*http.Response) error {
 	// If a *http.Response was provided, and we could not parse Error object,
 	// read its *http.Response body to provide a more descriptive error message to avoid
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/53
-	if errorMessage == err.Error() && len(resp) > 0 && resp[0] != nil {
+	if errorMessage == err.Error() && len(resp) > 0 && resp[0] != nil && resp[0].Body != nil {
 		defer resp[0].Body.Close()
 
 		bodyBytes, readErr := io.ReadAll(resp[0].Body)


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed "panic: runtime error: invalid memory address or nil pointer dereference" issue.


Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes NPE issue in the `utils.go:946`:
```
Stack trace from the terraform-provider-confluent plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105812290]

goroutine 359 [running]:
github.com/confluentinc/terraform-provider-confluent/internal/provider.createDescriptiveError({0x105e16d28, 0x14000a0df10}, {0x140008290f0, 0x1, 0x18?})
        /Users/klinou/work/terraform-provider-confluent/internal/provider/utils.go:946 +0x520
```

Blast Radius
----

Not applicable, as we added additional safety checks.

References
----------
* https://confluentinc.atlassian.net/browse/APIE-608

Test & Review
-------------
* https://confluent.slack.com/archives/C02TG07V058/p1758579654556959

In short, when we ran [this example](https://github.com/confluentinc/terraform-provider-confluent/blob/master/examples/configurations/connectors/managed-datagen-source-connector), and then removed the connector manually using CC UI and then rerun `terraform plan`.

**Before**:
```
confluent_kafka_acl.app-connector-create-on-data-preview-topics: Refreshing state... [id=lkc-0v7356/TOPIC#data-preview#PREFIXED#User:sa-387o07m#*#CREATE#ALLOW]
confluent_kafka_acl.app-consumer-read-on-group: Refreshing state... [id=lkc-0v7356/GROUP#confluent_cli_consumer_#PREFIXED#User:sa-do1681z#*#READ#ALLOW]
confluent_kafka_acl.app-connector-describe-on-cluster: Refreshing state... [id=lkc-0v7356/CLUSTER#kafka-cluster#LITERAL#User:sa-387o07m#*#DESCRIBE#ALLOW]
data.confluent_schema_registry_cluster.essentials: Read complete after 1s [id=lsrc-mqyzpx]
confluent_kafka_acl.app-producer-write-on-topic: Refreshing state... [id=lkc-0v7356/TOPIC#orders#LITERAL#User:sa-6kgpzg6#*#WRITE#ALLOW]
Click to expand inline (12 lines)







[3:58](https://confluent.slack.com/archives/C02TG07V058/p1758581884554359?thread_ts=1758579654.556959&cid=C02TG07V058)
image.png
 
image.png
[3:58](https://confluent.slack.com/archives/C02TG07V058/p1758581924389349?thread_ts=1758579654.556959&cid=C02TG07V058)
Untitled
 
confluent_kafka_acl.app-consumer-read-on-topic: Refreshing state... [id=lkc-0v7356/TOPIC#orders#LITERAL#User:sa-do1681z#*#READ#ALLOW]
confluent_connector.source: Refreshing state... [id=lcc-3jg702]
Planning failed. Terraform encountered an error while generating this plan.
╷
│ Error: Plugin did not respond
│ 
│   with confluent_connector.source,
│   on main.tf line 293, in resource "confluent_connector" "source":
│  293: resource "confluent_connector" "source" {
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵
Stack trace from the terraform-provider-confluent plugin:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105812290]
goroutine 359 [running]:
github.com/confluentinc/terraform-provider-confluent/internal/provider.createDescriptiveError({0x105e16d28, 0x14000a0df10}, {0x140008290f0, 0x1, 0x18?})
        /Users/klinou/work/terraform-provider-confluent/internal/provider/utils.go:946 +0x520
github.com/confluentinc/terraform-provider-confluent/internal/provider.readConnectorAndSetAttributes({0x105e20fa0, 0x140008c6770}, 0x14000aa8300, {0x105ddfd40?, 0x1400025d608}, {0x140008225e8, 0x18}, {0x14000903c10, 0xa}, {0x14000903c50, ...})
```

**After**:
```
confluent_kafka_acl.app-connector-write-on-target-topic: Refreshing state... [id=lkc-r9o09p/TOPIC#orders#LITERAL#User:sa-gq9zx5m#*#WRITE#ALLOW]
confluent_kafka_acl.app-consumer-read-on-topic: Refreshing state... [id=lkc-r9o09p/TOPIC#orders#LITERAL#User:sa-zm68ypz#*#READ#ALLOW]
confluent_connector.source: Refreshing state... [id=lcc-0v7dn9]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # confluent_connector.source will be created
  + resource "confluent_connector" "source" {
      + config_nonsensitive = {
          + "connector.class"          = "DatagenSource"
          + "kafka.auth.mode"          = "SERVICE_ACCOUNT"
          + "kafka.service.account.id" = "sa-gq9zx5m"
          + "kafka.topic"              = "orders"
          + "name"                     = "DatagenSourceConnector_0"
          + "output.data.format"       = "JSON"
          + "quickstart"               = "ORDERS"
          + "tasks.max"                = "1"
        }
      + config_sensitive    = (sensitive value)
      + id                  = (known after apply)
      + status              = (known after apply)

      + environment {
          + id = "env-08n036"
        }

      + kafka_cluster {
          + id = "lkc-r9o09p"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
➜
```