### PR TITLE
[APIE-654] Add Unity Catalog support and fix an error in the catalog data source for Snowflake catalogs

### DIFF
--- a/docs/data-sources/confluent_catalog_integration.md
+++ b/docs/data-sources/confluent_catalog_integration.md
@@ -89,4 +89,7 @@ In addition to the preceding arguments, the following attributes are exported:
     - `endpoint` - (Required String) The catalog integration connection endpoint for Snowflake Open Catalog.
     - `warehouse` - (Required String) Warehouse name of the Snowflake Open Catalog.
     - `allowed_scope` - (Required String) Allowed scope of the Snowflake Open Catalog.
+- `unity` (Optional Configuration Block) supports the following:
+    - `workspace_endpoint` - (Required String) The Databricks workspace URL associated with the Unity Catalog.
+    - `catalog_name` - (Required String) The name of the catalog within Unity Catalog.
 - `suspended` - (Optional Boolean) Indicates whether the Catalog Integration should be suspended.

--- a/docs/resources/confluent_catalog_integration.md
+++ b/docs/resources/confluent_catalog_integration.md
@@ -94,6 +94,11 @@ The following arguments are supported:
     - `client_secret` - (Required String, Sensitive) The client secret of the catalog integration.
     - `warehouse` - (Required String) Warehouse name of the Snowflake Open Catalog, for example, `catalog-name`.
     - `allowed_scope` - (Required String) Allowed scope of the Snowflake Open Catalog.
+- `unity` (Optional Configuration Block) supports the following (see [Integrate Tableflow with Unity Catalog in Confluent Cloud](https://docs.confluent.io/cloud/current/topics/tableflow/how-to-guides/catalog-integration/integrate-with-unity-catalog.html) for more details):
+    - `workspace_endpoint` - (Required String) The Databricks workspace URL associated with the Unity Catalog, for example, `https://user1.cloud.databricks.com`.
+    - `catalog_name` - (Required String) The name of the catalog within Unity Catalog.
+    - `client_id` - (Required String, Sensitive) The OAuth client ID used to authenticate with the Unity Catalog.
+    - `client_secret` - (Required String, Sensitive) The OAuth client secret used for authentication with the Unity Catalog.
 - `credentials` (Optional Configuration Block) supports the following:
     - `key` - (Required String) The Tableflow API Key.
     - `secret` - (Required String, Sensitive) The Tableflow API Secret.

--- a/docs/resources/confluent_tableflow_topic.md
+++ b/docs/resources/confluent_tableflow_topic.md
@@ -12,7 +12,7 @@ description: |-
 
 -> **Note:** It is recommended to set `lifecycle { prevent_destroy = true }` on production instances to prevent accidental tableflow topic deletion. This setting rejects plans that would destroy or recreate the tableflow topic, such as attempting to change uneditable attributes. Read more about it in the [Terraform docs](https://www.terraform.io/language/meta-arguments/lifecycle#prevent_destroy).
 
--> **Note:** Make sure to use `confluent_catalog_integration` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_integration) if you want to integrate Tableflow with AWS Glue Catalog or Snowflake Open Catalog.
+-> **Note:** Make sure to use `confluent_catalog_integration` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_integration) if you want to integrate Tableflow with AWS Glue Catalog, Snowflake Open Catalog, or Unity Catalog.
 
 ## Example Usage
 

--- a/internal/provider/data_source_catalog_integration.go
+++ b/internal/provider/data_source_catalog_integration.go
@@ -48,6 +48,7 @@ func catalogIntegrationDataSource() *schema.Resource {
 			paramCredentials:  credentialsSchema(),
 			paramAwsGlue:      awsGlueDataSourceSchema(),
 			paramSnowflake:    snowflakeDataSourceSchema(),
+			paramUnity:        unityDataSourceSchema(),
 		},
 	}
 }
@@ -123,6 +124,27 @@ func snowflakeDataSourceSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "Allowed scope of the Snowflake Open Catalog.",
+				},
+			},
+		},
+		Computed: true,
+	}
+}
+
+func unityDataSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				paramWorkspaceEndpoint: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The Databricks workspace URL associated with the Unity Catalog.",
+				},
+				paramCatalogName: {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The name of the catalog within Unity Catalog.",
 				},
 			},
 		},

--- a/internal/provider/data_source_catalog_integration_test.go
+++ b/internal/provider/data_source_catalog_integration_test.go
@@ -15,7 +15,7 @@ const (
 	CatalogIntegrationDataSourceScenarioName = "confluent_catalog_integration Data Source Lifecycle"
 )
 
