### PR TITLE
INC-7313: Updated the confluent_custom_connector_plugin resource to support in-place update for the sensitive_config_properties attribute.

### DIFF
--- a/internal/provider/resource_custom_connector_plugin.go
+++ b/internal/provider/resource_custom_connector_plugin.go
@@ -102,8 +102,8 @@ func customConnectorPluginResource() *schema.Resource {
 }
 
 func customConnectorPluginUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramDisplayName, paramDescription, paramDocumentationLink) {
-		return diag.Errorf("error updating Custom Connector Plugin %q: only %q, %q, %q attributes can be updated for Custom Connector Plugin", d.Id(), paramDisplayName, paramDescription, paramDocumentationLink)
+	if d.HasChangesExcept(paramDisplayName, paramDescription, paramDocumentationLink, paramSensitiveConfigProperties) {
+		return diag.Errorf("error updating Custom Connector Plugin %q: only %q, %q, %q, %q attributes can be updated for Custom Connector Plugin", d.Id(), paramDisplayName, paramDescription, paramDocumentationLink, paramSensitiveConfigProperties)
 	}
 
 	updateCustomConnectorPluginRequest := ccp.NewConnectV1CustomConnectorPluginUpdate()
@@ -119,6 +119,10 @@ func customConnectorPluginUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange(paramDocumentationLink) {
 		updatedDocumentationLink := d.Get(paramDocumentationLink).(string)
 		updateCustomConnectorPluginRequest.SetDocumentationLink(updatedDocumentationLink)
+	}
+	if d.HasChange(paramSensitiveConfigProperties) {
+		updatedSensitiveConfigProperties := convertToStringSlice(d.Get(paramSensitiveConfigProperties).(*schema.Set).List())
+		updateCustomConnectorPluginRequest.SetSensitiveConfigProperties(updatedSensitiveConfigProperties)
 	}
 
 	updateCustomConnectorPluginRequestJson, err := json.Marshal(updateCustomConnectorPluginRequest)

--- a/internal/provider/resource_custom_connector_plugin_test.go
+++ b/internal/provider/resource_custom_connector_plugin_test.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -130,9 +132,11 @@ func TestAccCustomConnectorPlugin(t *testing.T) {
 
 	customConnectorPluginDisplayName := "datagen-plugin-name"
 	customConnectorPluginDescription := "datagen-plugin-description"
+	customConnectorPluginSensitiveProperties := []string{"keys", "passwords"}
 	// in order to test tf update (step #3)
 	customConnectorPluginUpdatedDisplayName := "datagen-plugin-name-upd"
 	customConnectorPluginUpdatedDescription := "datagen-plugin-description-upd"
+	customConnectorPluginUpdatedSensitiveProperties := []string{"keys", "passwords", "auth_token"}
 	customConnectorPluginResourceLabel := "test_plugin_resource_label"
 	fullCustomConnectorPluginResourceLabel := fmt.Sprintf("confluent_custom_connector_plugin.%s", customConnectorPluginResourceLabel)
 
@@ -150,12 +154,19 @@ func TestAccCustomConnectorPlugin(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginDisplayName, customConnectorPluginDescription),
+				Config: testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginDisplayName, customConnectorPluginDescription, customConnectorPluginSensitiveProperties),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomConnectorPluginExists(fullCustomConnectorPluginResourceLabel),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "id", "ccp-4rrw00"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "display_name", customConnectorPluginDisplayName),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "description", customConnectorPluginDescription),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "documentation_link", "https://www.confluent.io/hub/confluentinc/kafka-connect-datagen"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_class", "io.confluent.kafka.connect.datagen.DatagenConnector"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_type", "SOURCE"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.#", strconv.Itoa(len(customConnectorPluginSensitiveProperties))),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginSensitiveProperties[0]),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginSensitiveProperties[1]),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "filename", "foo.zip"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "cloud", "AWS"),
 				),
 			},
@@ -166,12 +177,20 @@ func TestAccCustomConnectorPlugin(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginUpdatedDisplayName, customConnectorPluginUpdatedDescription),
+				Config: testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginUpdatedDisplayName, customConnectorPluginUpdatedDescription, customConnectorPluginUpdatedSensitiveProperties),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomConnectorPluginExists(fullCustomConnectorPluginResourceLabel),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "id", "ccp-4rrw00"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "display_name", customConnectorPluginUpdatedDisplayName),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "description", customConnectorPluginUpdatedDescription),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "documentation_link", "https://www.confluent.io/hub/confluentinc/kafka-connect-datagen"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_class", "io.confluent.kafka.connect.datagen.DatagenConnector"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_type", "SOURCE"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.#", strconv.Itoa(len(customConnectorPluginUpdatedSensitiveProperties))),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginUpdatedSensitiveProperties[0]),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginUpdatedSensitiveProperties[1]),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginUpdatedSensitiveProperties[2]),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "filename", "foo.zip"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "cloud", "AWS"),
 				),
 			},
