### PR TITLE
APIE-647: Update PNI and Freight examples

### DIFF
--- a/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
+++ b/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
@@ -415,7 +415,7 @@ resource "confluent_kafka_cluster" "enterprise" {
   }
 
   depends_on = [
-    aws_network_interface_permission.main
+    confluent_access_point.aws
   ]
 }
 

--- a/examples/configurations/freight-aws-kafka-rbac/main.tf
+++ b/examples/configurations/freight-aws-kafka-rbac/main.tf
@@ -410,7 +410,7 @@ resource "confluent_kafka_cluster" "freight" {
   }
 
   depends_on = [
-    aws_network_interface_permission.main
+    confluent_access_point.aws
   ]
 }
 


### PR DESCRIPTION
Release Notes
---------
Examples
- Update `enterprise-pni-aws-kafka-rbac` and `freight-aws-kafka-rbac` examples to resolve potential dependency issues.

Checklist
---------
NA, as there were no code changes.

What
----
This PR updates our both PNI examples to make sure that the access point is created first and minimize potential dependency errors / TF drift in the endpoint state of the Kafka cluster.

Blast Radius
----
`enterprise-pni-aws-kafka-rbac` and `freight-aws-kafka-rbac` examples may stop working for their new invocations.

References
----------
* https://confluent.slack.com/archives/C09LJDNNFH6/p1760547342548659

Test & Review
-------------
```
➜  enterprise-pni-aws-kafka-rbac git:(update-pni-examples) ✗ terraform validate

Success! The configuration is valid, but there were some validation warnings as shown above.

➜  enterprise-pni-aws-kafka-rbac git:(update-pni-examples) ✗ cd ../freight-aws-kafka-rbac                               
➜  freight-aws-kafka-rbac git:(update-pni-examples) ✗ terraform validate

Success! The configuration is valid, but there were some validation warnings as shown above.
```
