### PR TITLE
Removes the schema-level ConflictsWith between byok_key and freight.

### DIFF
--- a/internal/provider/constants_test.go
+++ b/internal/provider/constants_test.go
@@ -448,6 +448,7 @@ const (
 	kafkaClientQuotaResourceLabel                                       = "test_kafka_client_quota_resource_label"
 	kafkaClientQuotaScenarioName                                        = "confluent_kafka_client_quota Resource Lifecycle"
 	kafkaClientQuotaUrlPath                                             = "/kafka-quotas/v1/client-quotas/cq-e857e"
+	kafkaByokKeyId                                                      = "cck-abcde"
 	kafkaCloud                                                          = "GCP"
 	kafkaClusterId                                                      = "lkc-19ynpv"
 	kafkaClustersDataSourceLabel                                        = "test_kafka_clusters_data_source_label"

--- a/internal/provider/resource_kafka_cluster.go
+++ b/internal/provider/resource_kafka_cluster.go
@@ -744,8 +744,7 @@ func freightClusterSchema() *schema.Schema {
 				},
 			},
 		},
-		ExactlyOneOf:  acceptedClusterTypes,
-		ConflictsWith: []string{paramConfluentCustomerKey},
+		ExactlyOneOf: acceptedClusterTypes,
 	}
 }
 
@@ -766,7 +765,7 @@ func byokSchema() *schema.Schema {
 				},
 			},
 		},
-		ConflictsWith: []string{paramBasicCluster, paramStandardCluster, paramFreightCluster},
+		ConflictsWith: []string{paramBasicCluster, paramStandardCluster},
 	}
 }
 

