### PR TITLE
Fix TF live tests by isolating RTCE live tests so they run with RTCE-specific env flags

### DIFF
--- a/.semaphore/live-tests.yml
+++ b/.semaphore/live-tests.yml
@@ -56,3 +56,11 @@ blocks:
               
               echo "Running live tests for: ${TF_LIVE_TEST_GROUPS:-all groups}"
               make live-test ${TF_LIVE_TEST_GROUPS:+TF_LIVE_TEST_GROUPS="$TF_LIVE_TEST_GROUPS"}
+
+              # RTCE live tests run separately because they require their own env flags
+              # (e.g. TF_ACC_REGION pinned to a region where RTCE is enabled in prod).
+              # Skip if the caller asked for a specific group that isn't "core" or "all".
+              case "$TF_LIVE_TEST_GROUPS" in
+                ""|*core*) make live-test-rtce ;;
+                *) echo "Skipping live-test-rtce (group filter excludes RTCE)" ;;
+              esac

--- a/Makefile
+++ b/Makefile
@@ -106,21 +106,31 @@ testacc:
 
 # Live integration tests with group filtering and concurrency support
 # Usage: make live-test TF_LIVE_TEST_GROUPS="core,kafka" or make live-test (for all)
+# RTCE tests are excluded here because RTCE prod is only enabled in aws.us-east-1;
+# run them via the dedicated `live-test-rtce` target below.
 .PHONY: live-test
 live-test:
 	@echo "Running live integration tests against Confluent Cloud..."
 	@if [ -z "$(TF_LIVE_TEST_GROUPS)" ]; then \
 		echo "Running ALL live tests with parallel execution..."; \
-		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$|.*DriftDetection$$" -tags="live_test,all" -timeout 1440m -parallel 10; \
+		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$|.*DriftDetection$$" -skip="Rtce" -tags="live_test,all" -timeout 1440m -parallel 10; \
 	else \
 		echo "Running live tests for groups: $(TF_LIVE_TEST_GROUPS) with parallel execution..."; \
 		TAGS="live_test"; \
 		for group in $$(echo "$(TF_LIVE_TEST_GROUPS)" | tr ',' ' '); do \
 			TAGS="$$TAGS,$$group"; \
 		done; \
-		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$|.*DriftDetection$$" -tags="$$TAGS" -timeout 1440m -parallel 10; \
+		TF_ACC=1 TF_ACC_PROD=1 $(GOCMD) test ./internal/provider/ -v -run=".*Live$$|.*DriftDetection$$" -skip="Rtce" -tags="$$TAGS" -timeout 1440m -parallel 10; \
 	fi
 	@echo "Finished running live integration tests against Confluent Cloud"
+
+# RTCE live tests — pinned to aws.us-east-1 because that's the only region
+# where RTCE is enabled in prod. Run separately from the main live-test target.
+.PHONY: live-test-rtce
+live-test-rtce:
+	@echo "Running RTCE live integration tests against Confluent Cloud (region=us-east-1)..."
+	TF_ACC=1 TF_ACC_PROD=1 TF_ACC_REGION=us-east-1 $(GOCMD) test ./internal/provider/ -v -run="Rtce.*Live$$" -tags="live_test,all" -timeout 1440m -parallel 10
+	@echo "Finished running RTCE live integration tests"
 
 # Helper targets for common group combinations
 .PHONY: live-test-core


### PR DESCRIPTION
Release Notes
  ---------

  (No user-facing changes — CI/test infrastructure only.)

  Checklist
  ---------
  - [x] I can successfully build and use a custom Terraform provider binary for Confluent.
  - [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
  - [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
  - [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
  - [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
  - [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
  - [ ] I have included rate limit/load testing results.
  - [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
  - [x] I have updated the corresponding documentation and include relevant examples for this PR.
  - [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
  - [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
    - [x] Confluent Cloud prod
    - [x] Confluent Cloud stag
    - [x] Check this box if the feature is enabled for certain organizations only

  What
  ----

  RTCE live tests need their own env flags (notably `TF_ACC_REGION` pinned to a region where RTCE is enabled in prod) — running them via the shared `live-test` target makes the prod CI run fail because the default region
  doesn't apply to RTCE.

  This PR isolates RTCE from the general live-test sweep:

  - **`Makefile`**: added `-skip="Rtce"` to the existing `live-test` target so RTCE tests no longer run there. Added a dedicated `live-test-rtce` target that runs only `Rtce.*Live` tests with `TF_ACC_REGION=us-east-1` pinned.
  - **`.semaphore/live-tests.yml`**: after the main `make live-test` step, the job now also runs `make live-test-rtce` when the group filter is empty (all groups) or contains `core` (which is the build tag RTCE tests are gated
  on). Other group filters skip RTCE.

  No `.go` files were touched — the test source still reads `TF_ACC_REGION` as before; the new target just supplies the right value at invocation time.

  Blast Radius
  ----

  None for customers — this PR only changes how live tests are scheduled in CI. The provider source code, schemas, and runtime behavior are untouched. In the worst case, a regression here would cause RTCE live test coverage to
  be skipped or to run in the wrong region, surfacing as a CI failure rather than any customer impact.

  References
  ----------

  - PR #163 review feedback (hardcoded `us-west-2` in 4 places in `resource_rtce_topic_live_test.go`)
  - Companion to https://github.com/confluentinc/terraform-provider-confluent/pull/1018 (RTCE topic resource & data source)

  Test & Review
  -------------

  - Verified locally that `make live-test` no longer matches `TestAccRtceTopicLive` / `TestAccRtceTopicUpdateLive` / `TestAccRtceTopicMinimalLive` thanks to `-skip="Rtce"`.
  - Verified `make live-test-rtce` selects only the RTCE live tests via `-run="Rtce.*Live$"` and forwards `TF_ACC_REGION=us-east-1` to the test process.
  - Verified the Semaphore branch logic: `TF_LIVE_TEST_GROUPS=""` (all) and `TF_LIVE_TEST_GROUPS="core"` invoke `make live-test-rtce`; `TF_LIVE_TEST_GROUPS="kafka"` (or any non-core group) skips it with a log line.