### PR TITLE
Fix "Error pushing artifact: path 'dist/darwin-fips_darwin_arm64' does not exist locally" CI error

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -38,7 +38,7 @@ blocks:
             - cd terraform-provider-confluent*
             - curl https://goreleaser.com/static/run | GOROOT=/Users/semaphore/go VERSION=v2.13.0 bash -s -- build --config .goreleaser-darwin-fips.yml
             - artifact push workflow dist/darwin-fips_darwin_amd64_v1 --force
-            - artifact push workflow dist/darwin-fips_darwin_arm64 --force
+            - artifact push workflow dist/darwin-fips_darwin_arm64_v8.0 --force
   - name: "Draft a Release (Part 2)"
     dependencies: ["Draft a Release (Part 1)"]
     task:
@@ -73,6 +73,6 @@ blocks:
             - sudo apt install -y gcc-aarch64-linux-gnu
             - mkdir prebuilt && cd prebuilt
             - artifact pull workflow darwin-fips_darwin_amd64_v1 --force
-            - artifact pull workflow darwin-fips_darwin_arm64 --force
+            - artifact pull workflow darwin-fips_darwin_arm64_v8.0 --force
             - cd ..
             - curl https://goreleaser.com/static/run | DISTRIBUTION=pro VERSION=v2.13.0-pro bash -s -- release --config .goreleaser.yml --key $(vault kv get -field goreleaser_key v1/ci/kv/cli/release)


### PR DESCRIPTION
### What
This PR resolves "Error pushing artifact: path 'dist/darwin-fips_darwin_arm64' does not exist locally" error.

### Context
This PR updates the ARM64 artifact path to include the _v8.0 suffix required by GoReleaser v2.

## Change

```diff
- artifact push workflow dist/darwin-fips_darwin_arm64 --force
+ artifact push workflow dist/darwin-fips_darwin_arm64_v8.0 --force
```

## Why

GoReleaser v2 appends microarchitecture level suffixes to output directories:

| Architecture | Suffix | Meaning |
|-------------|--------|---------|
| `amd64` | `_v1` | Baseline x86-64 (SSE2) |
| `arm64` | `_v8.0` | Baseline ARMv8-A |

The `amd64_v1` path was already correct. This aligns `arm64` to use the same convention.