### PR TITLE
APIE-1075: Allow rest_endpoint to be updated in-place for confluent_tag and confluent_schema_registry_kek

### DIFF
--- a/internal/provider/resource_schema_registry_kek.go
+++ b/internal/provider/resource_schema_registry_kek.go
@@ -45,7 +45,6 @@ func schemaRegistryKekResource() *schema.Resource {
 			paramRestEndpoint: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Description:  "The REST endpoint of the Schema Registry cluster, for example, `https://psrc-00000.us-central1.gcp.confluent.cloud:443`).",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^http"), "the REST endpoint must start with 'https://'"),
 			},
@@ -256,7 +255,7 @@ func schemaRegistryKekDelete(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func schemaRegistryKekUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete) {
+	if d.HasChangesExcept(paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete, paramRestEndpoint) {
 		return diag.Errorf("error updating Schema Registry KEK %q: only %q, %q, %q, %q, %q attributes can be updated for Schema Registry KEK", d.Id(), paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete)
 	}
 

--- a/internal/provider/resource_schema_registry_kek.go
+++ b/internal/provider/resource_schema_registry_kek.go
@@ -256,7 +256,7 @@ func schemaRegistryKekDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 func schemaRegistryKekUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	if d.HasChangesExcept(paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete, paramRestEndpoint) {
-		return diag.Errorf("error updating Schema Registry KEK %q: only %q, %q, %q, %q, %q attributes can be updated for Schema Registry KEK", d.Id(), paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete)
+		return diag.Errorf("error updating Schema Registry KEK %q: only %q, %q, %q, %q, %q, %q attributes can be updated for Schema Registry KEK", d.Id(), paramCredentials, paramProperties, paramDoc, paramShared, paramHardDelete, paramRestEndpoint)
 	}
 
 	restEndpoint, err := extractSchemaRegistryRestEndpoint(meta.(*Client), d, false)

--- a/internal/provider/resource_schema_registry_kek_test.go
+++ b/internal/provider/resource_schema_registry_kek_test.go
@@ -28,22 +28,43 @@ import (
 func TestAccKek(t *testing.T) {
 	ctx := context.Background()
 
-	wiremockContainer, err := setupWiremock(ctx)
+	initialContainer, err := setupWiremock(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer wiremockContainer.Terminate(ctx)
+	defer initialContainer.Terminate(ctx)
 
-	mockServerUrl := wiremockContainer.URI
-	wiremockClient := wiremock.NewClient(mockServerUrl)
+	updatedContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer updatedContainer.Terminate(ctx)
+
+	mockServerInitialUrl := initialContainer.URI
+	mockServerUpdatedUrl := updatedContainer.URI
+	initialClient := wiremock.NewClient(mockServerInitialUrl)
+	updatedClient := wiremock.NewClient(mockServerUpdatedUrl)
 	// nolint:errcheck
-	defer wiremockClient.Reset()
+	defer initialClient.Reset()
+	defer updatedClient.Reset()
 
 	// nolint:errcheck
-	defer wiremockClient.ResetAllScenarios()
+	defer initialClient.ResetAllScenarios()
+	defer updatedClient.ResetAllScenarios()
+
+	// WireMock scenario state does not transfer between containers. When step 2 switches
+	// to mockServerUpdatedUrl, advance updatedClient from Started to KekHasBeenCreated so
+	// it can serve reads/updates without the resource being recreated.
+	dummyPath := "/state-sync"
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(dummyPath)).
+		InScenario(kekResourceScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateKekHasBeenCreated).
+		WillReturn("OK", contentTypeJSONHeader, http.StatusOK))
+	http.Get(mockServerUpdatedUrl + dummyPath)
 
 	createKekResponse, _ := ioutil.ReadFile("../testdata/schema_registry_kek/kek.json")
-	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createKekUrlPath)).
+	createKekStub := wiremock.Post(wiremock.URLPathEqualTo(createKekUrlPath)).
 		InScenario(kekResourceScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
 		WillSetStateTo(scenarioStateKekHasBeenCreated).
@@ -51,9 +72,19 @@ func TestAccKek(t *testing.T) {
 			string(createKekResponse),
 			contentTypeJSONHeader,
 			http.StatusCreated,
+		)
+	_ = initialClient.StubFor(createKekStub)
+
+	_ = initialClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(kekUrlPath)).
+		InScenario(kekResourceScenarioName).
+		WhenScenarioStateIs(scenarioStateKekHasBeenCreated).
+		WillReturn(
+			string(createKekResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
 		))
 
