### PR TITLE
[APIE-579] Show more descriptive errors when OAuth token exchange request fails

### DIFF
--- a/internal/provider/oauth.go
+++ b/internal/provider/oauth.go
@@ -175,7 +175,7 @@ func requestNewExternalOAuthToken(ctx context.Context, tokenUrl, clientId, clien
 		if err != nil {
 			return nil, fmt.Errorf("failed to read external token exchange response body: %w", err)
 		}
-		return nil, fmt.Errorf("external token exchange request failed: status=%s, description=%s\n", resp.Status, string(body))
+		return nil, fmt.Errorf("external token exchange request failed: status=%s, description=%s", resp.Status, string(body))
 	}
 
 	// Parse the response

--- a/internal/provider/oauth.go
+++ b/internal/provider/oauth.go
@@ -98,11 +98,14 @@ func requestNewSTSOAuthToken(ctx context.Context, subjectToken, identityPoolId, 
 	tflog.Debug(ctx, "requesting new STS OAuth token")
 
 	resp, status, err := req.Execute()
+	// Both Transport-level error (DNS, timeout, TLS, etc.)
+	// and Application-level error (HTTP 4xx/5xx) are handled here
 	if err != nil {
-		return nil, err
-	}
-	if status.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("STS token exchange request failed with status: %s\n", status.Status)
+		if status != nil && status.Body != nil {
+			body, _ := io.ReadAll(status.Body)
+			return nil, fmt.Errorf("STS token exchange request failed: status=%s, description=%s", status.Status, string(body))
+		}
+		return nil, fmt.Errorf("STS token exchange request failed: %w", err)
 	}
 
 	// Parse the response
@@ -155,19 +158,24 @@ func requestNewExternalOAuthToken(ctx context.Context, tokenUrl, clientId, clien
 	tflog.Debug(ctx, "requesting new external OAuth token")
 
 	resp, err := retryableClient.Do(req)
+	// Transport-level error (DNS, timeout, TLS, etc.)
 	if err != nil {
 		return nil, err
 	}
 
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			tflog.Warn(ctx, "failed to close external token exchange response body", map[string]any{"error": closeErr.Error()})
 		}
-	}(resp.Body)
+	}()
 
+	// Application-level error (HTTP 4xx/5xx)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("exchange external token request failed with status: %s\n", resp.Status)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read external token exchange response body: %w", err)
+		}
+		return nil, fmt.Errorf("external token exchange request failed: status=%s, description=%s\n", resp.Status, string(body))
 	}
 
 	// Parse the response

--- a/internal/provider/oauth.go
+++ b/internal/provider/oauth.go
@@ -140,20 +140,10 @@ func requestNewExternalOAuthToken(ctx context.Context, tokenUrl, clientId, clien
 		return nil, fmt.Errorf("retryable HTTP client is nil, cannot request new external OAuth token")
 	}
 
-	data := url.Values{}
-	data.Set("grant_type", "client_credentials")
-	data.Set("client_id", clientId)
-	data.Set("client_secret", clientSecret)
-	if customScope != "" {
-		data.Set("scope", customScope)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, tokenUrl, strings.NewReader(data.Encode()))
+	req, err := buildExternalOAuthRequest(tokenUrl, clientId, clientSecret, customScope)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to build external OAuth request: %w", err)
 	}
-	req.Header.Set("content-type", "application/x-www-form-urlencoded")
-	req.Header.Set("accept", "application/json")
 
 	tflog.Debug(ctx, "requesting new external OAuth token")
 
@@ -179,40 +169,73 @@ func requestNewExternalOAuthToken(ctx context.Context, tokenUrl, clientId, clien
 	}
 
 	// Parse the response
