### PR TITLE
Update docs/data-sources/confluent_ip_addresses.md to use GA label

### DIFF
--- a/docs/data-sources/confluent_ip_addresses.md
+++ b/docs/data-sources/confluent_ip_addresses.md
@@ -8,7 +8,7 @@ description: |-
 
 # confluent_ip_addresses Data Source
 
-[![Preview](https://img.shields.io/badge/Lifecycle%20Stage-Preview-%2300afba)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
+[![General Availability](https://img.shields.io/badge/Lifecycle%20Stage-General%20Availability-%2345c6e8)](https://docs.confluent.io/cloud/current/api.html#section/Versioning/API-Lifecycle-Policy)
 
 `confluent_ip_addresses` describes IP Addresses data source.
 


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Updated the docs.

Checklist
---------
NA, as there are no code changes.

What
----

This PR updates the documentation for the confluent_ip_addresses data source to reflect its Generally Available (GA) status by removing the Preview lifecycle stage warning and disclaimer.

Blast Radius
----
NA, as there are no code changes.

Test & Review
-------------
Doc Preview Tool: https://registry.terraform.io/tools/doc-preview

<img width="1530" height="676" alt="image" src="https://github.com/user-attachments/assets/7e612882-f6b9-4715-a11f-c1b881cf458e" />


