### PR TITLE
[APIE-652] Refactor the OAuth validation logic for resource metadata in provider block

### DIFF
--- a/docs/guides/migration-guide-oauth.md
+++ b/docs/guides/migration-guide-oauth.md
@@ -1,7 +1,7 @@
 ---
 page_title: "Confluent Provider 2.46.0: Upgrade Guide for OAuth Authentication Migration"
 ---
-# Confluent Provider 2.45.0: Upgrade Guide for OAuth Authentication Migration
+# Confluent Provider 2.46.0: Upgrade Guide for OAuth Authentication Migration
 
 ## Summary
 


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- Fixed an incorrect validation issue when migration from the API key/secret to OAuth authentication with option#2.

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
This PR refactored the validation logic of checking the provider level resource specific metadata, to ensure that we have separate handling between OAuth and non-OAuth authentication.

Also, the refactor includes 2 dedicated functions to handling the validation to improve the readability:
`validateAllOrNoneAttributesSetForResourcesWithOAuth()` - For OAuth authentication
`validateAllOrNoneAttributesSetForResources()` - For non-OAuth authentication (no changes compared to prior version)

Basically it's a fix of the reported Terraform provider issue:
https://github.com/confluentinc/terraform-provider-confluent/issues/862

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Customers migrate from API key/secret to OAuth authentication may see unexpected 40x errors for all resources/data-sources if something went wrong.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
https://confluentinc.atlassian.net/browse/APIE-652
https://github.com/confluentinc/terraform-provider-confluent/issues/862

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
The manual verification result can be found here, with/with-out the OAuth migration:
https://confluent.slack.com/archives/C02TG07V058/p1760747082459579