### PR TITLE
Use GitHub write token for GoReleaser release

### DIFF
--- a/.semaphore/goreleaser.yml
+++ b/.semaphore/goreleaser.yml
@@ -34,7 +34,7 @@ blocks:
             - CGO_CFLAGS="-Wno-error=gnu-folding-constant" ./make.bash -v
             - cd ../../
             - export PATH=$(pwd)/go/bin:$PATH
-            - export "GITHUB_TOKEN=$(gh auth token)"
+            - export "GITHUB_TOKEN=${GITHUB_TOKEN_WRITE}"
             - cd terraform-provider-confluent*
             - GOROOT=/Users/semaphore/go VERSION=v1.25.1 ./scripts/run-goreleaser.sh build --config .goreleaser-darwin-fips.yml
             - artifact push workflow dist/darwin-fips_darwin_amd64_v1 --force
@@ -47,7 +47,7 @@ blocks:
           commands:
             - sem-version go 1.24.9
             - export "GOPATH=$(go env GOPATH)"
-            - export "GITHUB_TOKEN=$(gh auth token)"
+            - export "GITHUB_TOKEN=${GITHUB_TOKEN_WRITE}"
             - >-
               export
               "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"


### PR DESCRIPTION
## Summary

- Use `$GITHUB_TOKEN_WRITE` instead of `$(gh auth token)` for GoReleaser build and release operations (2 places in `.semaphore/goreleaser.yml`)

## Context

After the read/write GitHub token split in ci-build-agent-infra (DP-15608), `gh auth token` returns the read token (`semaphore-agent-reader`). GoReleaser uses `$GITHUB_TOKEN` directly for GitHub API calls (creating releases, uploading artifacts) and needs the write token.

`$GITHUB_TOKEN_WRITE` is already set by the pre-job hook (`get-auth-token github`) and uses `semaphore-agent-production` on prod branch builds.

## Why this is safe

- `GITHUB_TOKEN_WRITE` is already available in the environment, set by the pre-job hook
- GoReleaser inherently performs write operations (creating releases, uploading artifacts), so using the write token is correct
- Git push operations in the same jobs already use the write token via `.gitconfig` `pushInsteadOf` rewrites

## Related

- DP-15608 (Semaphore CI: GitHub token permission scoping)
- INC-9036 (CLI release homebrew step blocked — same root cause)

## Test plan

- [ ] Verify the next GoReleaser release completes successfully