--- a/internal/provider/resource_kafka_cluster_with_sg_package_freight_byok_test.go
+++ b/internal/provider/resource_kafka_cluster_with_sg_package_freight_byok_test.go
@@ -1,0 +1,293 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/walkerus/go-wiremock"
+)
+
+func TestAccFreightClusterWithBYOK(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	createClusterResponse, _ := ioutil.ReadFile("../testdata/freight_kafka_byok/create_kafka.json")
+	createClusterStub := wiremock.Post(wiremock.URLPathEqualTo(createKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateKafkaHasBeenCreated).
+		WillReturn(
+			string(createClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusAccepted,
+		)
+	_ = wiremockClient.StubFor(createClusterStub)
+
+	readCreatedClusterResponse, _ := ioutil.ReadFile("../testdata/freight_kafka_byok/read_created_kafka.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreated).
+		WillReturn(
+			string(readCreatedClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readEnvironmentResponse, _ := ioutil.ReadFile("../testdata/environment/read_created_env.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readEnvPath)).
+		InScenario(kafkaScenarioName).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreated).
+		WillSetStateTo(scenarioStateKafkaHasBeenCreatedButZeroSRClusters).
+		WillReturn(
+			string(readEnvironmentResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	listZeroSchemaRegistryClusterResponse, _ := ioutil.ReadFile("../testdata/schema_registry_cluster/read_zero_clusters.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(listSchemaRegistryClusterUrlPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreatedButZeroSRClusters).
+		WillSetStateTo(scenarioStateKafkaHasBeenCreatedButSRClusterIsProvisioning).
+		WillReturn(
+			string(listZeroSchemaRegistryClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	listProvisioningSchemaRegistryClusterResponse, _ := ioutil.ReadFile("../testdata/schema_registry_cluster/read_provisioning_clusters.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(listSchemaRegistryClusterUrlPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreatedButSRClusterIsProvisioning).
+		WillSetStateTo(scenarioStateKafkaHasBeenCreatedAndSRClusterIsProvisioned).
+		WillReturn(
+			string(listProvisioningSchemaRegistryClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readCreatedSchemaRegistryClustersResponse, _ := ioutil.ReadFile("../testdata/schema_registry_cluster/read_provisioned_clusters.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(listSchemaRegistryClusterUrlPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreatedAndSRClusterIsProvisioned).
+		WillSetStateTo(scenarioStateKafkaHasBeenCreatedAndSyncIsComplete).
+		WillReturn(
+			string(readCreatedSchemaRegistryClustersResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readCreatedClusterResponse, _ = ioutil.ReadFile("../testdata/freight_kafka_byok/read_created_kafka.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreatedAndSyncIsComplete).
+		WillReturn(
+			string(readCreatedClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readUpdatedClusterResponse, _ := ioutil.ReadFile("../testdata/freight_kafka_byok/read_updated_kafka.json")
+	updateClusterStub := wiremock.Patch(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenCreatedAndSyncIsComplete).
+		WillSetStateTo(scenarioStateKafkaHasBeenUpdated).
+		WillReturn(
+			string(readUpdatedClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		)
+	_ = wiremockClient.StubFor(updateClusterStub)
+
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenUpdated).
+		WillReturn(
+			string(readUpdatedClusterResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	readDeletedEnvResponse, _ := ioutil.ReadFile("../testdata/freight_kafka_byok/read_deleted_kafka.json")
+
+	deleteClusterStub := wiremock.Delete(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenUpdated).
+		WillSetStateTo(scenarioStateKafkaHasBeenDeleted).
+		WillReturn(
+			"",
+			contentTypeJSONHeader,
+			http.StatusNoContent,
+		)
+	_ = wiremockClient.StubFor(deleteClusterStub)
+
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readKafkaPath)).
+		InScenario(kafkaScenarioName).
+		WithQueryParam("environment", wiremock.EqualTo(testEnvironmentId)).
+		WhenScenarioStateIs(scenarioStateKafkaHasBeenDeleted).
+		WillReturn(
+			string(readDeletedEnvResponse),
+			contentTypeJSONHeader,
+			http.StatusForbidden,
+		))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckClusterDestroy,
+		// https://www.terraform.io/docs/extend/testing/acceptance-tests/teststep.html
+		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckFreightClusterWithBYOKConfig(mockServerUrl, paramFreightCluster, kafkaDisplayName, kafkaMaxEcku, kafkaByokKeyId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fullFreightKafkaResourceLabel),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "id", kafkaClusterId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "api_version", kafkaApiVersion),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "kind", kafkaKind),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "display_name", kafkaDisplayName),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "availability", lowAvailability),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "bootstrap_endpoint", freightKafkaBootstrapEndpoint),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "cloud", freightKafkaCloud),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "basic.#", "0"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "standard.#", "0"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.0.%", "2"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.0.max_ecku", "5"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "byok_key.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "byok_key.0.id", kafkaByokKeyId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "environment.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "environment.0.id", testEnvironmentId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "network.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "network.0.%", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "rest_endpoint", freightKafkaHttpEndpoint),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "rbac_crn", kafkaRbacCrn),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.#", "2"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.access_point_id", "ap1pni123"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.connection_type", "PRIVATENETWORKINTERFACE"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.rest_endpoint", "https://lkc-s1232.us-central1.gcp.private.confluent.cloud:443"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.bootstrap_endpoint", "lkc-s1232-00000.us-central1.gcp.private.confluent.cloud:9092"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.access_point_id", "ap2platt67890"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.connection_type", "PRIVATELINK"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.rest_endpoint", "https://lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:443"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.bootstrap_endpoint", "lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:9092"),
+				),
+			},
+			{
+				Config: testAccCheckFreightClusterWithBYOKConfig(mockServerUrl, paramFreightCluster, kafkaDisplayNameUpdated, kafkaMaxEckuUpdated, kafkaByokKeyId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(fullFreightKafkaResourceLabel),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "id", kafkaClusterId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "api_version", kafkaApiVersion),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "kind", kafkaKind),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "display_name", kafkaDisplayNameUpdated),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "availability", lowAvailability),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "bootstrap_endpoint", freightKafkaBootstrapEndpoint),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "cloud", freightKafkaCloud),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "basic.#", "0"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "standard.#", "0"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.0.%", "2"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "freight.0.max_ecku", "3"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "byok_key.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "byok_key.0.id", kafkaByokKeyId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "environment.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "environment.0.id", testEnvironmentId),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "network.#", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "network.0.%", "1"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "rest_endpoint", freightKafkaHttpEndpoint),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "rbac_crn", kafkaRbacCrn),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.#", "2"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.access_point_id", "ap1pni123"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.connection_type", "PRIVATENETWORKINTERFACE"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.rest_endpoint", "https://lkc-s1232.us-central1.gcp.private.confluent.cloud:443"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.0.bootstrap_endpoint", "lkc-s1232-00000.us-central1.gcp.private.confluent.cloud:9092"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.access_point_id", "ap2platt67890"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.connection_type", "PRIVATELINK"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.rest_endpoint", "https://lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:443"),
+					resource.TestCheckResourceAttr(fullFreightKafkaResourceLabel, "endpoints.1.bootstrap_endpoint", "lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:9092"),
+				),
+			},
+			{
+				// https://www.terraform.io/docs/extend/resources/import.html
+				ResourceName:      fullFreightKafkaResourceLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					resources := state.RootModule().Resources
+					clusterId := resources[fullFreightKafkaResourceLabel].Primary.ID
+					environmentId := resources[fullFreightKafkaResourceLabel].Primary.Attributes["environment.0.id"]
+					return environmentId + "/" + clusterId, nil
+				},
+			},
+		},
+	})
+
+	checkStubCount(t, wiremockClient, createClusterStub, fmt.Sprintf("POST %s", createKafkaPath), expectedCountOne)
+	checkStubCount(t, wiremockClient, updateClusterStub, fmt.Sprintf("PATCH %s", readKafkaPath), expectedCountOne)
+	checkStubCount(t, wiremockClient, deleteClusterStub, fmt.Sprintf("DELETE %s", readKafkaPath), expectedCountOne)
+}
+
+func testAccCheckFreightClusterWithBYOKConfig(mockServerUrl, clusterType, displayName string, maxEcku int32, byokKeyId string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+ 		endpoint = "%s"
+	}
+	resource "confluent_kafka_cluster" "freight-cluster" {
+		display_name = "%s"
+		availability = "%s"
+		cloud = "%s"
+		region = "%s"
+		%s {
+			max_ecku = %v
+		}
+
+		byok_key {
+			id = "%s"
+		}
+
+	  	environment {
+			id = "%s"
+	  	}
+	}
+	`, mockServerUrl, displayName, lowAvailability, freightKafkaCloud, freightKafkaRegion, clusterType, maxEcku, byokKeyId, testEnvironmentId)
+}

--- a/internal/testdata/freight_kafka_byok/create_kafka.json
+++ b/internal/testdata/freight_kafka_byok/create_kafka.json
@@ -1,0 +1,47 @@
+{
+  "api_version": "cmk/v2",
+  "id": "lkc-19ynpv",
+  "kind": "Cluster",
+  "metadata": {
+    "created_at": "2021-08-24T14:37:56.09422Z",
+    "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj/cloud-cluster=lkc-19ynpv/kafka=lkc-19ynpv",
+    "self": "https://api.confluent.cloud/cmk/v2/clusters/lkc-19ynpv",
+    "updated_at": "2021-08-24T14:37:56.09422Z"
+  },
+  "spec": {
+    "api_endpoint": "https://lkaclkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "availability": "LOW",
+    "cloud": "AWS",
+    "config": {
+      "kind": "Freight",
+      "max_ecku": 5
+    },
+    "display_name": "TestCluster",
+    "environment": {
+      "id": "env-1jrymj",
+      "related": "https://api.confluent.cloud/v2/environments/env-1jrymj",
+      "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj"
+    },
+    "byok": {
+      "id": "cck-abcde"
+    },
+    "http_endpoint": "https://lkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "kafka_bootstrap_endpoint": "lkc-19ynpv.us-east-2.aws.private.confluent.cloud:9092",
+    "region": "us-east-2",
+    "endpoints": {
+      "ap1pni123": {
+        "kafka_bootstrap_endpoint": "lkc-s1232-00000.us-central1.gcp.private.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-s1232.us-central1.gcp.private.confluent.cloud:443",
+        "connection_type": "PRIVATENETWORKINTERFACE"
+      },
+      "ap2platt67890": {
+        "kafka_bootstrap_endpoint": "lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:443",
+        "connection_type": "PRIVATELINK"
+      }
+    }
+  },
+  "status": {
+    "phase": "PROVISIONED"
+  }
+}

--- a/internal/testdata/freight_kafka_byok/read_created_kafka.json
+++ b/internal/testdata/freight_kafka_byok/read_created_kafka.json
@@ -1,0 +1,48 @@
+{
+  "api_version": "cmk/v2",
+  "id": "lkc-19ynpv",
+  "kind": "Cluster",
+  "metadata": {
+    "created_at": "2021-08-24T14:37:56.09422Z",
+    "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj/cloud-cluster=lkc-19ynpv/kafka=lkc-19ynpv",
+    "self": "https://api.confluent.cloud/cmk/v2/clusters/lkc-19ynpv",
+    "updated_at": "2021-08-24T14:37:56.09422Z"
+  },
+  "spec": {
+    "api_endpoint": "https://lkaclkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "availability": "LOW",
+    "cloud": "AWS",
+    "config": {
+      "kind": "Freight",
+      "max_ecku": 5,
+      "zones": ["use1-az2", "use1-az3"]
+    },
+    "display_name": "TestCluster",
+    "environment": {
+      "id": "env-1jrymj",
+      "related": "https://api.confluent.cloud/v2/environments/env-1jrymj",
+      "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj"
+    },
+    "byok": {
+      "id": "cck-abcde"
+    },
+    "http_endpoint": "https://lkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "kafka_bootstrap_endpoint": "lkc-19ynpv.us-east-2.aws.private.confluent.cloud:9092",
+    "region": "us-east-2",
+    "endpoints": {
+      "ap1pni123": {
+        "kafka_bootstrap_endpoint": "lkc-s1232-00000.us-central1.gcp.private.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-s1232.us-central1.gcp.private.confluent.cloud:443",
+        "connection_type": "PRIVATENETWORKINTERFACE"
+      },
+      "ap2platt67890": {
+        "kafka_bootstrap_endpoint": "lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:443",
+        "connection_type": "PRIVATELINK"
+      }
+    }
+  },
+  "status": {
+    "phase": "PROVISIONED"
+  }
+}

--- a/internal/testdata/freight_kafka_byok/read_deleted_kafka.json
+++ b/internal/testdata/freight_kafka_byok/read_deleted_kafka.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "id": "d2f8a68a77ed67adde49967132ad79b8",
+      "status": "403",
+      "code": "forbidden_access",
+      "detail": "Forbidden Access",
+      "source": {}
+    }
+  ]
+}

--- a/internal/testdata/freight_kafka_byok/read_updated_kafka.json
+++ b/internal/testdata/freight_kafka_byok/read_updated_kafka.json
@@ -1,0 +1,48 @@
+{
+  "api_version": "cmk/v2",
+  "id": "lkc-19ynpv",
+  "kind": "Cluster",
+  "metadata": {
+    "created_at": "2021-08-24T14:37:56.09422Z",
+    "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj/cloud-cluster=lkc-19ynpv/kafka=lkc-19ynpv",
+    "self": "https://api.confluent.cloud/cmk/v2/clusters/lkc-19ynpv",
+    "updated_at": "2021-08-24T14:37:56.09422Z"
+  },
+  "spec": {
+    "api_endpoint": "https://lkaclkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "availability": "LOW",
+    "cloud": "AWS",
+    "config": {
+      "kind": "Freight",
+      "max_ecku": 3,
+      "zones": ["use1-az2", "use1-az3"]
+    },
+    "display_name": "TestClusterUpdated",
+    "environment": {
+      "id": "env-1jrymj",
+      "related": "https://api.confluent.cloud/v2/environments/env-1jrymj",
+      "resource_name": "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-1jrymj"
+    },
+    "byok": {
+      "id": "cck-abcde"
+    },
+    "http_endpoint": "https://lkc-19ynpv.us-east-2.aws.private.confluent.cloud:443",
+    "kafka_bootstrap_endpoint": "lkc-19ynpv.us-east-2.aws.private.confluent.cloud:9092",
+    "region": "us-east-2",
+    "endpoints": {
+      "ap1pni123": {
+        "kafka_bootstrap_endpoint": "lkc-s1232-00000.us-central1.gcp.private.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-s1232.us-central1.gcp.private.confluent.cloud:443",
+        "connection_type": "PRIVATENETWORKINTERFACE"
+      },
+      "ap2platt67890": {
+        "kafka_bootstrap_endpoint": "lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:9092",
+        "http_endpoint": "https://lkc-00000-00000.us-central1.gcp.glb.confluent.cloud:443",
+        "connection_type": "PRIVATELINK"
+      }
+    }
+  },
+  "status": {
+    "phase": "PROVISIONED"
+  }
+}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->
Bug Fixes
  - Fixed schema-level conflict that prevented creating Freight Kafka clusters with a customer-managed encryption key on confluent_kafka_cluster (byok).

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Removes the schema-level conflict between byok_key and freight on confluent_kafka_cluster so users can create Freight clusters with a customer-managed encryption key via Terraform. The create and read paths already handled byok for any cluster type. The schema conflict was the only thing blocking it. 

This fix just basically mirrors the Enterprise + BYOK fix we had previously applied

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
This change only relaxes a schema validation rule and will not affect existing configs. The worst case is that the CMK backend rejects byok on a Freight spec, in which case a user attempting Freight + BYOK gets an apply-time API error and no partial state. In that case, the customer can remove byok_key and re-apply.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
APIT-3631.

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Added a wiremock acceptance test covering create, update, and import for a Freight cluster with a byok_key block. The create step would have failed at validation before this PR. Ran locally and build and vet are clean. Manual pre-prod apply and the testing thread in #terraform-provider-development-testing are still TODO.