### PR TITLE
#minor Add "CGO_CFLAGS="-Wno-error=gnu-folding-constant"

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -31,7 +31,7 @@ blocks:
             - sed -i '' 's/linux/darwin/' src/crypto/internal/backend/openssl.go
             - sed -i '' 's/"libcrypto.so.%s"/"libcrypto.%s.dylib"/' src/crypto/internal/backend/openssl.go
             - cd src/
-            - ./make.bash -v
+            - CGO_CFLAGS="-Wno-error=gnu-folding-constant" ./make.bash -v
             - cd ../../
             - export PATH=$(pwd)/go/bin:$PATH
             - export "GITHUB_TOKEN=$(gh auth token)"


### PR DESCRIPTION
### What: Build Fix for CGO VLA Extension Error
This PR resolves a build failure caused by the C compiler's global -Werror flag converting a specific warning into a fatal error.

### Problem
The build fails due to the warning -Wgnu-folding-constant, which flags the use of a non-standard C extension (Variable Length Array, or VLA) in our cgo code:
```
error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
```
### Solution
We use the narrow suppression flag CGO_CFLAGS="-Wno-error=gnu-folding-constant" to prevent only this single warning from being treated as an error.

### Justification
This change is safe because:

* Scope is Minimal: We are not disabling the global -Werror flag. All other critical warnings (logic errors, memory issues, uninitialized variables) remain fatal errors, preserving our code quality standard.

* Warning Type: The warning relates to compiler extension compatibility, not a functional bug or memory safety issue in the Go code itself. It is safe to suppress this specific instance.

### Testing
We'll verify the generated binary before publishing it by running https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/sample-project

CI building step also passed:
<img width="3806" height="358" alt="image" src="https://github.com/user-attachments/assets/8744eca6-4baa-4824-bc58-5bb76e2d5d60" />