-	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(kekUrlPath)).
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(kekUrlPath)).
 		InScenario(kekResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateKekHasBeenCreated).
 		WillReturn(
@@ -63,7 +94,7 @@ func TestAccKek(t *testing.T) {
 		))
 
 	updateKekResponse, _ := ioutil.ReadFile("../testdata/schema_registry_kek/updated_kek.json")
-	_ = wiremockClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(kekUrlPath)).
+	_ = updatedClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(kekUrlPath)).
 		InScenario(kekResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateKekHasBeenCreated).
 		WillSetStateTo(scenarioStateKekHasBeenUpdated).
@@ -73,7 +104,7 @@ func TestAccKek(t *testing.T) {
 			http.StatusCreated,
 		))
 
-	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(kekUrlPath)).
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(kekUrlPath)).
 		InScenario(kekResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateKekHasBeenUpdated).
 		WillReturn(
@@ -82,13 +113,14 @@ func TestAccKek(t *testing.T) {
 			http.StatusOK,
 		))
 
-	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(kekUrlPath)).
+	deleteKekStub := wiremock.Delete(wiremock.URLPathEqualTo(kekUrlPath)).
 		InScenario(kekResourceScenarioName).
 		WillReturn(
 			"",
 			contentTypeJSONHeader,
 			http.StatusNoContent,
-		))
+		)
+	_ = updatedClient.StubFor(deleteKekStub)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -97,24 +129,26 @@ func TestAccKek(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: kekResourceConfig(mockServerUrl),
+				Config: kekResourceConfig(mockServerInitialUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(kekLabel, "id", "111/testkek"),
 					resource.TestCheckResourceAttr(kekLabel, "name", "testkek"),
 					resource.TestCheckResourceAttr(kekLabel, "kms_type", "aws-kms"),
 					resource.TestCheckResourceAttr(kekLabel, "kms_key_id", "kmsKeyId"),
+					resource.TestCheckResourceAttr(kekLabel, "rest_endpoint", mockServerInitialUrl),
 					resource.TestCheckResourceAttr(kekLabel, "shared", "false"),
 					resource.TestCheckResourceAttr(kekLabel, "hard_delete", "false"),
 					resource.TestCheckResourceAttr(kekLabel, "doc", ""),
 				),
 			},
 			{
-				Config: kekResourceUpdatedConfig(mockServerUrl),
+				Config: kekResourceUpdatedConfig(mockServerUpdatedUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(kekLabel, "id", "111/testkek"),
 					resource.TestCheckResourceAttr(kekLabel, "name", "testkek"),
 					resource.TestCheckResourceAttr(kekLabel, "kms_type", "aws-kms"),
 					resource.TestCheckResourceAttr(kekLabel, "kms_key_id", "kmsKeyId"),
+					resource.TestCheckResourceAttr(kekLabel, "rest_endpoint", mockServerUpdatedUrl),
 					resource.TestCheckResourceAttr(kekLabel, "shared", "false"),
 					resource.TestCheckResourceAttr(kekLabel, "hard_delete", "false"),
 					resource.TestCheckResourceAttr(kekLabel, "doc", "new description"),
@@ -122,17 +156,24 @@ func TestAccKek(t *testing.T) {
 			},
 		},
 	})
