### PR TITLE
#minor Update GoReleaser version from 1.25.1 to 2.13.0

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -36,7 +36,7 @@ blocks:
             - export PATH=$(pwd)/go/bin:$PATH
             - export "GITHUB_TOKEN=$(gh auth token)"
             - cd terraform-provider-confluent*
-            - curl https://goreleaser.com/static/run | GOROOT=/Users/semaphore/go VERSION=v1.25.1 bash -s -- build --config .goreleaser-darwin-fips.yml
+            - curl https://goreleaser.com/static/run | GOROOT=/Users/semaphore/go VERSION=v2.13.0 bash -s -- build --config .goreleaser-darwin-fips.yml
             - artifact push workflow dist/darwin-fips_darwin_amd64_v1 --force
             - artifact push workflow dist/darwin-fips_darwin_arm64 --force
   - name: "Draft a Release (Part 2)"
@@ -75,4 +75,4 @@ blocks:
             - artifact pull workflow darwin-fips_darwin_amd64_v1 --force
             - artifact pull workflow darwin-fips_darwin_arm64 --force
             - cd ..
-            - curl https://goreleaser.com/static/run | DISTRIBUTION=pro VERSION=v1.25.1-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)
+            - curl https://goreleaser.com/static/run | DISTRIBUTION=pro VERSION=v2.13.0-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)


### PR DESCRIPTION
### What
This PR updates the GoReleaser version to use the latest one to resolve CI issues as these curls were failing siliently:
```
(
    cd "$TMP_DIR"
    echo "Downloading GoReleaser $VERSION..."
    curl -sfLO "$RELEASES_URL/download/$VERSION/$TAR_FILE" 
    curl -sfLO "$RELEASES_URL/download/$VERSION/checksums.txt"
    curl -sfLO "$RELEASES_URL/download/$VERSION/checksums.txt.sigstore.json" # fails
    ...
)
```

as there was no `checksums.txt.sigstore.json` on https://github.com/goreleaser/goreleaser/releases/tag/v1.25.1, there's no checksums.txt.sigstore.json file, but this file is present here: https://github.com/goreleaser/goreleaser/releases/tag/v2.13.0. 

### Testing
The changes were manually tested by @sgagniere:
```
curl https://goreleaser.com/static/run | VERSION=v1.25.1 bash -s -- check                                 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1761  100  1761    0     0  13451      0 --:--:-- --:--:-- --:--:-- 13546
Using the OSS distribution...
Downloading GoReleaser v1.25.1...
```
fails, but
```
curl https://goreleaser.com/static/run | VERSION=v2.13.0 bash -s -- check
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1761  100  1761    0     0  14308      0 --:--:-- --:--:-- --:--:-- 14434
Using the OSS distribution...
Downloading GoReleaser v2.13.0...
Verifying checksums...
Could not verify signatures, cosign is not installed.
  ⨯ command failed                                  
    error=
    │ yaml: unmarshal errors:
```

### References
* https://github.com/goreleaser/goreleaser-pro/releases