### PR TITLE
Add isLiveProductionTestMode to use full delays in live tests

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -66,9 +66,9 @@ func testAccPreCheck(t *testing.T) {
 }
 
 func TestSleepIfNotTestMode(t *testing.T) {
-	t.Run("should not sleep in acceptance test mode", func(t *testing.T) {
+	t.Run("should not sleep in acceptance test mode (mock tests)", func(t *testing.T) {
 		start := time.Now()
-		SleepIfNotTestMode(time.Second, true)
+		SleepIfNotTestMode(time.Second, true, false)
 		duration := time.Since(start)
 
 		if duration >= time.Second {
@@ -78,11 +78,21 @@ func TestSleepIfNotTestMode(t *testing.T) {
 
 	t.Run("should sleep in normal mode", func(t *testing.T) {
 		start := time.Now()
-		SleepIfNotTestMode(time.Second, false)
+		SleepIfNotTestMode(time.Second, false, false)
 		duration := time.Since(start)
 
 		if duration < time.Second {
 			t.Errorf("expected to sleep, but slept for %v\n", duration)
+		}
+	})
+
+	t.Run("should sleep in live production test mode", func(t *testing.T) {
+		start := time.Now()
+		SleepIfNotTestMode(time.Second, true, true)
+		duration := time.Since(start)
+
+		if duration < time.Second {
+			t.Errorf("expected to sleep in live production test mode, but slept for %v\n", duration)
 		}
 	})
 }

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -525,12 +525,12 @@ func waitForApiKeyToSync(ctx context.Context, c *Client, createdApiKey apikeys.I
 				return fmt.Errorf("error waiting for Kafka API Key %q to sync: %s", createdApiKey.GetId(), createDescriptiveError(err))
 			}
 		} else if isSchemaRegistryApiKey(createdApiKey) || isFlinkApiKey(createdApiKey) {
-			SleepIfNotTestMode(1*time.Minute, c.isAcceptanceTestMode)
+			SleepIfNotTestMode(1*time.Minute, c.isAcceptanceTestMode, c.isLiveProductionTestMode)
 		} else if isKsqlDbClusterApiKey(createdApiKey) {
 			// Currently, there are no data plane API for ksqlDB clusters so there is no endpoint we could leverage
 			// to check whether the Cluster API Key is synced which is why we're adding SleepIfNotTestMode() here.
 			// TODO: SVCF-3560
-			SleepIfNotTestMode(5*time.Minute, c.isAcceptanceTestMode)
+			SleepIfNotTestMode(5*time.Minute, c.isAcceptanceTestMode, c.isLiveProductionTestMode)
 		} else if isTableflowApiKey(createdApiKey) {
 			tableflowRestClient := c.tableflowRestClientFactory.CreateTableflowRestClient(createdApiKey.GetId(), createdApiKey.Spec.GetSecret(), false, c.oauthToken, c.stsToken)
 			if err := waitForCreatedTableflowApiKeyToSync(ctx, tableflowRestClient, c.isAcceptanceTestMode); err != nil {

--- a/internal/provider/resource_business_metadata.go
+++ b/internal/provider/resource_business_metadata.go
@@ -178,7 +178,7 @@ func businessMetadataCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/282
-	SleepIfNotTestMode(dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	createdBusinessMetadataJson, err := json.Marshal(createdBusinessMetadata)
 	if err != nil {
@@ -272,7 +272,7 @@ func businessMetadataDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error deleting Business Metadata %q: %s", businessMetadataId, createDescriptiveError(serviceErr))
 	}
 
-	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Business Metadata %q", businessMetadataId), map[string]interface{}{businessMetadataLoggingKey: businessMetadataId})
 
 	return nil

--- a/internal/provider/resource_business_metadata_binding.go
+++ b/internal/provider/resource_business_metadata_binding.go
@@ -117,7 +117,7 @@ func businessMetadataBindingCreate(ctx context.Context, d *schema.ResourceData, 
 
 	// sleep 60 seconds to wait for entity (resource) to sync to SR
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "error creating Business Metadata Binding 404 Not Found"
-	SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	request := catalogRestClient.apiClient.EntityV1Api.CreateBusinessMetadata(catalogRestClient.dataCatalogApiContext(ctx))
 	request = request.BusinessMetadata([]dc.BusinessMetadata{businessMetadataBindingRequest})
@@ -145,7 +145,7 @@ func businessMetadataBindingCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "Root object was present, but now absent."
-	SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	createdBusinessMetadataBindingJson, err := json.Marshal(createdBusinessMetadataBinding)
 	if err != nil {
@@ -266,7 +266,7 @@ func businessMetadataBindingDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error deleting Business Metadata Binding %q: %s", businessMetadataBindingId, createDescriptiveError(serviceErr))
 	}
 
-	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Business Metadata Binding %q", businessMetadataBindingId), map[string]interface{}{businessMetadataBindingLoggingKey: businessMetadataBindingId})
 
 	return nil

--- a/internal/provider/resource_cluster_link.go
+++ b/internal/provider/resource_cluster_link.go
@@ -190,7 +190,7 @@ func clusterLinkCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.SetId(clusterLinkCompositeId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	// Don't log created cluster link since API returns an empty 201 response.
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Cluster Link %q", d.Id()), map[string]interface{}{clusterLinkLoggingKey: d.Id()})
@@ -427,7 +427,7 @@ func clusterLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	if d.HasChange(paramConfigs) {
@@ -474,7 +474,7 @@ func clusterLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 			// 400 Bad Request: Config property 'delete.retention.ms' with value '63113904003' exceeded max limit of 60566400000.
 			return diag.Errorf("error updating Cluster Link Config: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Cluster Link %q", d.Id()), map[string]interface{}{clusterLinkLoggingKey: d.Id()})
 	}
 	return clusterLinkRead(ctx, d, meta)

--- a/internal/provider/resource_connector.go
+++ b/internal/provider/resource_connector.go
@@ -191,7 +191,7 @@ func connectorCreate(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.Errorf("error creating Connector %q: %s: %s", displayName, createDescriptiveError(err, resp), string(descriptiveError))
 	}
 	// There's no ID attribute in createdConnector, so we have to send another request to a different endpoint to get a connector object with ID attribute
-	SleepIfNotTestMode(connectAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(connectAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	createdConnectorWithId, resp, err := executeConnectorRead(c.connectApiContext(ctx), c, displayName, environmentId, clusterId)
 	if err != nil {
 		return diag.Errorf("error creating Connector %q: error reading created Connector: %s", displayName, createDescriptiveError(err, resp))

--- a/internal/provider/resource_kafka_acl.go
+++ b/internal/provider/resource_kafka_acl.go
@@ -188,7 +188,7 @@ func kafkaAclCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 	d.SetId(kafkaAclId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Kafka ACLs %q", d.Id()), map[string]interface{}{kafkaAclLoggingKey: d.Id()})
 

--- a/internal/provider/resource_kafka_client_quota.go
+++ b/internal/provider/resource_kafka_client_quota.go
@@ -117,7 +117,7 @@ func kafkaClientQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error updating Kafka Client Quota %q: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 
-	SleepIfNotTestMode(kafkaQuotasAPIWaitAfterUpdate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaQuotasAPIWaitAfterUpdate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	updatedClientQuotaJson, err := json.Marshal(updatedClientQuota)
 	if err != nil {
@@ -161,7 +161,7 @@ func kafkaClientQuotaCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	d.SetId(createdKafkaClientQuota.GetId())
 
-	SleepIfNotTestMode(kafkaQuotasAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaQuotasAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	createdClientQuotaJson, err := json.Marshal(createdKafkaClientQuota)
 	if err != nil {

--- a/internal/provider/resource_kafka_cluster_config.go
+++ b/internal/provider/resource_kafka_cluster_config.go
@@ -108,7 +108,7 @@ func kafkaConfigCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.SetId(kafkaConfigId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Kafka Config %q", d.Id()), map[string]interface{}{kafkaClusterLoggingKey: d.Id()})
 
@@ -286,7 +286,7 @@ func kafkaConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 			// 400 Bad Request: Config property 'delete.retention.ms' with value '63113904003' exceeded max limit of 60566400000.
 			return diag.Errorf("error updating Kafka Config: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Kafka Config %q", d.Id()), map[string]interface{}{kafkaClusterConfigLoggingKey: d.Id()})
 	}
 	return kafkaConfigRead(ctx, d, meta)

--- a/internal/provider/resource_kafka_mirror_topic.go
+++ b/internal/provider/resource_kafka_mirror_topic.go
@@ -121,7 +121,7 @@ func kafkaMirrorTopicCreate(ctx context.Context, d *schema.ResourceData, meta in
 	d.SetId(kafkaMirrorTopicId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	// Don't log created Kafka Mirror Topic since API returns an empty 201 response.
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Kafka Mirror Topic %q", d.Id()), map[string]interface{}{kafkaMirrorTopicLoggingKey: d.Id()})

--- a/internal/provider/resource_kafka_topic.go
+++ b/internal/provider/resource_kafka_topic.go
@@ -244,7 +244,7 @@ func kafkaTopicCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.SetId(kafkaTopicId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	createdKafkaTopicJson, err := json.Marshal(createdKafkaTopic)
 	if err != nil {
@@ -538,7 +538,7 @@ func kafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 			return diag.FromErr(createDescriptiveError(err, resp))
 		}
 		// Give some time to Kafka REST API to apply an update of partitions count
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Kafka Topic %q: topic settings update has been completed", d.Id()), map[string]interface{}{kafkaTopicLoggingKey: d.Id()})
 	}
 	if d.HasChange(paramConfigs) {
@@ -617,7 +617,7 @@ func kafkaTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 			return diag.FromErr(createDescriptiveError(err, resp))
 		}
 		// Give some time to Kafka REST API to apply an update of topic settings
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 		// Check that topic configs update was successfully executed
 		// In other words, remote topic setting values returned by Kafka REST API match topic setting values from updated TF configuration

--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -111,7 +111,7 @@ func roleBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Role Binding %q: %s", d.Id(), createdRoleBindingJson), map[string]interface{}{roleBindingLoggingKey: d.Id()})
 	if !skipSync {
-		SleepIfNotTestMode(rbacWaitAfterCreateToSync, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(rbacWaitAfterCreateToSync, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 	return roleBindingRead(ctx, d, meta)
 }

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -651,7 +651,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	d.SetId(schemaId)
 
 	// https://github.com/confluentinc/terraform-provider-confluentcloud/issues/40#issuecomment-1048782379
-	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	tflog.Debug(ctx, fmt.Sprintf("Finished creating Schema %q", d.Id()), map[string]interface{}{schemaLoggingKey: d.Id()})
 

--- a/internal/provider/resource_schema_registry_cluster_config.go
+++ b/internal/provider/resource_schema_registry_cluster_config.go
@@ -97,7 +97,7 @@ func schemaRegistryClusterConfigCreate(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("error creating Schema Registry Cluster Config: %s", createDescriptiveError(err, resp))
 		}
 
-		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	schemaRegistryClusterConfigId := createSchemaRegistryClusterConfigId(schemaRegistryRestClient.clusterId)
@@ -250,7 +250,7 @@ func schemaRegistryClusterConfigUpdate(ctx context.Context, d *schema.ResourceDa
 		if err != nil {
 			return diag.Errorf("error updating Schema Registry Cluster Config: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Schema Registry Cluster Config %q", d.Id()), map[string]interface{}{kafkaClusterConfigLoggingKey: d.Id()})
 	}
 	return schemaRegistryClusterConfigRead(ctx, d, meta)

--- a/internal/provider/resource_schema_registry_cluster_mode.go
+++ b/internal/provider/resource_schema_registry_cluster_mode.go
@@ -96,7 +96,7 @@ func schemaRegistryClusterModeCreate(ctx context.Context, d *schema.ResourceData
 			return diag.Errorf("error creating Schema Registry Cluster Mode: %s", createDescriptiveError(err, resp))
 		}
 
-		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	schemaRegistryClusterModeId := createSchemaRegistryClusterModeId(schemaRegistryRestClient.clusterId)
@@ -251,7 +251,7 @@ func schemaRegistryClusterModeUpdate(ctx context.Context, d *schema.ResourceData
 		if err != nil {
 			return diag.Errorf("error updating Schema Registry Cluster Mode: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Schema Registry Cluster Mode %q", d.Id()), map[string]interface{}{kafkaClusterConfigLoggingKey: d.Id()})
 	}
 	return schemaRegistryClusterModeRead(ctx, d, meta)

--- a/internal/provider/resource_subject_config.go
+++ b/internal/provider/resource_subject_config.go
@@ -123,7 +123,7 @@ func subjectConfigCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			return diag.Errorf("error creating Subject Config: %s", createDescriptiveError(err, resp))
 		}
 
-		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	subjectConfigId := createSubjectConfigId(schemaRegistryRestClient.clusterId, subjectName)
@@ -159,7 +159,7 @@ func subjectConfigDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("error deleting Subject Config %q: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 
-	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Subject Config %q", d.Id()), map[string]interface{}{subjectConfigLoggingKey: d.Id()})
 
 	return nil
@@ -312,7 +312,7 @@ func subjectConfigUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if err != nil {
 			return diag.Errorf("error updating Subject Config: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Subject Config %q", d.Id()), map[string]interface{}{kafkaClusterConfigLoggingKey: d.Id()})
 	}
 	return subjectConfigRead(ctx, d, meta)

--- a/internal/provider/resource_subject_mode.go
+++ b/internal/provider/resource_subject_mode.go
@@ -117,7 +117,7 @@ func subjectModeCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 			return diag.Errorf("error creating Subject Mode: %s", createDescriptiveError(err, resp))
 		}
 
-		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	subjectModeId := createSubjectModeId(schemaRegistryRestClient.clusterId, subjectName)
@@ -153,7 +153,7 @@ func subjectModeDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("error deleting Subject Mode %q: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 
-	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(schemaRegistryAPIWaitAfterCreateOrDelete, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Subject Mode %q", d.Id()), map[string]interface{}{subjectModeLoggingKey: d.Id()})
 
 	return nil
@@ -308,7 +308,7 @@ func subjectModeUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		if err != nil {
 			return diag.Errorf("error updating Subject Mode: %s", createDescriptiveError(err, resp))
 		}
-		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(kafkaRestAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		tflog.Debug(ctx, fmt.Sprintf("Finished updating Subject Mode %q", d.Id()), map[string]interface{}{kafkaClusterConfigLoggingKey: d.Id()})
 	}
 	return subjectModeRead(ctx, d, meta)

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -134,7 +134,7 @@ func tagCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 	}
 
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/282
-	SleepIfNotTestMode(dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 
 	createdTagJson, err := json.Marshal(createdTag)
 	if err != nil {
@@ -232,7 +232,7 @@ func tagDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 		return diag.Errorf("error deleting Tag %q: %s", tagId, createDescriptiveError(serviceErr))
 	}
 
-	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Tag %q", tagId), map[string]any{tagLoggingKey: tagId})
 
 	return nil

--- a/internal/provider/resource_tag_binding.go
+++ b/internal/provider/resource_tag_binding.go
@@ -117,7 +117,7 @@ func tagBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !skipSync {
 		// sleep 60 seconds to wait for entity (resource) to sync to SR
 		// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "error creating Tag Binding 404 Not Found"
-		SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(60*time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	request := catalogRestClient.apiClient.EntityV1Api.CreateTags(catalogRestClient.dataCatalogApiContext(ctx))
@@ -147,7 +147,7 @@ func tagBindingCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	if !skipSync {
 		// https://github.com/confluentinc/terraform-provider-confluent/issues/282 to resolve "Root object was present, but now absent."
-		SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode)
+		SleepIfNotTestMode(2*dataCatalogAPIWaitAfterCreate, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	}
 
 	createdTagBindingJson, err := json.Marshal(createdTagBinding)
@@ -269,7 +269,7 @@ func tagBindingDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("error deleting Tag Binding %q: %s", tagBindingId, createDescriptiveError(serviceErr))
 	}
 
-	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode)
+	SleepIfNotTestMode(time.Second, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Tag Binding %q", tagBindingId), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
 
 	return nil

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -373,7 +373,7 @@ func loadInstances(ctx context.Context, resourceName string, importer *Importer,
 		if resourceName == "confluent_kafka_topic" || resourceName == "confluent_kafka_acl" {
 			// APIF-2043: TEMPORARY HACK
 			// Sleep for 0.5s to avoid sending too many requests
-			SleepIfNotTestMode(500*time.Millisecond, meta.(*Client).isAcceptanceTestMode)
+			SleepIfNotTestMode(500*time.Millisecond, meta.(*Client).isAcceptanceTestMode, meta.(*Client).isLiveProductionTestMode)
 		}
 
 		instanceState, err := getInstanceState(ctx, resourceSchema, instanceId, meta)


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Briefly describe any bugs fixed in this PR].

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Live tests running against real Confluent Cloud infrastructure now use full API propagation delays instead of the reduced 500ms delay used for mock tests. This fixes intermittent test failures (like ACL "not found" errors attached below) caused by eventual consistency when TF_ACC_PROD=1 is set.
```
=== NAME  TestAccKafkaAclUpdateLive03:36
    resource_kafka_acl_live_test.go:127: Step 2/2 error: Error running apply: exit status 103:36
        03:36
        Error: error reading Kafka ACLs: error reading Kafka ACLs "[REDACTED_KAFKA_STANDARD_AWS_CLUSTER_ID]/TOPIC#tf-live-update-topic-17875#LITERAL#User:*#*#WRITE#ALLOW": no Kafka ACLs were matched03:36
        03:36
          with confluent_kafka_acl.test_live_kafka_acl_update,03:36
          on terraform_plugin_test.tf line 8, in resource "confluent_kafka_acl" "test_live_kafka_acl_update":03:36
           8: 	resource "confluent_kafka_acl" "test_live_kafka_acl_update" {03:36
```

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Passing pipeline: https://semaphore.ci.confluent.io/workflows/ae5f2a9b-ce6a-4f02-bf00-c26dff29d28b