+
+	checkStubCount(t, initialClient, createKekStub, fmt.Sprintf("POST %s", createKekUrlPath), expectedCountOne)
+	checkStubCount(t, updatedClient, deleteKekStub, fmt.Sprintf("DELETE %s", kekUrlPath), expectedCountOne)
 }
 
 func kekResourceConfig(mockServerUrl string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
- 	  schema_registry_id = "111"
-	  schema_registry_rest_endpoint = "%s" # optionally use SCHEMA_REGISTRY_REST_ENDPOINT env var
-	  schema_registry_api_key       = "x"       # optionally use SCHEMA_REGISTRY_API_KEY env var
-	  schema_registry_api_secret = "x"
  	}
  	resource "confluent_schema_registry_kek" "mykek" {
+	  schema_registry_cluster {
+	    id = "111"
+	  }
+	  rest_endpoint = "%s"
+	  credentials {
+	    key    = "x"
+	    secret = "x"
+	  }
 	  name = "testkek"
 	  kms_type = "aws-kms"
 	  kms_key_id = "kmsKeyId"
@@ -145,12 +186,16 @@ func kekResourceConfig(mockServerUrl string) string {
 func kekResourceUpdatedConfig(mockServerUrl string) string {
 	return fmt.Sprintf(`
  	provider "confluent" {
- 	  schema_registry_id = "111"
-	  schema_registry_rest_endpoint = "%s" # optionally use SCHEMA_REGISTRY_REST_ENDPOINT env var
-	  schema_registry_api_key       = "x"       # optionally use SCHEMA_REGISTRY_API_KEY env var
-	  schema_registry_api_secret = "x"
  	}
  	resource "confluent_schema_registry_kek" "mykek" {
+	  schema_registry_cluster {
+	    id = "111"
+	  }
+	  rest_endpoint = "%s"
+	  credentials {
+	    key    = "x"
+	    secret = "x"
+	  }
 	  name = "testkek"
 	  kms_type = "aws-kms"
 	  kms_key_id = "kmsKeyId"

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -235,7 +235,7 @@ func tagDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 
 func tagUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	if d.HasChangesExcept(paramDescription, paramRestEndpoint) {
-		return diag.Errorf("error updating Tag %q: only %q attribute can be updated for Tag", d.Id(), paramDescription)
+		return diag.Errorf("error updating Tag %q: only %q and %q attributes can be updated for Tag", d.Id(), paramDescription, paramRestEndpoint)
 	}
 
 	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, false)

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -47,7 +47,6 @@ func tagResource() *schema.Resource {
 			paramRestEndpoint: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Description:  "The REST endpoint of the Schema Registry cluster, for example, `https://psrc-00000.us-central1.gcp.confluent.cloud:443`).",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^http"), "the REST endpoint must start with 'https://'"),
 			},
@@ -235,7 +234,7 @@ func tagDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 }
 
 func tagUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if d.HasChangeExcept(paramDescription) {
+	if d.HasChangesExcept(paramDescription, paramRestEndpoint) {
 		return diag.Errorf("error updating Tag %q: only %q attribute can be updated for Tag", d.Id(), paramDescription)
 	}
 

--- a/internal/provider/resource_tag_test.go
+++ b/internal/provider/resource_tag_test.go
@@ -29,22 +29,43 @@ import (
 func TestAccTag(t *testing.T) {
 	ctx := context.Background()
 
-	wiremockContainer, err := setupWiremock(ctx)
+	initialContainer, err := setupWiremock(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer wiremockContainer.Terminate(ctx)
+	defer initialContainer.Terminate(ctx)
 
-	mockServerUrl := wiremockContainer.URI
-	wiremockClient := wiremock.NewClient(mockServerUrl)
+	updatedContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer updatedContainer.Terminate(ctx)
+
+	mockServerInitialUrl := initialContainer.URI
+	mockServerUpdatedUrl := updatedContainer.URI
+	initialClient := wiremock.NewClient(mockServerInitialUrl)
+	updatedClient := wiremock.NewClient(mockServerUpdatedUrl)
 	// nolint:errcheck
-	defer wiremockClient.Reset()
+	defer initialClient.Reset()
+	defer updatedClient.Reset()
 
 	// nolint:errcheck
-	defer wiremockClient.ResetAllScenarios()
+	defer initialClient.ResetAllScenarios()
+	defer updatedClient.ResetAllScenarios()
+
+	// WireMock scenario state does not transfer between containers. When step 2 switches
+	// to mockServerUpdatedUrl, advance updatedClient from Started to TagHasBeenCreated so
+	// it can serve reads/updates without the resource being recreated.
+	dummyPath := "/state-sync"
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(dummyPath)).
+		InScenario(tagResourceScenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateTagHasBeenCreated).
+		WillReturn("OK", contentTypeJSONHeader, http.StatusOK))
+	http.Get(mockServerUpdatedUrl + dummyPath)
 
 	createTagResponse, _ := ioutil.ReadFile("../testdata/tag/create_tag.json")
-	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createTagUrlPath)).
+	createTagStub := wiremock.Post(wiremock.URLPathEqualTo(createTagUrlPath)).
 		InScenario(tagResourceScenarioName).
 		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
 		WillSetStateTo(scenarioStateTagHasBeenPending).
@@ -52,9 +73,10 @@ func TestAccTag(t *testing.T) {
 			string(createTagResponse),
 			contentTypeJSONHeader,
 			http.StatusCreated,
-		))
+		)
+	_ = initialClient.StubFor(createTagStub)
 
