### PR TITLE
INC-5632: Add import functionality to confluent_catalog_entity_attributes resource.

### DIFF
--- a/docs/resources/confluent_catalog_entity_attributes.md
+++ b/docs/resources/confluent_catalog_entity_attributes.md
@@ -212,7 +212,7 @@ In addition to the preceding arguments, the following attributes are exported:
 
 ## Import
 
-You can import a Catalog Entity Attributes resource by using the Schema Registry Cluster ID, Entity name in the format `<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>`, for example:
+You can import a Catalog Entity Attributes resource by using the Schema Registry Cluster ID, Entity name in the format `<Schema Registry Cluster ID>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>`, for example:
 
 ```shell
 # Option #1: Manage multiple Catalog Entity Attributes in the same Terraform workspace
@@ -224,5 +224,7 @@ $ terraform import confluent_catalog_entity_attributes.environment lsrc-abc123/c
 # Option #2: Manage a single Catalog Entity Attributes in the same Terraform workspace
 $ terraform import confluent_catalog_entity_attributes.environment lsrc-abc123/cf_environment/env-abc123/owner,description,ownerEmail
 ```
+
+-> **Note:** Use the `<Schema Registry Cluster ID>/<Entity Type>/<Entity Name>/` format to import a Catalog Entity Attributes resource with an empty list of attributes.
 
 !> **Warning:** Do not forget to delete terminal command history afterwards for security purposes.

--- a/docs/resources/confluent_catalog_entity_attributes.md
+++ b/docs/resources/confluent_catalog_entity_attributes.md
@@ -209,3 +209,20 @@ The following arguments are supported:
 In addition to the preceding arguments, the following attributes are exported:
 
 - `id` - (Required String) The ID of the Entity Attributes, in the format `<Entity Type>/<Entity Name>`, for example, `lsrc-8wrx70/PII/lsrc-8wrx70:.:100001/sr_schema`.
+
+## Import
+
+You can import a Catalog Entity Attributes resource by using the Schema Registry Cluster ID, Entity name in the format `<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>`, for example:
+
+```shell
+# Option #1: Manage multiple Catalog Entity Attributes in the same Terraform workspace
+$ export IMPORT_SCHEMA_REGISTRY_API_KEY="<schema_registry_api_key>"
+$ export IMPORT_SCHEMA_REGISTRY_API_SECRET="<schema_registry_api_secret>"
+$ export IMPORT_SCHEMA_REGISTRY_REST_ENDPOINT="<schema_registry_rest_endpoint>"
+$ terraform import confluent_catalog_entity_attributes.environment lsrc-abc123/cf_environment/env-abc123/owner,description,ownerEmail
+
+# Option #2: Manage a single Catalog Entity Attributes in the same Terraform workspace
+$ terraform import confluent_catalog_entity_attributes.environment lsrc-abc123/cf_environment/env-abc123/owner,description,ownerEmail
+```
+
+!> **Warning:** Do not forget to delete terminal command history afterwards for security purposes.

