### PR TITLE
Add cli-tfgen marker comments to provider.go for auto-registration to support TF generator tool

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -151,6 +151,7 @@ type Client struct {
 	isAcceptanceTestMode            bool
 	isLiveProductionTestMode        bool
 	isOAuthEnabled                  bool
+	// cli-tfgen:tf-client-fields
 }
 
 type ResourceMetadataSetFlags struct {
@@ -385,6 +386,7 @@ func New(version, userAgent string) func() *schema.Provider {
 				"confluent_business_metadata_binding":          businessMetadataBindingDataSource(),
 				"confluent_schema_registry_kek":                schemaRegistryKekDataSource(),
 				"confluent_schema_registry_dek":                schemaRegistryDekDataSource(),
+				// cli-tfgen:tf-datasources
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"confluent_catalog_integration":                catalogIntegrationResource(),
@@ -448,6 +450,7 @@ func New(version, userAgent string) func() *schema.Provider {
 				"confluent_schema_registry_kek":                schemaRegistryKekResource(),
 				"confluent_schema_registry_dek":                schemaRegistryDekResource(),
 				"confluent_catalog_entity_attributes":          catalogEntityAttributesResource(),
+				// cli-tfgen:tf-resources
 			},
 		}
 
@@ -791,6 +794,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		isLiveProductionTestMode:     liveProductionTestMode,
 		isOAuthEnabled:               oauthEnabled,
 	}
+
+	// cli-tfgen:tf-client-init
 
 	return &client, nil
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -70,7 +70,10 @@ func testAccPreCheck(t *testing.T) {
 
 func TestProviderGoContainsTfgenMarkers(t *testing.T) {
 	// Locate provider.go relative to this test file.
-	_, thisFile, _, _ := runtime.Caller(0)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed: unable to determine test file path")
+	}
 	providerGoPath := filepath.Join(filepath.Dir(thisFile), "provider.go")
 
 	content, err := os.ReadFile(providerGoPath)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -16,6 +16,9 @@ package provider
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,6 +65,30 @@ func testAccPreCheck(t *testing.T) {
 	canUseApiKeyAndSecret := ccApiKey != "" && ccApiSecret != ""
 	if !canUseApiKeyAndSecret {
 		t.Fatal("Both CONFLUENT_CLOUD_API_KEY and CONFLUENT_CLOUD_API_SECRET must be set for acceptance tests (having them set to fake values is fine)")
+	}
+}
+
+func TestProviderGoContainsTfgenMarkers(t *testing.T) {
+	// Locate provider.go relative to this test file.
+	_, thisFile, _, _ := runtime.Caller(0)
+	providerGoPath := filepath.Join(filepath.Dir(thisFile), "provider.go")
+
+	content, err := os.ReadFile(providerGoPath)
+	if err != nil {
+		t.Fatalf("failed to read provider.go: %s", err)
+	}
+	text := string(content)
+
+	markers := []string{
+		"// cli-tfgen:tf-resources",
+		"// cli-tfgen:tf-datasources",
+		"// cli-tfgen:tf-client-fields",
+		"// cli-tfgen:tf-client-init",
+	}
+	for _, marker := range markers {
+		if !strings.Contains(text, marker) {
+			t.Errorf("provider.go is missing required marker %q (needed by cli-terraform-generator --provider-dir)", marker)
+		}
 	}
 }
 


### PR DESCRIPTION
Release Notes
---------
NA, as the changes are limited to comments and don't affect runtime behavior.

Checklist
---------
NA, as the changes are limited to comments and don't affect runtime behavior.

What
----
Add four cli-tfgen marker comments to provider.go to support the `--provider-dir` flag of the TF generator tool. These markers (tf-resources, tf-datasources, tf-client-fields,          
  tf-client-init) allow the generator to automatically insert new resources, data sources, and client configurations into the provider. Each marker is placed at the end of its respective section with matching indentation so    
  that insertBeforeMarker can insert entries in the correct alphabetical order. A unit test is added to ensure the markers are not accidentally removed. No runtime behavior is changed — the markers are plain Go comments.

Blast Radius
----
None, as the changes are limited to comments and don't affect runtime behavior.

References
----------
NA

Test & Review
-------------
A unit test is added to ensure the markers are not accidentally removed. No runtime behavior is changed — the markers are plain Go comments.



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