-	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
+	_ = initialClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
 		InScenario(tagResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateTagHasBeenPending).
 		WillSetStateTo(scenarioStateTagHasBeenCreated).
@@ -64,8 +86,27 @@ func TestAccTag(t *testing.T) {
 			http.StatusNotFound,
 		))
 
+	readTagResponse, _ := ioutil.ReadFile("../testdata/tag/read_tag.json")
+	_ = initialClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
+		InScenario(tagResourceScenarioName).
+		WhenScenarioStateIs(scenarioStateTagHasBeenCreated).
+		WillReturn(
+			string(readTagResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
+		InScenario(tagResourceScenarioName).
+		WhenScenarioStateIs(scenarioStateTagHasBeenCreated).
+		WillReturn(
+			string(readTagResponse),
+			contentTypeJSONHeader,
+			http.StatusOK,
+		))
+
 	updateTagResponse, _ := ioutil.ReadFile("../testdata/tag/update_tag.json")
-	_ = wiremockClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(createTagUrlPath)).
+	_ = updatedClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(createTagUrlPath)).
 		InScenario(tagResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateTagHasBeenCreated).
 		WillSetStateTo(scenarioStateTagHasBeenUpdated).
@@ -75,18 +116,8 @@ func TestAccTag(t *testing.T) {
 			http.StatusCreated,
 		))
 
-	readTagResponse, _ := ioutil.ReadFile("../testdata/tag/read_tag.json")
-	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
-		InScenario(tagResourceScenarioName).
-		WhenScenarioStateIs(scenarioStateTagHasBeenCreated).
-		WillReturn(
-			string(readTagResponse),
-			contentTypeJSONHeader,
-			http.StatusOK,
-		))
-
 	readUpdatedTagResponse, _ := ioutil.ReadFile("../testdata/tag/read_updated_tag.json")
-	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
+	_ = updatedClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
 		InScenario(tagResourceScenarioName).
 		WhenScenarioStateIs(scenarioStateTagHasBeenUpdated).
 		WillReturn(
@@ -95,18 +126,19 @@ func TestAccTag(t *testing.T) {
 			http.StatusOK,
 		))
 
-	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
+	deleteTagStub := wiremock.Delete(wiremock.URLPathEqualTo(readCreatedTagUrlPath)).
 		InScenario(tagResourceScenarioName).
 		WillReturn(
 			"",
 			contentTypeJSONHeader,
 			http.StatusNoContent,
-		))
+		)
+	_ = updatedClient.StubFor(deleteTagStub)
 
 	// Set fake values for secrets since those are required for importing
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_KEY", testSchemaRegistryUpdatedKey)
 	_ = os.Setenv("IMPORT_SCHEMA_REGISTRY_API_SECRET", testSchemaRegistryUpdatedSecret)