--- a/internal/provider/resource_catalog_entity_attributes.go
+++ b/internal/provider/resource_catalog_entity_attributes.go
@@ -361,7 +361,6 @@ func catalogEntityAttributesImport(ctx context.Context, d *schema.ResourceData, 
 	parts := strings.Split(entityAttributesId, "/")
 	if len(parts) != 4 {
 		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: expected '<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>' (for example, 'lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail')")
-		// TODO: add a note saying that <Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/ should be used for 0 attributes
 	}
 
 	clusterId := parts[0]

--- a/internal/provider/resource_catalog_entity_attributes.go
+++ b/internal/provider/resource_catalog_entity_attributes.go
@@ -360,7 +360,7 @@ func catalogEntityAttributesImport(ctx context.Context, d *schema.ResourceData, 
 
 	parts := strings.Split(entityAttributesId, "/")
 	if len(parts) != 4 {
-		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: expected '<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>' (e.g., 'lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail')")
+		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: expected '<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>' (for example, 'lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail')")
 	}
 
 	clusterId := parts[0]

--- a/internal/provider/resource_catalog_entity_attributes.go
+++ b/internal/provider/resource_catalog_entity_attributes.go
@@ -361,6 +361,7 @@ func catalogEntityAttributesImport(ctx context.Context, d *schema.ResourceData, 
 	parts := strings.Split(entityAttributesId, "/")
 	if len(parts) != 4 {
 		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: expected '<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>' (for example, 'lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail')")
+		// TODO: add a note saying that <Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/ should be used for 0 attributes
 	}
 
 	clusterId := parts[0]

--- a/internal/provider/resource_catalog_entity_attributes.go
+++ b/internal/provider/resource_catalog_entity_attributes.go
@@ -371,7 +371,7 @@ func catalogEntityAttributesImport(ctx context.Context, d *schema.ResourceData, 
 	// Parse and validate attributes
 	initialAttributes, err := parseImportAttributes(attributesList)
 	if err != nil {
-		return nil, fmt.Errorf("error importing Entity Attributes: %s", err.Error())
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
 	}
 
 	if err := d.Set(paramAttributes, initialAttributes); err != nil {

--- a/internal/provider/resource_catalog_entity_attributes.go
+++ b/internal/provider/resource_catalog_entity_attributes.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -37,6 +38,9 @@ func catalogEntityAttributesResource() *schema.Resource {
 		CreateContext: catalogEntityAttributesCreate,
 		DeleteContext: catalogEntityAttributesDelete,
 		UpdateContext: catalogEntityAttributesUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: catalogEntityAttributesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			paramSchemaRegistryCluster: schemaRegistryClusterBlockSchema(),
 			paramRestEndpoint: {
@@ -129,34 +133,38 @@ func catalogEntityAttributesRead(ctx context.Context, d *schema.ResourceData, me
 	entityAttributesId := d.Id()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading Entity Attributes %q=%q", paramId, entityAttributesId), map[string]interface{}{entityAttributesLoggingKey: entityAttributesId})
-	if _, err := readEntityAttributesAndSetAttributes(ctx, d, meta); err != nil {
-		return diag.FromErr(fmt.Errorf("error reading Entity Attributes %q: %s", entityAttributesId, createDescriptiveError(err)))
+
+	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
 	}
+	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
+	}
+	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, false)
+	if err != nil {
+		return diag.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
+	}
+	catalogRestClient := meta.(*Client).catalogRestClientFactory.CreateCatalogRestClient(restEndpoint, clusterId, clusterApiKey, clusterApiSecret, meta.(*Client).isSchemaRegistryMetadataSet, meta.(*Client).oauthToken)
+	entityName := d.Get(paramEntityName).(string)
+	entityType := d.Get(paramEntityType).(string)
+
+	_, err = readEntityAttributesAndSetAttributes(ctx, d, catalogRestClient, entityType, entityName)
+	if err != nil {
+		return diag.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Finished reading Entity Attributes %q", d.Id()), map[string]any{entityAttributesLoggingKey: d.Id()})
 
 	return nil
 }
 
-func readEntityAttributesAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, false)
-	if err != nil {
-		return nil, fmt.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
-	}
-	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, false)
-	if err != nil {
-		return nil, fmt.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
-	}
-	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, false)
-	if err != nil {
-		return nil, fmt.Errorf("error reading Entity Attributes: %s", createDescriptiveError(err))
-	}
-
-	entityName := d.Get(paramEntityName).(string)
-	entityType := d.Get(paramEntityType).(string)
+func readEntityAttributesAndSetAttributes(ctx context.Context, d *schema.ResourceData, catalogRestClient *CatalogRestClient, entityType, entityName string) ([]*schema.ResourceData, error) {
 	entityAttributesId := createEntityAttributesId(entityType, entityName)
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading Entity Attributes %q=%q", paramId, entityAttributesId), map[string]interface{}{entityAttributesLoggingKey: entityAttributesId})
 
-	catalogRestClient := meta.(*Client).catalogRestClientFactory.CreateCatalogRestClient(restEndpoint, clusterId, clusterApiKey, clusterApiSecret, meta.(*Client).isSchemaRegistryMetadataSet, meta.(*Client).oauthToken)
 	request := catalogRestClient.apiClient.EntityV1Api.GetByUniqueAttributes(catalogRestClient.dataCatalogApiContext(ctx), entityType, entityName)
 	entity, resp, err := request.Execute()
 	if err != nil {
@@ -331,4 +339,78 @@ func resetAttributes(entityAttributes map[string]interface{}) {
 	for attributeName, _ := range entityAttributes {
 		entityAttributes[attributeName] = ""
 	}
+}
+
+func catalogEntityAttributesImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	tflog.Debug(ctx, fmt.Sprintf("Importing Entity Attributes %q", d.Id()), map[string]any{entityAttributesLoggingKey: d.Id()})
+
+	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, true)
+	if err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
+	}
+	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, true)
+	if err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
+	}
+
+	entityAttributesId := d.Id()
+	if entityAttributesId == "" {
+		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: Entity Attributes import ID is missing")
+	}
+
+	parts := strings.Split(entityAttributesId, "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("error importing Entity Attributes: invalid format: expected '<Schema Registry Cluster Id>/<Entity Type>/<Entity Name>/<Comma-Delimited-Attributes>' (e.g., 'lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail')")
+	}
+
+	clusterId := parts[0]
+	entityType := parts[1]
+	entityName := parts[2]
+	attributesList := parts[3]
+
+	// Parse and validate attributes
+	initialAttributes, err := parseImportAttributes(attributesList)
+	if err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", err.Error())
+	}
+
+	if err := d.Set(paramAttributes, initialAttributes); err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
+	}
+	if err := d.Set(paramEntityName, entityName); err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
+	}
+	if err := d.Set(paramEntityType, entityType); err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes: %s", createDescriptiveError(err))
+	}
+
+	catalogRestClient := meta.(*Client).catalogRestClientFactory.CreateCatalogRestClient(restEndpoint, clusterId, clusterApiKey, clusterApiSecret, meta.(*Client).isSchemaRegistryMetadataSet, meta.(*Client).oauthToken)
+
+	// Mark resource as new to avoid d.Set("") when getting 404
+	d.MarkNewResource()
+	_, err = readEntityAttributesAndSetAttributes(ctx, d, catalogRestClient, entityType, entityName)
+	if err != nil {
+		return nil, fmt.Errorf("error importing Entity Attributes %q: %s", d.Id(), createDescriptiveError(err))
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Finished importing Entity Attributes %q", d.Id()), map[string]any{entityAttributesLoggingKey: d.Id()})
+	return []*schema.ResourceData{d}, nil
+}
+
+func parseImportAttributes(attributesList string) (map[string]interface{}, error) {
+	// Allow empty attributes list
+	if attributesList == "" {
+		return make(map[string]interface{}), nil
+	}
+
+	attributeNames := strings.Split(attributesList, ",")
+	initialAttributes := make(map[string]interface{})
+
+	for _, attrName := range attributeNames {
+		attrName = strings.TrimSpace(attrName)
+		if attrName != "" && attrName != qualifiedName {
+			initialAttributes[attrName] = ""
+		}
+	}
+
+	return initialAttributes, nil
 }

