### PR TITLE
Update community-contributed-examples README and add Flink OAuth example

### DIFF
--- a/community-contributed-examples/README.md
+++ b/community-contributed-examples/README.md
@@ -25,11 +25,10 @@ We welcome community contributions! If you have a working Terraform configuratio
 
 ### Contribution Process
 
-1. **Clone the [terraform-community-examples](https://github.com/confluentinc/terraform-community-examples) repository** and create a new branch for your contribution
-2. **Create your example directory** under the repository with a descriptive name
-3. **Include your Terraform files** (`.tf` files) and any supporting documentation
-4. **Use the PR template** when submitting your pull request (see [contribution_pr_template.md](./contribution_pr_template.md))
-5. **Submit your PR** for review by the API team
+1. **Host your example** in a public GitHub repository (your own repo, [terraform-community-examples](https://github.com/confluentinc/terraform-community-examples), or any other public repo)
+2. **Open a PR** on [terraform-provider-confluent](https://github.com/confluentinc/terraform-provider-confluent) to add a link to your example in [`docs/guides/community-contributed-examples.md`](../docs/guides/community-contributed-examples.md)
+3. **Use the PR template** when submitting your pull request (see [contribution_pr_template.md](./contribution_pr_template.md))
+4. **Submit your PR** for review by the API team
 
 
 ## 📁 Example Structure
@@ -37,14 +36,13 @@ We welcome community contributions! If you have a working Terraform configuratio
 Each contributed example should follow a structure similar to below:
 
 ```
-community-contributed-examples/
-└── your-example-name/
-    ├── README.md             # Explanation of the use case
-    ├── main.tf               # Main Terraform configuration
-    ├── variables.tf          # Variable definitions (if applicable)
-    ├── outputs.tf            # Output definitions (if applicable)
-    ├── terraform.tfvars.example  # Example variable values (if applicable)
-    └── versions.tf           # Provider version constraints (if applicable)
+your-example-name/
+├── README.md             # Explanation of the use case
+├── main.tf               # Main Terraform configuration
+├── variables.tf          # Variable definitions (if applicable)
+├── outputs.tf            # Output definitions (if applicable)
+├── terraform.tfvars.example  # Example variable values (if applicable)
+└── versions.tf           # Provider version constraints (if applicable)
 ```
 
 ## 🏷️ Categories

--- a/docs/guides/community-contributed-examples.md
+++ b/docs/guides/community-contributed-examples.md
@@ -10,3 +10,4 @@ If you have an example you’d like to contribute, please see the [Contributing 
 
 ### [Flink SQL & Compute Pool: Real-Time Data Processing Pipeline with AWS Bedrock Integration](https://github.com/confluentinc/flink-ai-examples/tree/rt-clinical-data-extraction/demos/rt-clinical-data-extraction)
 
+### [OAuth Identity Pool with Flink Service Account Delegation](https://github.com/confluentinc/terraform-community-examples/tree/master/flink-oauth-identity-pool)


### PR DESCRIPTION
Release Notes
---------

Examples
- Added a link to the [Flink OAuth Identity Pool](https://github.com/confluentinc/terraform-community-examples/tree/master/flink-oauth-identity-pool) community example
- Updated the contribution process in `community-contributed-examples/README.md` to reflect that examples can be hosted in any public repo and contributing means opening a PR to add a link to `docs/guides/community-contributed-examples.md`

Checklist
---------
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.

What
----
Two documentation-only changes:

1. Added a link to the Flink OAuth Identity Pool community example in `docs/guides/community-contributed-examples.md`
2. Fixed the contribution process in `community-contributed-examples/README.md` after #972 moved the examples listing to `docs/guides/`. The README still described a flow where examples had to go into the `terraform-community-examples` repo, but in practice examples can live in any public repo (as seen with existing entries). Updated the contribution steps and removed the misleading `community-contributed-examples/` parent path from the example directory structure.

Blast Radius
----
None. Documentation-only changes with no impact on provider functionality.

References
----------
- #972

Test & Review
-------------
Documentation-only changes; no provider code modified.