### PR TITLE
Handle 404 for already deleted `confluent_plugin` resources

### DIFF
--- a/internal/provider/resource_plugin.go
+++ b/internal/provider/resource_plugin.go
@@ -219,6 +219,10 @@ func pluginDelete(ctx context.Context, d *schema.ResourceData, meta interface{})
 	resp, err := req.Execute()
 
 	if err != nil {
+		if isNonKafkaRestApiResourceNotFound(resp) {
+			tflog.Warn(ctx, fmt.Sprintf("Removing Plugin %q in TF state because Plugin could not be found on the server", d.Id()), map[string]interface{}{pluginLoggingKey: d.Id()})
+			return nil
+		}
 		return diag.Errorf("error deleting Plugin %q: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Finished deleting Plugin %q", d.Id()), map[string]interface{}{pluginLoggingKey: d.Id()})


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- Fix an error that occurs when deleting `confluent_plugin` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_plugin) after deleting all corresponding `confluent_custom_connector_plugin_version` [resources](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_custom_connector_plugin_version).

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Deleting all `confluent_custom_connector_plugin_version` resources causes a cascading deletion of the parent `confluent_plugin` resource. So attempting to delete both the versions and the plugin produces the following error:
```
Error: error deleting Plugin "ccp-abc123": 404 Not Found: Not Found
```

This PR handles this case by treating a 404 on delete as a successful delete.

Blast Radius
----
Minimal. This only changes how the provider handles a backend error for an already deleted resource.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
Manual testing: https://docs.google.com/document/d/1nUqFQOC_Me-vzzrUhOHUvF18ohGTGBLuoI8uMlDq_VE/edit?usp=sharing

Live tests pass again: https://semaphore.ci.confluent.io/workflows/f406d9f0-74fc-4959-90b1-62df8ea36319