--- a/internal/provider/resource_catalog_entity_attributes_test.go
+++ b/internal/provider/resource_catalog_entity_attributes_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/walkerus/go-wiremock"
 	"io/ioutil"
 	"net/http"
@@ -32,6 +33,8 @@ const (
 	readCreatedEntityAttributesUrlPath          = "/catalog/v1/entity/type/kafka_topic/name/lkc-15xq83:topic_0"
 	deleteCreatedEntityAttributesUrlPath        = "/catalog/v1/entity"
 	entityAttributesLabel                       = "confluent_catalog_entity_attributes.main"
+	testDataCatalogSchemaRegistryClusterID      = "lsrc-8wrx70"
+	testAttributesToImport                      = "owner,description,ownerEmail"
 )
 
 func TestAccCatalogEntityAttributes(t *testing.T) {
@@ -43,7 +46,8 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 	}
 	defer wiremockContainer.Terminate(ctx)
 
-	mockServerUrl := wiremockContainer.URI
+	//mockServerUrl := wiremockContainer.URI
+	mockServerUrl := "http://localhost:8080"
 	wiremockClient := wiremock.NewClient(mockServerUrl)
 	// nolint:errcheck
 	defer wiremockClient.Reset()
@@ -109,7 +113,7 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: entityAttributesResourceConfig(mockServerUrl),
+				Config: entityAttributesResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityName, "lkc-15xq83:topic_0"),
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityType, "kafka_topic"),
@@ -121,7 +125,18 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 				),
 			},
 			{
-				Config: entityAttributesSchemaRegistryResourceConfig(mockServerUrl),
+				// https://www.terraform.io/docs/extend/resources/import.html
+				ResourceName:      entityAttributesLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					entityTypeAndEntityName := resources[entityAttributesLabel].Primary.ID
+					return testDataCatalogSchemaRegistryClusterID + "/" + entityTypeAndEntityName + "/" + testAttributesToImport, nil
+				},
+			},
+			{
+				Config: entityAttributesSchemaRegistryResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityName, "lkc-15xq83:topic_0"),
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityType, "kafka_topic"),
@@ -133,7 +148,18 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 				),
 			},
 			{
-				Config: updateEntityAttributesResourceConfig(mockServerUrl),
+				// https://www.terraform.io/docs/extend/resources/import.html
+				ResourceName:      entityAttributesLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					entityTypeAndEntityName := resources[entityAttributesLabel].Primary.ID
+					return testDataCatalogSchemaRegistryClusterID + "/" + entityTypeAndEntityName + "/" + testAttributesToImport, nil
+				},
+			},
+			{
+				Config: updateEntityAttributesResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityName, "lkc-15xq83:topic_0"),
 					resource.TestCheckResourceAttr(entityAttributesLabel, paramEntityType, "kafka_topic"),