-	result := &OAuthToken{}
-	resultMap := make(map[string]any)
-	responseBody, _ := io.ReadAll(resp.Body)
-	if err := json.Unmarshal(responseBody, &resultMap); err != nil {
+	result, err := parseExternalOAuthResponse(resp.Body, customScope, identityPoolId, tokenUrl, clientId, clientSecret, retryableClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OAuth response: %w", err)
+	}
+	tflog.Debug(ctx, "new external OAuth token acquired", map[string]any{
+		"expires_in":  result.ExpiresInSeconds + "s",
+		"valid_until": result.ValidUntil.Format(time.RFC3339),
+	})
+	return result, nil
+}
+
+func buildExternalOAuthRequest(tokenURL, clientID, clientSecret, customScope string) (*http.Request, error) {
+	data := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+	}
+	if customScope != "" {
+		data.Set("scope", customScope)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/x-www-form-urlencoded")
+	req.Header.Set("accept", "application/json")
+	return req, nil
+}
+
+func parseExternalOAuthResponse(body io.Reader, customScope, identityPoolId, tokenUrl, clientId, clientSecret string, client *http.Client) (*OAuthToken, error) {
+	raw, err := io.ReadAll(body)
+	if err != nil {
 		return nil, err
 	}
 
-	for k, v := range resultMap {
-		switch k {
-		case "expires_in":
-			result.ExpiresInSeconds = fmt.Sprintf("%v", v)
-			// Be careful about the token expiry time, use half the expiry time as buffer if expiry is too short
-			expiryDuration := time.Duration(v.(float64)) * time.Second
-			buffer := externalTokenExpirationBuffer
-			if expiryDuration <= buffer {
-				buffer = expiryDuration / 2
-			}
-			result.ValidUntil = time.Now().Add(expiryDuration - buffer)
-		case "access_token":
-			result.AccessToken = v.(string)
-		case "token_type":
-			result.TokenType = v.(string)
-		default:
-			// Ignore other fields
-		}
+	var respMap map[string]any
+	if err := json.Unmarshal(raw, &respMap); err != nil {
+		return nil, err
 	}
 
-	// Always override the scope field to the requested scope, as some providers do not return it from the response
-	result.Scope = customScope
-	result.IdentityPoolId = identityPoolId
-	result.TokenUrl = tokenUrl
-	result.ClientId = clientId
-	result.ClientSecret = clientSecret
-	result.HTTPClient = retryableClient
+	result := &OAuthToken{
+		Scope:          customScope,
+		IdentityPoolId: identityPoolId,
+		TokenUrl:       tokenUrl,
+		ClientId:       clientId,
+		ClientSecret:   clientSecret,
+		HTTPClient:     client,
+	}
+
+	if v, ok := respMap["access_token"].(string); ok {
+		result.AccessToken = v
+	}
+	if v, ok := respMap["token_type"].(string); ok {
+		result.TokenType = v
+	}
+	if v, ok := respMap["expires_in"]; ok {
+		result.ExpiresInSeconds = fmt.Sprintf("%v", v)
+		// Be careful about the token expiry time, use half the expiry time as buffer if expiry is too short
+		expiryDuration := time.Duration(v.(float64)) * time.Second
+		buffer := externalTokenExpirationBuffer
+		if expiryDuration <= buffer {
+			buffer = expiryDuration / 2
+		}
+		result.ValidUntil = time.Now().Add(expiryDuration - buffer)
+	}
+
 	return result, nil
 }
 

--- a/internal/provider/resource_schema_exporter.go
+++ b/internal/provider/resource_schema_exporter.go
@@ -327,20 +327,9 @@ func readSchemaExporterAndSetAttributes(ctx context.Context, d *schema.ResourceD
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Fetched Schema Exporter %q: %s", id, exporterJson), map[string]interface{}{schemaExporterLoggingKey: id})
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading Schema Exporter Status %q", name))
-	status, resp, err := c.apiClient.ExportersV1Api.GetExporterStatusByName(c.apiContext(ctx), name).Execute()
-	if err != nil {
-		return nil, fmt.Errorf("error creating Schema Exporter Status: %s", createDescriptiveError(err, resp))
-	}
-	if status.GetState() == stateRunning {
-		if err := d.Set(paramStatus, stateRunning); err != nil {
-			return nil, err
-		}
-	}
-	if status.GetState() == statePaused {
-		if err := d.Set(paramStatus, statePaused); err != nil {
-			return nil, err
-		}
+	// Read and set the Schema Exporter status with a different API call
+	if err := readSchemaExporterStatusAndSetAttributes(ctx, d, c, id, name); err != nil {
+		return nil, err
 	}
 
 	if _, err := setSchemaExporterAttributes(d, clusterId, exporter, c, meta); err != nil {
@@ -561,18 +550,48 @@ func setSchemaExporterAttributes(d *schema.ResourceData, clusterId string, expor
 	}
 
 	configs := exporter.GetConfig()
+	if err := setDestinationSchemaRegistryClusterAttributes(d, configs, meta.(*Client).isOAuthEnabled); err != nil {
+		return nil, err
+	}
+
+	removeSensitiveInfoFromConfigs(configs, standardConfigs, oauthBearConfigs)
+	if err := d.Set(paramConfigs, configs); err != nil {
+		return nil, err
+	}
+
+	d.SetId(createExporterId(clusterId, exporter.GetName()))
+	return d, nil
+}
+
+func readSchemaExporterStatusAndSetAttributes(ctx context.Context, d *schema.ResourceData, c *SchemaRegistryRestClient, id, name string) error {
+	tflog.Debug(ctx, fmt.Sprintf("Reading Schema Exporter Status %q", name))
+	status, resp, err := c.apiClient.ExportersV1Api.GetExporterStatusByName(c.apiContext(ctx), name).Execute()
+	if err != nil {
+		return fmt.Errorf("error reading Schema Exporter %q Status: %s", id, createDescriptiveError(err, resp))
+	}
+	switch state := status.GetState(); state {
+	case stateRunning, statePaused:
+		// valid states at this point
+		if err := d.Set(paramStatus, state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setDestinationSchemaRegistryClusterAttributes(d *schema.ResourceData, configs map[string]string, isOAuthEnabled bool) error {
 	destinationClusterId := configs[bearerAuthLogicalCluster]
 	destinationClusterEndpoint := configs[schemaRegistryUrlConfig]
 	destinationSRClusterApiKey := extractStringValueFromNestedBlock(d, paramDestinationSchemaRegistryCluster, paramCredentials, paramKey)
 	destinationSRClusterApiSecret := extractStringValueFromNestedBlock(d, paramDestinationSchemaRegistryCluster, paramCredentials, paramSecret)
 
-	if meta.(*Client).isOAuthEnabled {
+	if isOAuthEnabled {
 		if err := d.Set(paramDestinationSchemaRegistryCluster, []interface{}{map[string]interface{}{
 			paramId:           destinationClusterId,
 			paramRestEndpoint: destinationClusterEndpoint,
 		},
 		}); err != nil {
-			return nil, err
+			return err
 		}
 	} else {
 		if err := d.Set(paramDestinationSchemaRegistryCluster, []interface{}{map[string]interface{}{
@@ -582,25 +601,18 @@ func setSchemaExporterAttributes(d *schema.ResourceData, clusterId string, expor
 				paramSecret: destinationSRClusterApiSecret,
 			}},
 		}}); err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
 
-	// Remove the API key/secret authentication related configs from the user provided configs
-	for _, key := range standardConfigs {
-		delete(configs, key)
+func removeSensitiveInfoFromConfigs(configs map[string]string, keysGroupToRemove ...[]string) {
+	for _, group := range keysGroupToRemove {
+		for _, key := range group {
+			delete(configs, key)
+		}
 	}
-	// Remove the OAuth authentication related configs from the user provided configs
-	for _, key := range oauthBearConfigs {
-		delete(configs, key)
-	}
-
-	if err := d.Set(paramConfigs, configs); err != nil {
-		return nil, err
-	}
-
-	d.SetId(createExporterId(clusterId, exporter.GetName()))
-	return d, nil
 }
 
 func createExporterId(clusterId, exporterName string) string {

--- a/internal/provider/resource_schema_exporter.go
+++ b/internal/provider/resource_schema_exporter.go
@@ -57,7 +57,7 @@ const (
 )
 
 var standardConfigs = []string{basicAuthUserInfoConfig, schemaRegistryUrlConfig, basicAuthCredentialsSourceConfig}
-var oauthBearConfigs = []string{bearerAuthClientId, bearerAuthClientSecret, bearerAuthIssuerEndpointUrl, bearerAuthCredentialsSource, bearerAuthScope, bearerAuthIdentityPoolId, bearerAuthLogicalCluster, configOAuthBearer}
+var oauthBearerConfigs = []string{bearerAuthClientId, bearerAuthClientSecret, bearerAuthIssuerEndpointUrl, bearerAuthCredentialsSource, bearerAuthScope, bearerAuthIdentityPoolId, bearerAuthLogicalCluster, configOAuthBearer}
 
 func schemaExporterResource() *schema.Resource {
 	return &schema.Resource{
@@ -554,7 +554,7 @@ func setSchemaExporterAttributes(d *schema.ResourceData, clusterId string, expor
 		return nil, err
 	}
 
-	removeSensitiveInfoFromConfigs(configs, standardConfigs, oauthBearConfigs)
+	removeSensitiveInfoFromConfigs(configs, standardConfigs, oauthBearerConfigs)
 	if err := d.Set(paramConfigs, configs); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Added error descriptions when token exchange request fails using OAuth authentication.

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

This PR is an enhancement on top of the existing OAuth authentication support, it includes more descriptive errors for when external/STS token exchange request fails.

The benefit is that users will have more context into why the Terraform fails plan/apply with better correction items, such as:

- Invalid client id/secret
- Invalid identity pool
- Incorrect scope
- Incorrect RBAC role for the identity pool
- Incorrect token request URL
- and so on

Also, this PR introduces a minor refactor on the function of `setSchemaExporterAttributes()` and `requestNewExternalOAuthToken()` to reduce the cognitive complexity as reported by the Copilot.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

When OAuth is enabled, users may see unexpected error message when external/STS token exchange request fails.

The impact is restricted with debugging and shouldn't affect the normal usage of OAuth for Terraform provider Confluent.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/APIE-579

https://confluent.slack.com/archives/C01880K2BAA/p1756410861475649?thread_ts=1755615175.972819&cid=C01880K2BAA

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
The manual verification result for both Entra ID and Okta can be found:
https://confluent.slack.com/archives/C02TG07V058/p1759523353541859

The manual verification result for the refactor work can be found here to ensure the logic is the same:
https://confluent.slack.com/archives/C02TG07V058/p1758921182381939?thread_ts=1758921124.841769&cid=C02TG07V058