@@ -262,6 +281,7 @@ func TestAccCustomConnectorPluginGCP(t *testing.T) {
 	customConnectorPluginDisplayName := "datagen-plugin-name-gcp"
 	customConnectorPluginDescription := "datagen-plugin-description-gcp"
 	customConnectorPluginResourceLabel := "test_plugin_resource_label_gcp"
+	customConnectorPluginSensitiveProperties := []string{"keys", "passwords"}
 	fullCustomConnectorPluginResourceLabel := fmt.Sprintf("confluent_custom_connector_plugin.%s", customConnectorPluginResourceLabel)
 
 	// Set fake values for secrets since those are required for importing
@@ -276,12 +296,19 @@ func TestAccCustomConnectorPluginGCP(t *testing.T) {
 		CheckDestroy:      testAccCheckCustomConnectorPluginDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckCustomConnectorPluginConfigWithCloud(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginDisplayName, customConnectorPluginDescription, "GCP"),
+				Config: testAccCheckCustomConnectorPluginConfigWithCloud(mockServerUrl, customConnectorPluginResourceLabel, customConnectorPluginDisplayName, customConnectorPluginDescription, "GCP", customConnectorPluginSensitiveProperties),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomConnectorPluginExists(fullCustomConnectorPluginResourceLabel),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "id", "ccp-5rrw00"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "display_name", customConnectorPluginDisplayName),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "description", customConnectorPluginDescription),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "documentation_link", "https://www.confluent.io/hub/confluentinc/kafka-connect-datagen"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_class", "io.confluent.kafka.connect.datagen.DatagenConnector"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "connector_type", "SOURCE"),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.#", strconv.Itoa(len(customConnectorPluginSensitiveProperties))),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginSensitiveProperties[0]),
+					resource.TestCheckTypeSetElemAttr(fullCustomConnectorPluginResourceLabel, "sensitive_config_properties.*", customConnectorPluginSensitiveProperties[1]),
+					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "filename", "foo.zip"),
 					resource.TestCheckResourceAttr(fullCustomConnectorPluginResourceLabel, "cloud", "GCP"),
 				),
 			},
@@ -322,7 +349,14 @@ func testAccCheckCustomConnectorPluginDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription string) string {
+func testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription string, sensitiveConfigProperties []string) string {
+	quotedSensitiveConfigProperties := make([]string, len(sensitiveConfigProperties))
+	for i, prop := range sensitiveConfigProperties {
+		quotedSensitiveConfigProperties[i] = fmt.Sprintf("%q", prop)
+	}
+
+	joinedQuotedSensitiveConfigProperties := strings.Join(quotedSensitiveConfigProperties, ",\n    ")
+
 	return fmt.Sprintf(`
 	provider "confluent" {
 		endpoint = "%s"
@@ -333,28 +367,39 @@ func testAccCheckCustomConnectorPluginConfig(mockServerUrl, customConnectorPlugi
 		documentation_link = "https://www.confluent.io/hub/confluentinc/kafka-connect-datagen"
 		connector_class = "io.confluent.kafka.connect.datagen.DatagenConnector"
 		connector_type = "SOURCE"
-		sensitive_config_properties = ["keys", "passwords"]
+		sensitive_config_properties = [
+			%s
+		]
 		filename = "foo.zip"
 	}
-	`, mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription)
+	`, mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription, joinedQuotedSensitiveConfigProperties)
 }
 
-func testAccCheckCustomConnectorPluginConfigWithCloud(mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription, cloud string) string {
-	return fmt.Sprintf(`
-	provider "confluent" {
-		endpoint = "%s"
+func testAccCheckCustomConnectorPluginConfigWithCloud(mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription, cloud string, sensitiveConfigProperties []string) string {
+	quotedSensitiveConfigProperties := make([]string, len(sensitiveConfigProperties))
+	for i, prop := range sensitiveConfigProperties {
+		quotedSensitiveConfigProperties[i] = fmt.Sprintf("%q", prop)
 	}
-	resource "confluent_custom_connector_plugin" "%s" {
+
+	joinedQuotedSensitiveConfigProperties := strings.Join(quotedSensitiveConfigProperties, ",\n    ")
+
+	return fmt.Sprintf(`
+    provider "confluent" {
+		endpoint = "%s"
+    }
+    resource "confluent_custom_connector_plugin" "%s" {
 		display_name = "%s"
 		description = "%s"
 		documentation_link = "https://www.confluent.io/hub/confluentinc/kafka-connect-datagen"
 		connector_class = "io.confluent.kafka.connect.datagen.DatagenConnector"
 		connector_type = "SOURCE"
-		sensitive_config_properties = ["keys", "passwords"]
+		sensitive_config_properties = [
+			%s
+		]
 		filename = "foo.zip"
 		cloud = "%s"
 	}
-	`, mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription, cloud)
+	`, mockServerUrl, customConnectorPluginResourceLabel, saDisplayName, saDescription, joinedQuotedSensitiveConfigProperties, cloud)
 }
 
 func testAccCheckCustomConnectorPluginExists(n string) resource.TestCheckFunc {

--- a/internal/testdata/custom_connector_plugin/read_updated_plugin.json
+++ b/internal/testdata/custom_connector_plugin/read_updated_plugin.json
@@ -16,7 +16,8 @@
   },
   "sensitive_config_properties": [
     "keys",
-    "passwords"
+    "passwords",
+    "auth_token"
   ],
   "cloud": "AWS"
 }


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Updated the `confluent_custom_connector_plugin` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_custom_connector_plugin) to support in-place update for the sensitive_config_properties attribute.

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This PR fixes a bug where updating the value of the sensitive_config_properties attribute of the `confluent_custom_connector_plugin` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_custom_connector_plugin) forced resource recreation.

Blast Radius
----
- Confluent Cloud customers who are using `confluent_custom_connector_plugin` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_custom_connector_plugin) and trying to **update** the value of its attributes may experience errors (TF drift or backend errors). We only updated the update code path; the CRD path remains untouched.

References
----------
* https://confluentinc.atlassian.net/browse/INC-7313

Test & Review
-------------
This PR has been tested in 2 days:
1. The acceptance tests have been updated.
2. The manual tests have been performed: [link](https://confluent.slack.com/archives/C08H9NWM0TG/p1763597983928479).