@@ -144,14 +170,25 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(entityAttributesLabel, fmt.Sprintf("%s.ownerEmail", paramAttributes), "dev2@gmail.com"),
 				),
 			},
+			{
+				// https://www.terraform.io/docs/extend/resources/import.html
+				ResourceName:      entityAttributesLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					entityTypeAndEntityName := resources[entityAttributesLabel].Primary.ID
+					return testDataCatalogSchemaRegistryClusterID + "/" + entityTypeAndEntityName + "/" + testAttributesToImport, nil
+				},
+			},
 		},
 	})
 }
 
-func entityAttributesResourceConfig(mockServerUrl string) string {
+func entityAttributesResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
- 	  schema_registry_id = "xxx"
+ 	  schema_registry_id = "%s"
 	  catalog_rest_endpoint = "%s"          # optionally use SCHEMA_REGISTRY_REST_ENDPOINT env var
 	  schema_registry_api_key       = "x"   # optionally use SCHEMA_REGISTRY_API_KEY env var
 	  schema_registry_api_secret = "x"
@@ -165,13 +202,13 @@ func entityAttributesResourceConfig(mockServerUrl string) string {
 		"ownerEmail": "dev@gmail.com"
 	  }
 	}
- 	`, mockServerUrl)
+ 	`, testDataCatalogSchemaRegistryClusterID, mockServerUrl)
 }
 
-func entityAttributesSchemaRegistryResourceConfig(mockServerUrl string) string {
+func entityAttributesSchemaRegistryResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
- 	  schema_registry_id = "xxx"
+ 	  schema_registry_id = "%s"
 	  schema_registry_rest_endpoint = "%s" # optionally use SCHEMA_REGISTRY_REST_ENDPOINT env var
 	  schema_registry_api_key       = "x"       # optionally use SCHEMA_REGISTRY_API_KEY env var
 	  schema_registry_api_secret = "x"
@@ -185,13 +222,13 @@ func entityAttributesSchemaRegistryResourceConfig(mockServerUrl string) string {
 		"ownerEmail": "dev@gmail.com"
 	  }
 	}
- 	`, mockServerUrl)
+ 	`, testDataCatalogSchemaRegistryClusterID, mockServerUrl)
 }
 