-func TestAccDataSourceCatalogIntegration(t *testing.T) {
+func TestAccDataSourceCatalogIntegrationAwsGlue(t *testing.T) {
 	ctx := context.Background()
 
 	wiremockContainer, err := setupWiremock(ctx)
@@ -60,12 +60,121 @@ func TestAccDataSourceCatalogIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "suspended", "false"),
 					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "aws_glue.#", "1"),
 					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.#", "0"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "unity.#", "0"),
 					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "aws_glue.0.provider_integration_id", "cspi-stgce89r7"),
 				),
 			},
 		},
 	})
+}
 
+func TestAccDataSourceCatalogIntegrationSnowflake(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	readCatalogIntegrationResponse, _ := os.ReadFile("../testdata/catalog_integration/read_created_snowflake_ci.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/tableflow/v1/catalog-integrations/tci-abc123")).
+		InScenario(CatalogIntegrationDataSourceScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(readCatalogIntegrationResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	CatalogIntegrationResourceName := "data.confluent_catalog_integration.main"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDataSourceCatalogIntegration(mockServerUrl, "tci-abc123"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "id", "tci-abc123"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "display_name", "catalog_integration_1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "environment.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "environment.0.id", "env-abc123"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "kafka_cluster.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "kafka_cluster.0.id", "lkc-00000"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "suspended", "false"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "aws_glue.#", "0"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "unity.#", "0"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.0.endpoint", "https://vuser1_polaris.snowflakecomputing.com/"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.0.warehouse", "warehouse-name"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.0.allowed_scope", "allowed-scope"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceCatalogIntegrationUnity(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	readCatalogIntegrationResponse, _ := os.ReadFile("../testdata/catalog_integration/read_created_unity_ci.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/tableflow/v1/catalog-integrations/tci-abc123")).
+		InScenario(CatalogIntegrationDataSourceScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillReturn(
+			string(readCatalogIntegrationResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	CatalogIntegrationResourceName := "data.confluent_catalog_integration.main"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDataSourceCatalogIntegration(mockServerUrl, "tci-abc123"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "id", "tci-abc123"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "display_name", "catalog_integration_1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "environment.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "environment.0.id", "env-abc123"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "kafka_cluster.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "kafka_cluster.0.id", "lkc-00000"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "suspended", "false"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "aws_glue.#", "0"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "snowflake.#", "0"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "unity.#", "1"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "unity.0.workspace_endpoint", "https://user1.cloud.databricks.com"),
+					resource.TestCheckResourceAttr(CatalogIntegrationResourceName, "unity.0.catalog_name", "catalog_name"),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckDataSourceCatalogIntegration(mockServerUrl, resourceId string) string {

--- a/internal/testdata/catalog_integration/create_unity_ci.json
+++ b/internal/testdata/catalog_integration/create_unity_ci.json
@@ -1,0 +1,41 @@
+{
+  "api_version": "tableflow/v1",
+  "kind": "CatalogIntegration",
+  "id": "tci-abc123",
+  "metadata": {
+    "created_at": "2024-02-01T22:25:50.415274Z",
+    "resource_name": "crn://confluent.cloud/organization=abc123/tableflow-topic=tci-abc123",
+    "self": "https://api.confluent.cloud/tableflow/v1/catalog-integrations/tci-abc123",
+    "updated_at": "2024-02-01T22:25:50.415274Z"
+  },
+  "spec": {
+    "display_name": "catalog_integration_1",
+    "suspended": false,
+    "environment": {
+      "api_version": "org/v2",
+      "id": "env-abc123",
+      "kind": "Environment",
+      "related": "https://api.confluent.cloud/v2/environments/env-abc123",
+      "resource_name": "crn://confluent.cloud/organization=abc123/environment=env-abc123"
+    },
+    "kafka_cluster": {
+      "id": "lkc-00000",
+      "environment": "env-abc123",
+      "related": "https://api.confluent.cloud/cmk/v2/clusters/lkc-00000",
+      "resource_name": "https://api.confluent.cloud/organization=abc123/environment=env-abc123/cloud-cluster=lkc-00000",
+      "api_version": "cmk/v2",
+      "kind": "Cluster"
+    },
+    "config": {
+      "kind": "Unity",
+      "workspace_endpoint": "https://user1.cloud.databricks.com",
+      "catalog_name": "catalog_name",
+      "client_id": "client-id",
+      "client_secret": "client-secret"
+    }
+  },
+  "status": {
+    "phase": "PENDING",
+    "last_sync_at": "2024-02-01T22:25:50.415274Z"
+  }
+}

--- a/internal/testdata/catalog_integration/read_created_unity_ci.json
+++ b/internal/testdata/catalog_integration/read_created_unity_ci.json
@@ -1,0 +1,41 @@
+{
+  "api_version": "tableflow/v1",
+  "kind": "CatalogIntegration",
+  "id": "tci-abc123",
+  "metadata": {
+    "created_at": "2024-02-01T22:25:50.415274Z",
+    "resource_name": "crn://confluent.cloud/organization=abc123/tableflow-topic=tci-abc123",
+    "self": "https://api.confluent.cloud/tableflow/v1/catalog-integrations/tci-abc123",
+    "updated_at": "2024-02-01T22:25:50.415274Z"
+  },
+  "spec": {
+    "display_name": "catalog_integration_1",
+    "suspended": false,
+    "environment": {
+      "api_version": "org/v2",
+      "id": "env-abc123",
+      "kind": "Environment",
+      "related": "https://api.confluent.cloud/v2/environments/env-abc123",
+      "resource_name": "crn://confluent.cloud/organization=abc123/environment=env-abc123"
+    },
+    "kafka_cluster": {
+      "id": "lkc-00000",
+      "environment": "env-abc123",
+      "related": "https://api.confluent.cloud/cmk/v2/clusters/lkc-00000",
+      "resource_name": "https://api.confluent.cloud/organization=abc123/environment=env-abc123/cloud-cluster=lkc-00000",
+      "api_version": "cmk/v2",
+      "kind": "Cluster"
+    },
+    "config": {
+      "kind": "Unity",
+      "workspace_endpoint": "https://user1.cloud.databricks.com",
+      "catalog_name": "catalog_name",
+      "client_id": "client-id",
+      "client_secret": "client-secret"
+    }
+  },
+  "status": {
+    "phase": "CONNECTED",
+    "last_sync_at": "2024-02-01T22:25:50.415274Z"
+  }
+}

--- a/internal/testdata/catalog_integration/update_unity_ci.json
+++ b/internal/testdata/catalog_integration/update_unity_ci.json
@@ -1,0 +1,41 @@
+{
+  "api_version": "tableflow/v1",
+  "kind": "CatalogIntegration",
+  "id": "tci-abc123",
+  "metadata": {
+    "created_at": "2024-02-01T22:25:50.415274Z",
+    "resource_name": "crn://confluent.cloud/organization=abc123/tableflow-topic=tci-abc123",
+    "self": "https://api.confluent.cloud/tableflow/v1/catalog-integrations/tci-abc123",
+    "updated_at": "2024-02-01T22:25:50.415274Z"
+  },
+  "spec": {
+    "display_name": "catalog_integration_2",
+    "suspended": false,
+    "environment": {
+      "api_version": "org/v2",
+      "id": "env-abc123",
+      "kind": "Environment",
+      "related": "https://api.confluent.cloud/v2/environments/env-abc123",
+      "resource_name": "crn://confluent.cloud/organization=abc123/environment=env-abc123"
+    },
+    "kafka_cluster": {
+      "id": "lkc-00000",
+      "environment": "env-abc123",
+      "related": "https://api.confluent.cloud/cmk/v2/clusters/lkc-00000",
+      "resource_name": "https://api.confluent.cloud/organization=abc123/environment=env-abc123/cloud-cluster=lkc-00000",
+      "api_version": "cmk/v2",
+      "kind": "Cluster"
+    },
+    "config": {
+      "kind": "Unity",
+      "workspace_endpoint": "https://user2.cloud.databricks.com",
+      "catalog_name": "catalog_name_2",
+      "client_id": "client-id-2",
+      "client_secret": "client-secret-2"
+    }
+  },
+  "status": {
+    "phase": "CONNECTED",
+    "last_sync_at": "2024-02-01T22:25:50.415274Z"
+  }
+}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- Added support for a new optional `unity` configuration block to `confluent_catalog_integration` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_integration) and [data-source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_catalog_integration) in a General Availability lifecycle stage.

Bug Fixes
- Fixed an issue where the `confluent_catalog_integration` [data-source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_catalog_integration) could not read Snowflake catalog integrations.

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

- Add support for Unity catalog integrations.
- Also fix a bug where the data source could not read Snowflake catalog integrations.
  - The cause of the bug was that the data source recycled the attribute setting function from the resource, but the resource has sensitive `client_id` and `client_secret` fields under the `snowflake` block while the data source does not, resulting in the following error:
```
Error: Invalid address to set: []string{"snowflake", "0", "client_id"}
```

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

Customers managing AWS Glue or Snowflake catalog integrations may be affected in case of bugs in the implementation.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
https://docs.google.com/document/d/1IxtcOvDHUazqV5CBluEQFfUq1mLp7lqrAhxwLPZQqHE/edit?usp=sharing