-	_ = os.Setenv("IMPORT_CATALOG_REST_ENDPOINT", mockServerUrl)
+	_ = os.Setenv("IMPORT_CATALOG_REST_ENDPOINT", mockServerUpdatedUrl)
 
 	defer func() {
 		_ = os.Unsetenv("IMPORT_SCHEMA_REGISTRY_API_KEY")
@@ -121,13 +153,13 @@ func TestAccTag(t *testing.T) {
 		// https://www.terraform.io/docs/extend/best-practices/testing.html#built-in-patterns
 		Steps: []resource.TestStep{
 			{
-				Config: tagResourceConfig(mockServerUrl),
+				Config: tagResourceConfig(mockServerInitialUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tagLabel, "id", fmt.Sprintf("%s/test1", testStreamGovernanceClusterId)),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.#", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.0.%", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.0.id", testStreamGovernanceClusterId),
-					resource.TestCheckResourceAttr(tagLabel, "rest_endpoint", mockServerUrl),
+					resource.TestCheckResourceAttr(tagLabel, "rest_endpoint", mockServerInitialUrl),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.#", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.0.%", "2"),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.0.key", testSchemaRegistryKey),
@@ -140,13 +172,13 @@ func TestAccTag(t *testing.T) {
 				),
 			},
 			{
-				Config: tagResourceUpdatedConfig(mockServerUrl),
+				Config: tagResourceUpdatedConfig(mockServerUpdatedUrl),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(tagLabel, "id", fmt.Sprintf("%s/test1", testStreamGovernanceClusterId)),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.#", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.0.%", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "schema_registry_cluster.0.id", testStreamGovernanceClusterId),
-					resource.TestCheckResourceAttr(tagLabel, "rest_endpoint", mockServerUrl),
+					resource.TestCheckResourceAttr(tagLabel, "rest_endpoint", mockServerUpdatedUrl),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.#", "1"),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.0.%", "2"),
 					resource.TestCheckResourceAttr(tagLabel, "credentials.0.key", testSchemaRegistryKey),
@@ -160,6 +192,9 @@ func TestAccTag(t *testing.T) {
 			},
 		},
 	})
+
+	checkStubCount(t, initialClient, createTagStub, fmt.Sprintf("POST %s", createTagUrlPath), expectedCountOne)
+	checkStubCount(t, updatedClient, deleteTagStub, fmt.Sprintf("DELETE %s", readCreatedTagUrlPath), expectedCountOne)
 }
 
 func tagResourceConfig(mockServerUrl string) string {


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- `confluent_tag` and `confluent_schema_registry_kek` no longer destroy and recreate the resource when only the resource-level `rest_endpoint` attribute changes. The endpoint is the Schema Registry API access URL, not part of the resource's identity (which is `schema_registry_cluster.id` + name), so endpoint changes (region migration, DNS rename, PrivateLink endpoint switch, etc.) now update in place.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
  - This change only removes `ForceNew` from the `rest_endpoint` schema attribute and extends the existing update-guard allow-list. The end-to-end CRUD paths against real Confluent Cloud were not exercised; behavior is covered by the WireMock-based acceptance tests below. Happy to run a manual pre-prod pass against a real Schema Registry if a reviewer wants screenshots before merge.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
  - `TestAccTag` and `TestAccKek` were both rewritten to mirror the two-container WireMock pattern from `resource_kafka_topic_test.go` so that step 2 switches `rest_endpoint` to a different mock server and verifies the resource is updated in place (POST = 1 on the initial container, DELETE = 1 on the updated container — no recreate). See Test & Review for the run output.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
  - Deliberately skipped: the reference resource `confluent_kafka_topic` does not exercise `rest_endpoint` changes in its live test either (`testAccCheckKafkaTopicLiveConfig` / `testAccCheckKafkaTopicUpdateLiveConfig` use the same `kafkaRestEndpoint`). Keeping the tag and KEK live tests consistent with that precedent.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
  - Not applicable — this PR does not introduce new API calls or change request rates. The update path is the same PUT call that already existed.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
  - Removing `ForceNew` and widening the update allow-list strictly relaxes existing behavior. Configurations that don't change `rest_endpoint` plan and apply identically; configurations that do change it stop force-recreating, which is the desired fix.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
  - The published docs for both resources describe `rest_endpoint` as `(Optional String)` with no language about recreation behavior, so no doc edit is required.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only
  - Not applicable — no feature flag gates this change.

What
----
Two resources had `ForceNew: true` set on the `rest_endpoint` schema attribute:

- `internal/provider/resource_tag.go` (schema line 50, update guard line 238)
- `internal/provider/resource_schema_registry_kek.go` (schema line 48, update guard line 259)

That caused Terraform to plan a destroy+create for the entire tag/KEK whenever the user changed the Schema Registry endpoint URL — even though the resource's identity is captured by the separate `schema_registry_cluster` block (which legitimately has `ForceNew`). The `rest_endpoint` is purely the API access point, so an endpoint URL change should not destroy server-side state.

Fix has two parts in each file (mirrors what `confluent_kafka_topic` already does):

1. Drop `ForceNew: true` from the `paramRestEndpoint` schema definition.
2. Add `paramRestEndpoint` to the `HasChange(s)Except(...)` allow-list at the top of the update function, so a pure `rest_endpoint` change does not error out the update path.

Acceptance tests for both resources were rewritten to mirror the two-WireMock-container pattern in `resource_kafka_topic_test.go`: step 1 creates the resource against the initial container, step 2 switches `rest_endpoint` to the updated container, and `checkStubCount` asserts the create stub was hit exactly once on the initial container and the delete stub exactly once on the updated container — proving the resource was updated in place, not recreated. For the KEK test this also required moving `rest_endpoint` / `credentials` / `schema_registry_cluster` from the provider block onto the resource so the new behavior is actually exercised.

Blast Radius
----
Small and contained:

- Customers using `confluent_tag` or `confluent_schema_registry_kek` who change `rest_endpoint` previously had their resource destroyed and recreated, which may be surprising or destructive (e.g., loses tag bindings on the old tag). After this fix they get an in-place update against the new endpoint. This is strictly safer.
- Customers who never change `rest_endpoint` see no behavioral change at all — `terraform plan` is identical.
- If something does go wrong (e.g., the new endpoint is wrong), the update PUT against the new endpoint fails and Terraform reports the error on apply; no state is lost. The resource is recoverable by correcting the endpoint and re-applying.
- No new code paths are added; the update flow that was already covered for `description` (tag) and `doc`/`shared`/`properties` (KEK) is the same path now reached for endpoint-only diffs.

References
----------
- [APIE-1075](https://confluentinc.atlassian.net/browse/APIE-1075)
- Prior art / same change on another resource: [#834 — INC-5291: Support in-place update for the `rest_endpoint` attribute of the `confluent_kafka_topic` resource](https://github.com/confluentinc/terraform-provider-confluent/pull/834). This PR applies the identical fix (drop `ForceNew`, extend the update allow-list, two-container WireMock test) to `confluent_tag` and `confluent_schema_registry_kek`.
- Reference pattern: `internal/provider/resource_kafka_topic.go` already follows this exact shape (no `ForceNew` on `rest_endpoint`; `paramRestEndpoint` in the update allow-list; two-container WireMock test).

Test & Review
-------------
* updated acceptance tests (Docker + WireMock via testcontainers-go):

```
$ TF_ACC=1 go test -v -run '^TestAccTag$|^TestAccKek$' -count=1 -timeout 600s ./internal/provider/...
=== RUN   TestAccKek
--- PASS: TestAccKek (7.06s)
=== RUN   TestAccTag
--- PASS: TestAccTag (7.69s)
PASS
ok    github.com/confluentinc/terraform-provider-confluent/internal/provider  15.382s
```

What the new tests actually prove:

1. `TestAccTag` boots two WireMock containers. Step 1 applies the tag against the initial container (POST → 201). Step 2 changes `rest_endpoint` to the updated container's URL *and* changes `description`. WireMock stubs on the updated container only serve the update + read paths; the initial-container create stub is asserted to have been hit exactly once (`checkStubCount`) — if Terraform had recreated the resource, the initial-container create stub would have fired again on the new endpoint and the assertion would fail.
2. `TestAccKek` follows the same shape. The test config was also migrated from provider-block `schema_registry_rest_endpoint` to resource-level `rest_endpoint` + `credentials` + `schema_registry_cluster`, so the new in-place update path is exercised end-to-end.
3. The two stub counts (`POST = 1` on initial, `DELETE = 1` on updated) together establish that exactly one resource lifecycle occurred across the two endpoints — confirming no recreate.

* Manual testing (Flask mock server): see [this Slack thread](https://confluent.slack.com/archives/C02TG07V058/p1758596751790699) for the setup and steps used to verify the in-place `rest_endpoint` update against a Flask mock server.



[APIE-1075]: https://confluentinc.atlassian.net/browse/APIE-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