-func updateEntityAttributesResourceConfig(mockServerUrl string) string {
+func updateEntityAttributesResourceConfig(testDataCatalogSchemaRegistryClusterID, mockServerUrl string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
- 	  schema_registry_id = "xxx"
+ 	  schema_registry_id = "%s"
 	  schema_registry_rest_endpoint = "%s" # optionally use SCHEMA_REGISTRY_REST_ENDPOINT env var
 	  schema_registry_api_key       = "x"       # optionally use SCHEMA_REGISTRY_API_KEY env var
 	  schema_registry_api_secret = "x"
@@ -205,5 +242,5 @@ func updateEntityAttributesResourceConfig(mockServerUrl string) string {
 		"ownerEmail": "dev2@gmail.com"
 	  }
 	}
- 	`, mockServerUrl)
+ 	`, testDataCatalogSchemaRegistryClusterID, mockServerUrl)
 }

--- a/internal/provider/resource_catalog_entity_attributes_test.go
+++ b/internal/provider/resource_catalog_entity_attributes_test.go
@@ -46,8 +46,7 @@ func TestAccCatalogEntityAttributes(t *testing.T) {
 	}
 	defer wiremockContainer.Terminate(ctx)
 
-	//mockServerUrl := wiremockContainer.URI
-	mockServerUrl := "http://localhost:8080"
+	mockServerUrl := wiremockContainer.URI
 	wiremockClient := wiremock.NewClient(mockServerUrl)
 	// nolint:errcheck
 	defer wiremockClient.Reset()


### PR DESCRIPTION
Release Notes
---------
New Features
- Added import functionality for the `confluent_catalog_entity_attributes ` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_entity_attributes).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR (hot-fix) resolves a feature gap where `terraform import` was not supported for the `confluent_catalog_entity_attributes ` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_entity_attributes). This PR is a follow up item to the https://github.com/confluentinc/terraform-provider-confluent/issues/822.

The implementation strategy: 
1. Refactored read and import methods for code reuse
We refactored both the read and import methods to follow the same pattern used in confluent_tag and confluent_kafka_topic resources. This allows both methods to share the readEntityAttributesAndSetAttributes() function. The key change is that readEntityAttributesAndSetAttributes() now accepts a client and specific attributes as parameters instead of a generic meta argument. This is a standard pattern widely used across other resources in the provider.

2. Explicitly set entity name and type during import
During import, we explicitly set paramEntityName and paramEntityType because the API response might return a different entity name than what the user provided. As noted in the code: "The entity name returned from api response might be different from user input, so we stick with user's input value" [link](https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/provider/resource_catalog_entity_attributes.go#L302C5-L302C119)
3. Handle selective attribute filtering during import
This resource has a unique challenge: entities can have [many attributes](https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/testdata/entity_attributes/create_entity_attributes.json#L5-L56), but the current Terraform implementation only tracks attributes explicitly defined in the configuration file—all others are ignored.

Since terraform import doesn't have access to the Terraform configuration, we updated the import ID format to include a comma-delimited list of attributes that should be imported:
```
For example: lsrc-abc123/kafka_topic/lkc-xyz:topic_0/owner,description,ownerEmail
```
The new parseImportAttributes() function parses this list and creates a map with empty string values as placeholders. This ensures the existing setEntityAttributesAttributes() logic works correctly by giving it a list of expected attribute keys to filter from the API response.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
* https://confluentinc.atlassian.net/browse/INC-5632
* https://github.com/confluentinc/terraform-provider-confluent/issues/822.

Test & Review
-------------
We validated the import functionality through multiple testing approaches:

1. Manual testing: Verified both Terraform drift detection and manual import commands work correctly. Tested two scenarios:
- Importing with no attributes (len(attributes) = 0)
- Importing with multiple attributes (len(attributes) = 3)
- [link](https://docs.google.com/document/d/1_ZuBDVJ3RSi777_c7wSRzNQoHu8RYZkTwwY569VSOJI/edit?usp=sharing)
2. Acceptance tests: Updated the test suite in internal/provider/resource_catalog_entity_attributes_test.go to include import test cases
3. Live tests: Skipped for this PR since it's a hotfix and there are currently no existing live tests for this resource
