### PR TITLE
[INC-7746] Fix Tableflow topic creation with `SKIP` or `LOG` error handling modes

### DIFF
--- a/internal/provider/resource_tableflow_topic.go
+++ b/internal/provider/resource_tableflow_topic.go
@@ -271,7 +271,7 @@ func tableflowTopicCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		tableflowTopicSpec.SetTableFormats(tableFormats)
 	}
 
-	tableflowTopicSpec.Config = tableflow.NewTableflowV1TableFlowTopicConfigsSpec()
+	tableflowTopicSpec.Config = &tableflow.TableflowV1TableFlowTopicConfigsSpec{} // don't call NewTableflowV1TableFlowTopicConfigsSpec() because it explicitly sets RecordFailureStrategy to "SUSPEND"
 	if retentionMs := d.Get(paramRetentionMs).(string); retentionMs != "" {
 		tableflowTopicSpec.Config.SetRetentionMs(retentionMs)
 	}
@@ -579,7 +579,7 @@ func tableflowTopicUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	clusterId := extractStringValueFromBlock(d, paramKafkaCluster, paramId)
 
 	updateTableflowTopicSpec := tableflow.NewTableflowV1TableflowTopicSpecUpdate()
-	updateTableflowTopicSpec.Config = &tableflow.TableflowV1TableFlowTopicConfigsSpec{} // don't call NewTableflowV1TableFlowTopicConfigsSpec() because it explicitlysets RecordFailureStrategy to "SUSPEND"
+	updateTableflowTopicSpec.Config = &tableflow.TableflowV1TableFlowTopicConfigsSpec{} // don't call NewTableflowV1TableFlowTopicConfigsSpec() because it explicitly sets RecordFailureStrategy to "SUSPEND"
 	updateTableflowTopicSpec.SetEnvironment(tableflow.GlobalObjectReference{Id: environmentId})
 	updateTableflowTopicSpec.SetKafkaCluster(tableflow.EnvScopedObjectReference{Id: clusterId})
 	if d.HasChange(paramRetentionMs) {


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- Fixed an issue in the `confluent_tableflow_topic` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_tableflow_topic) where tableflow topics could not be created with `error_handling` mode set to `skip` or `log`.

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Currently, creating a new Tableflow topic with the error handling mode set to `SKIP` or `LOG` results in errors like:
```
│ Error: error creating Tableflow Topic: 400 Bad Request: Bad Request: conflicting error handling settings: error_handling.mode=LOG, record_failure_strategy=SUSPEND
```
because the provider is sending `record_failure_strategy` with the default value of `SUSPEND` even if the user doesn't set it.

Blast Radius
----
Minimal; this is fixing a broken feature.

References
----------
* https://github.com/confluentinc/ccloud-sdk-go-v2/blob/master/tableflow/v1/model_tableflow_v1_table_flow_topic_configs_spec.go#L58

Test & Review
-------------
Manual testing: https://docs.google.com/document/d/1HfuphXCRhedec6mna8Oz4qRDDPjgN0iNBefPHRBtDPY/edit?usp=sharing
