### PR TITLE
replace deprecated sql.secrets example with Flink Connection

### DIFF
--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -83,20 +83,55 @@ resource "confluent_flink_statement" "example" {
 }
 ```
 
-Example of `confluent_flink_statement` that creates a model:
-```
+### Example: Create a model using a Flink Connection
+
+Use a [`confluent_flink_connection`](confluent_flink_connection) resource to
+securely pass credentials instead of embedding secrets in statement properties.
+
+```terraform
+# Step 1: Create a Flink Connection for OpenAI
+resource "confluent_flink_connection" "openai" {
+  organization {
+    id = data.confluent_organization.main.id
+  }
+  environment {
+    id = data.confluent_environment.staging.id
+  }
+  compute_pool {
+    id = confluent_flink_compute_pool.example.id
+  }
+  principal {
+    id = confluent_service_account.app-manager-flink.id
+  }
+  rest_endpoint = data.confluent_flink_region.main.rest_endpoint
+  credentials {
+    key    = confluent_api_key.env-admin-flink-api-key.id
+    secret = confluent_api_key.env-admin-flink-api-key.secret
+  }
+
+  display_name = "openai-connection"
+  type         = "OPENAI"
+  endpoint     = "https://api.openai.com/v1/embeddings"
+  api_key      = var.openai_api_key
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Step 2: Create a model that references the connection
 resource "confluent_flink_statement" "example" {
-  statement  = "CREATE MODEL `vector_encoding` INPUT (input STRING) OUTPUT (vector ARRAY<FLOAT>) WITH( 'TASK' = 'classification','PROVIDER' = 'OPENAI','OPENAI.ENDPOINT' = 'https://api.openai.com/v1/embeddings','OPENAI.API_KEY' = '{{sessionconfig/sql.secrets.openaikey}}');"  
+  statement = "CREATE MODEL `vector_encoding` INPUT (input STRING) OUTPUT (vector ARRAY<FLOAT>) WITH ('TASK' = 'classification', 'PROVIDER' = 'OPENAI', 'OPENAI.CONNECTION' = 'openai-connection');"
   properties = {
     "sql.current-catalog"  = var.confluent_environment_display_name
     "sql.current-database" = var.confluent_kafka_cluster_display_name
   }
-  properties_sensitive = {
-      "sql.secrets.openaikey" : "***REDACTED***"
-  }
+
   lifecycle {
     prevent_destroy = true
   }
+
+  depends_on = [confluent_flink_connection.openai]
 }
 ```
 
@@ -129,7 +164,7 @@ The following arguments are supported:
 - `properties` - (Optional Map) The custom topic settings to set:
     - `name` - (Required String) The setting name, for example, `sql.local-time-zone`.
     - `value` - (Required String) The setting value, for example, `GMT-08:00`.
-- `properties_sensitive` - (Optional Map) Block for sensitive statement properties:
+- `properties_sensitive` - (Optional Map, **Deprecated**) Block for sensitive statement properties. Use [`confluent_flink_connection`](confluent_flink_connection) instead to securely manage credentials for external services like OpenAI. See the [Manage Flink Connections](https://docs.confluent.io/cloud/current/flink/operate-and-deploy/manage-connections.html) documentation for details.
     - `name` - (Required String) The setting name, for example, `sql.secrets.openaikey`.
     - `value` - (Required String) The setting value, for example, `s1234`.
 

--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -85,10 +85,16 @@ resource "confluent_flink_statement" "example" {
 
 ### Example: Create a model using a Flink Connection
 
-Use a [`confluent_flink_connection`](confluent_flink_connection) resource to
-securely pass credentials instead of embedding secrets in statement properties.
+Use a [`confluent_flink_connection`](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_connection) resource to
+avoid embedding secrets in statement properties. Note that secrets may still be
+persisted in Terraform state, so be sure to protect your state appropriately.
 
 ```terraform
+provider "confluent" {
+  cloud_api_key    = var.confluent_cloud_api_key    # optionally use CONFLUENT_CLOUD_API_KEY env var
+  cloud_api_secret = var.confluent_cloud_api_secret # optionally use CONFLUENT_CLOUD_API_SECRET env var
+}
+
 # Step 1: Create a Flink Connection for OpenAI
 resource "confluent_flink_connection" "openai" {
   organization {
@@ -121,10 +127,27 @@ resource "confluent_flink_connection" "openai" {
 
 # Step 2: Create a model that references the connection
 resource "confluent_flink_statement" "example" {
+  organization {
+    id = data.confluent_organization.main.id
+  }
+  environment {
+    id = data.confluent_environment.staging.id
+  }
+  compute_pool {
+    id = confluent_flink_compute_pool.example.id
+  }
+  principal {
+    id = confluent_service_account.app-manager-flink.id
+  }
+  rest_endpoint = data.confluent_flink_region.main.rest_endpoint
+  credentials {
+    key    = confluent_api_key.env-admin-flink-api-key.id
+    secret = confluent_api_key.env-admin-flink-api-key.secret
+  }
   statement = "CREATE MODEL `vector_encoding` INPUT (input STRING) OUTPUT (vector ARRAY<FLOAT>) WITH ('TASK' = 'classification', 'PROVIDER' = 'OPENAI', 'OPENAI.CONNECTION' = 'openai-connection');"
   properties = {
-    "sql.current-catalog"  = var.confluent_environment_display_name
-    "sql.current-database" = var.confluent_kafka_cluster_display_name
+    "sql.current-catalog"  = data.confluent_environment.example.display_name
+    "sql.current-database" = data.confluent_kafka_cluster.example.display_name
   }
 
   lifecycle {
@@ -164,7 +187,7 @@ The following arguments are supported:
 - `properties` - (Optional Map) The custom topic settings to set:
     - `name` - (Required String) The setting name, for example, `sql.local-time-zone`.
     - `value` - (Required String) The setting value, for example, `GMT-08:00`.
-- `properties_sensitive` - (Optional Map, **Deprecated**) Block for sensitive statement properties. Use [`confluent_flink_connection`](confluent_flink_connection) instead to securely manage credentials for external services like OpenAI. See the [Manage Flink Connections](https://docs.confluent.io/cloud/current/flink/operate-and-deploy/manage-connections.html) documentation for details.
+- `properties_sensitive` - (Optional Map, legacy / not recommended) Block for sensitive statement properties. Prefer using [`confluent_flink_connection`](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_connection) to manage credentials for external services like OpenAI. See the [Manage Flink Connections](https://docs.confluent.io/cloud/current/flink/operate-and-deploy/manage-connections.html) documentation for details.
     - `name` - (Required String) The setting name, for example, `sql.secrets.openaikey`.
     - `value` - (Required String) The setting value, for example, `s1234`.
 


### PR DESCRIPTION
## Summary

- Replace the deprecated `sql.secrets`/`properties_sensitive` pattern in the CREATE MODEL example with the GA approach using `confluent_flink_connection`
- Add a full working example showing `confluent_flink_connection` + `confluent_flink_statement` together
- Add deprecation notice to `properties_sensitive` argument reference pointing to `confluent_flink_connection`

Supersedes #758.

**Jira:** [DOCS-34166](https://confluentinc.atlassian.net/browse/DOCS-34166)

## Test plan

- [ ] Verify rendered docs on the Terraform Registry show the updated example
- [ ] Confirm `confluent_flink_connection` link resolves correctly
- [ ] Confirm deprecation notice renders with bold styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-34166]: https://confluentinc.atlassian.net/browse/DOCS-34166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