### PR TITLE
[APIE-1080] Fix TF rtce live test + refactor hardcoded string literals into shared constants

### DIFF
--- a/internal/provider/constants_live_test.go
+++ b/internal/provider/constants_live_test.go
@@ -1,0 +1,22 @@
+//go:build live_test
+
+// Copyright 2024 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+const (
+	liveTestOrganizationId = "424fb7bf-40c2-433f-81a5-c45942a6a539"
+	liveTestEnvironmentId  = "env-zyg27z"
+)

--- a/internal/provider/data_source_cluster_link_live_test.go
+++ b/internal/provider/data_source_cluster_link_live_test.go
@@ -113,7 +113,7 @@ func testAccCheckClusterLinkDataSourceLiveConfig(endpoint, clusterLinkResourceLa
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 

--- a/internal/provider/data_source_cluster_link_live_test.go
+++ b/internal/provider/data_source_cluster_link_live_test.go
@@ -113,7 +113,7 @@ func testAccCheckClusterLinkDataSourceLiveConfig(endpoint, clusterLinkResourceLa
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
 
@@ -150,5 +150,5 @@ func testAccCheckClusterLinkDataSourceLiveConfig(endpoint, clusterLinkResourceLa
 			secret = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, standardClusterId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret, clusterLinkDataSourceLabel, clusterLinkResourceLabel, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
+	`, endpoint, apiKey, apiSecret, standardClusterId, liveTestEnvironmentId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret, clusterLinkDataSourceLabel, clusterLinkResourceLabel, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
 }

--- a/internal/provider/data_source_kafka_cluster_live_test.go
+++ b/internal/provider/data_source_kafka_cluster_live_test.go
@@ -64,7 +64,7 @@ func TestAccKafkaClusterDataSourceLive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Check the data source can find the cluster
 					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "id", kafkaClusterId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "display_name"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "availability"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_kafka_cluster.%s", kafkaClusterDataSourceLabel), "cloud"),
@@ -89,7 +89,7 @@ func testAccCheckKafkaClusterDataSourceLiveConfig(endpoint, kafkaClusterDataSour
 	data "confluent_kafka_cluster" "%s" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 	`, endpoint, apiKey, apiSecret, kafkaClusterDataSourceLabel, kafkaClusterId)

--- a/internal/provider/data_source_kafka_cluster_live_test.go
+++ b/internal/provider/data_source_kafka_cluster_live_test.go
@@ -89,8 +89,8 @@ func testAccCheckKafkaClusterDataSourceLiveConfig(endpoint, kafkaClusterDataSour
 	data "confluent_kafka_cluster" "%s" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, kafkaClusterDataSourceLabel, kafkaClusterId)
+	`, endpoint, apiKey, apiSecret, kafkaClusterDataSourceLabel, kafkaClusterId, liveTestEnvironmentId)
 }

--- a/internal/provider/data_source_kafka_clusters_live_test.go
+++ b/internal/provider/data_source_kafka_clusters_live_test.go
@@ -83,7 +83,7 @@ func testAccCheckKafkaClustersDataSourceLiveConfig(endpoint, kafkaClustersDataSo
 
 	data "confluent_kafka_clusters" "%s" {
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 	`, endpoint, apiKey, apiSecret, kafkaClustersDataSourceLabel)

--- a/internal/provider/data_source_kafka_clusters_live_test.go
+++ b/internal/provider/data_source_kafka_clusters_live_test.go
@@ -83,10 +83,10 @@ func testAccCheckKafkaClustersDataSourceLiveConfig(endpoint, kafkaClustersDataSo
 
 	data "confluent_kafka_clusters" "%s" {
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, kafkaClustersDataSourceLabel)
+	`, endpoint, apiKey, apiSecret, kafkaClustersDataSourceLabel, liveTestEnvironmentId)
 }
 
 // testAccCheckKafkaClustersCountAtLeast verifies that at least minCount clusters exist

--- a/internal/provider/data_source_ksql_cluster_live_test.go
+++ b/internal/provider/data_source_ksql_cluster_live_test.go
@@ -74,7 +74,7 @@ func TestAccKsqlClusterDataSourceLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "display_name", ksqlClusterDisplayName),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "4"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", liveTestEnvironmentId),
 
 					// Check the data source can find it
 					resource.TestCheckResourceAttrPair(
@@ -117,7 +117,7 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 			id = confluent_service_account.live_ksql_sa.id
 		}
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		depends_on = [
 			confluent_role_binding.live_ksql_sa_rb
@@ -132,13 +132,13 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 	resource "confluent_role_binding" "live_ksql_sa_rb" {
 		principal   = "User:${confluent_service_account.live_ksql_sa.id}"
 		role_name   = "CloudClusterAdmin"
-		crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539/environment=env-zyg27z/cloud-cluster=%s"
+		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=`+liveTestEnvironmentId+`/cloud-cluster=%s"
 	}
 
 	data "confluent_ksql_cluster" "%s" {
 		id = confluent_ksql_cluster.%s.id
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 	`, endpoint, apiKey, apiSecret, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDataSourceLabel, ksqlClusterResourceLabel)

--- a/internal/provider/data_source_ksql_cluster_live_test.go
+++ b/internal/provider/data_source_ksql_cluster_live_test.go
@@ -117,7 +117,7 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 			id = confluent_service_account.live_ksql_sa.id
 		}
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		depends_on = [
 			confluent_role_binding.live_ksql_sa_rb
@@ -132,14 +132,14 @@ func testAccCheckKsqlClusterDataSourceLiveConfig(endpoint, ksqlClusterResourceLa
 	resource "confluent_role_binding" "live_ksql_sa_rb" {
 		principal   = "User:${confluent_service_account.live_ksql_sa.id}"
 		role_name   = "CloudClusterAdmin"
-		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=`+liveTestEnvironmentId+`/cloud-cluster=%s"
+		crn_pattern = "crn://confluent.cloud/organization=%s/environment=%s/cloud-cluster=%s"
 	}
 
 	data "confluent_ksql_cluster" "%s" {
 		id = confluent_ksql_cluster.%s.id
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterDataSourceLabel, ksqlClusterResourceLabel)
+	`, endpoint, apiKey, apiSecret, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId, liveTestEnvironmentId, ksqlClusterDisplayName, liveTestOrganizationId, liveTestEnvironmentId, kafkaClusterId, ksqlClusterDataSourceLabel, ksqlClusterResourceLabel, liveTestEnvironmentId)
 }

--- a/internal/provider/data_source_provider_integration_setup_live_test.go
+++ b/internal/provider/data_source_provider_integration_setup_live_test.go
@@ -38,7 +38,7 @@ func TestAccProviderIntegrationSetupAzureDataSourceLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := "env-zyg27z" // Hardcoded test environment
+	environmentId := liveTestEnvironmentId // Hardcoded test environment
 	azureTenantId := os.Getenv("AZURE_TENANT_ID")
 
 	// Validate required environment variables are present
@@ -109,7 +109,7 @@ func TestAccProviderIntegrationSetupGcpDataSourceLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := "env-zyg27z"                                                                            // Hardcoded test environment
+	environmentId := liveTestEnvironmentId                                                                   // Hardcoded test environment
 	gcpServiceAccount := fmt.Sprintf("test-sa-%d@test-project-123456.iam.gserviceaccount.com", randomSuffix) // Unique test service account
 
 	// Validate required environment variables are present

--- a/internal/provider/data_source_provider_integration_setup_live_test.go
+++ b/internal/provider/data_source_provider_integration_setup_live_test.go
@@ -38,7 +38,7 @@ func TestAccProviderIntegrationSetupAzureDataSourceLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := liveTestEnvironmentId // Hardcoded test environment
+	environmentId := liveTestEnvironmentId
 	azureTenantId := os.Getenv("AZURE_TENANT_ID")
 
 	// Validate required environment variables are present
@@ -109,7 +109,7 @@ func TestAccProviderIntegrationSetupGcpDataSourceLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := liveTestEnvironmentId                                                                   // Hardcoded test environment
+	environmentId := liveTestEnvironmentId
 	gcpServiceAccount := fmt.Sprintf("test-sa-%d@test-project-123456.iam.gserviceaccount.com", randomSuffix) // Unique test service account
 
 	// Validate required environment variables are present

--- a/internal/provider/data_source_role_binding_live_test.go
+++ b/internal/provider/data_source_role_binding_live_test.go
@@ -68,7 +68,7 @@ func TestAccRoleBindingDataSourceLive(t *testing.T) {
 					// Check the role binding was created
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "id"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "role_name", "MetricsViewer"),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "crn_pattern", "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "crn_pattern", "crn://confluent.cloud/organization="+liveTestOrganizationId),
 
 					// Check the data source can find it
 					resource.TestCheckResourceAttrPair(
@@ -109,7 +109,7 @@ func testAccCheckRoleBindingDataSourceLiveConfig(endpoint, serviceAccountResourc
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"
+		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
 	}
 
 	data "confluent_role_binding" "%s" {

--- a/internal/provider/data_source_role_binding_live_test.go
+++ b/internal/provider/data_source_role_binding_live_test.go
@@ -109,11 +109,11 @@ func testAccCheckRoleBindingDataSourceLiveConfig(endpoint, serviceAccountResourc
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
+		crn_pattern = "crn://confluent.cloud/organization=%s"
 	}
 
 	data "confluent_role_binding" "%s" {
 		id = confluent_role_binding.%s.id
 	}
-	`, endpoint, apiKey, apiSecret, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, roleBindingDataSourceLabel, roleBindingResourceLabel)
+	`, endpoint, apiKey, apiSecret, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, liveTestOrganizationId, roleBindingDataSourceLabel, roleBindingResourceLabel)
 }

--- a/internal/provider/data_source_schema_registry_cluster_live_test.go
+++ b/internal/provider/data_source_schema_registry_cluster_live_test.go
@@ -87,8 +87,8 @@ func testAccCheckSchemaRegistryClusterDataSourceLiveConfig(endpoint, schemaRegis
 	data "confluent_schema_registry_cluster" "%s" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, schemaRegistryDataSourceLabel, schemaRegistryId)
+	`, endpoint, apiKey, apiSecret, schemaRegistryDataSourceLabel, schemaRegistryId, liveTestEnvironmentId)
 }

--- a/internal/provider/data_source_schema_registry_cluster_live_test.go
+++ b/internal/provider/data_source_schema_registry_cluster_live_test.go
@@ -64,7 +64,7 @@ func TestAccSchemaRegistryClusterDataSourceLive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Check the data source can find the cluster
 					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "id", schemaRegistryId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "display_name"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "cloud"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("data.confluent_schema_registry_cluster.%s", schemaRegistryDataSourceLabel), "region"),
@@ -87,7 +87,7 @@ func testAccCheckSchemaRegistryClusterDataSourceLiveConfig(endpoint, schemaRegis
 	data "confluent_schema_registry_cluster" "%s" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 	`, endpoint, apiKey, apiSecret, schemaRegistryDataSourceLabel, schemaRegistryId)

--- a/internal/provider/resource_cluster_link_live_test.go
+++ b/internal/provider/resource_cluster_link_live_test.go
@@ -213,7 +213,7 @@ func testAccCheckClusterLinkLiveConfig(endpoint, clusterLinkResourceLabel, linkN
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 
@@ -252,7 +252,7 @@ func testAccCheckClusterLinkUpdateLiveConfig(endpoint, clusterLinkResourceLabel,
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 

--- a/internal/provider/resource_cluster_link_live_test.go
+++ b/internal/provider/resource_cluster_link_live_test.go
@@ -213,7 +213,7 @@ func testAccCheckClusterLinkLiveConfig(endpoint, clusterLinkResourceLabel, linkN
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
 
@@ -237,7 +237,7 @@ func testAccCheckClusterLinkLiveConfig(endpoint, clusterLinkResourceLabel, linkN
 			}
 		}
 	}
-	`, endpoint, apiKey, apiSecret, standardClusterId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
+	`, endpoint, apiKey, apiSecret, standardClusterId, liveTestEnvironmentId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
 }
 
 func testAccCheckClusterLinkUpdateLiveConfig(endpoint, clusterLinkResourceLabel, linkName, standardClusterId, dedicatedClusterId, dedicatedRestEndpoint, apiKey, apiSecret, standardApiKey, standardApiSecret, dedicatedApiKey, dedicatedApiSecret string) string {
@@ -252,7 +252,7 @@ func testAccCheckClusterLinkUpdateLiveConfig(endpoint, clusterLinkResourceLabel,
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
 
@@ -279,5 +279,5 @@ func testAccCheckClusterLinkUpdateLiveConfig(endpoint, clusterLinkResourceLabel,
 			"acl.sync.ms" = "5100"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, standardClusterId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
+	`, endpoint, apiKey, apiSecret, standardClusterId, liveTestEnvironmentId, clusterLinkResourceLabel, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
 }

--- a/internal/provider/resource_connect_artifact_live_test.go
+++ b/internal/provider/resource_connect_artifact_live_test.go
@@ -66,7 +66,7 @@ func TestAccConnectArtifactAWSLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "cloud", "aws"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "content_format", "JAR"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "description", "A test connect artifact for live testing"),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "id"),
 				),
 			},
@@ -127,7 +127,7 @@ func TestAccConnectArtifactAzureLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "cloud", "azure"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "content_format", "JAR"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "description", "A test connect artifact for live testing"),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "id"),
 				),
 			},
@@ -188,7 +188,7 @@ func TestAccConnectArtifactGCPLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "cloud", "gcp"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "content_format", "JAR"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "description", "A test connect artifact for live testing"),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_connect_artifact.%s", artifactResourceLabel), "id"),
 				),
 			},
@@ -256,7 +256,7 @@ func testAccCheckConnectArtifactLiveConfig(endpoint, artifactResourceLabel, arti
 		artifact_file  = "test_artifacts/connect_artifact.jar"
 
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 	`, endpoint, apiKey, apiSecret, artifactResourceLabel, artifactDisplayName, cloud)

--- a/internal/provider/resource_connect_artifact_live_test.go
+++ b/internal/provider/resource_connect_artifact_live_test.go
@@ -256,8 +256,8 @@ func testAccCheckConnectArtifactLiveConfig(endpoint, artifactResourceLabel, arti
 		artifact_file  = "test_artifacts/connect_artifact.jar"
 
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
-	`, endpoint, apiKey, apiSecret, artifactResourceLabel, artifactDisplayName, cloud)
+	`, endpoint, apiKey, apiSecret, artifactResourceLabel, artifactDisplayName, cloud, liveTestEnvironmentId)
 }

--- a/internal/provider/resource_connector_live_test.go
+++ b/internal/provider/resource_connector_live_test.go
@@ -218,7 +218,7 @@ func testAccCheckConnectorLiveConfigWithoutOffsets(endpoint, connectorResourceLa
 
 	resource "confluent_connector" "%s" {
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		kafka_cluster {
 			id = "%s"
@@ -240,7 +240,7 @@ func testAccCheckConnectorLiveConfigWithoutOffsets(endpoint, connectorResourceLa
 
 		depends_on = [confluent_kafka_topic.connector_topic]
 	}
-	`, endpoint, apiKey, apiSecret, kafkaClusterId, topicName, kafkaRestEndpoint, kafkaApiKey, kafkaApiSecret, connectorResourceLabel, kafkaClusterId, connectorName, kafkaApiKey, kafkaApiSecret)
+	`, endpoint, apiKey, apiSecret, kafkaClusterId, topicName, kafkaRestEndpoint, kafkaApiKey, kafkaApiSecret, connectorResourceLabel, liveTestEnvironmentId, kafkaClusterId, connectorName, kafkaApiKey, kafkaApiSecret)
 }
 
 func testAccCheckConnectorUpdateLiveConfigWithoutOffsets(endpoint, connectorResourceLabel, connectorName, topicName, kafkaClusterId, kafkaRestEndpoint, apiKey, apiSecret, kafkaApiKey, kafkaApiSecret string) string {
@@ -267,7 +267,7 @@ func testAccCheckConnectorUpdateLiveConfigWithoutOffsets(endpoint, connectorReso
 
 	resource "confluent_connector" "%s" {
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		kafka_cluster {
 			id = "%s"
@@ -289,5 +289,5 @@ func testAccCheckConnectorUpdateLiveConfigWithoutOffsets(endpoint, connectorReso
 
 		depends_on = [confluent_kafka_topic.connector_topic]
 	}
-	`, endpoint, apiKey, apiSecret, kafkaClusterId, topicName, kafkaRestEndpoint, kafkaApiKey, kafkaApiSecret, connectorResourceLabel, kafkaClusterId, connectorName, kafkaApiKey, kafkaApiSecret)
+	`, endpoint, apiKey, apiSecret, kafkaClusterId, topicName, kafkaRestEndpoint, kafkaApiKey, kafkaApiSecret, connectorResourceLabel, liveTestEnvironmentId, kafkaClusterId, connectorName, kafkaApiKey, kafkaApiSecret)
 }

--- a/internal/provider/resource_connector_live_test.go
+++ b/internal/provider/resource_connector_live_test.go
@@ -79,7 +79,7 @@ func TestAccConnectorLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "config_nonsensitive.max.interval", "1000"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "config_nonsensitive.tasks.max", "1"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "id"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_connector.%s", connectorResourceLabel), "status"),
 				),
@@ -218,7 +218,7 @@ func testAccCheckConnectorLiveConfigWithoutOffsets(endpoint, connectorResourceLa
 
 	resource "confluent_connector" "%s" {
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		kafka_cluster {
 			id = "%s"
@@ -267,7 +267,7 @@ func testAccCheckConnectorUpdateLiveConfigWithoutOffsets(endpoint, connectorReso
 
 	resource "confluent_connector" "%s" {
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		kafka_cluster {
 			id = "%s"

--- a/internal/provider/resource_flink_compute_pool_live_test.go
+++ b/internal/provider/resource_flink_compute_pool_live_test.go
@@ -45,7 +45,7 @@ func TestAccFlinkComputePoolAWSLive(t *testing.T) {
 		endpoint = "https://api.confluent.cloud"
 	}
 
-	environmentId := "env-zyg27z"
+	environmentId := liveTestEnvironmentId
 
 	// Validate required environment variables are present
 	if apiKey == "" || apiSecret == "" {

--- a/internal/provider/resource_flink_materialized_table_live_test.go
+++ b/internal/provider/resource_flink_materialized_table_live_test.go
@@ -30,8 +30,8 @@ import (
 // Shared infra the live tests target (also hardcoded in the existing live
 // tests for ksql, role_binding, etc.).
 const (
-	flinkMaterializedTableLiveOrganizationId = "424fb7bf-40c2-433f-81a5-c45942a6a539"
-	flinkMaterializedTableLiveEnvironmentId  = "env-zyg27z"
+	flinkMaterializedTableLiveOrganizationId = liveTestOrganizationId
+	flinkMaterializedTableLiveEnvironmentId  = liveTestEnvironmentId
 )
 
 // The Flink compute pool created by the test must live in the same AWS region

--- a/internal/provider/resource_kafka_client_quota_live_test.go
+++ b/internal/provider/resource_kafka_client_quota_live_test.go
@@ -72,7 +72,7 @@ func TestAccKafkaClientQuotaLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "display_name", quotaDisplayName),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "description", "A test client quota for live testing"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "throughput.0.ingress_byte_rate", "1048576"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "throughput.0.egress_byte_rate", "2097152"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_client_quota.%s", quotaResourceLabel), "principals.#", "1"),
@@ -195,7 +195,7 @@ func testAccCheckKafkaClientQuotaLiveConfig(endpoint, quotaResourceLabel, quotaD
 			id = "%s"
 		}
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		throughput {
 			ingress_byte_rate = "1048576"  # 1 MB/s
@@ -226,7 +226,7 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigWithSA(endpoint, quotaResourceL
 			id = "%s"
 		}
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		throughput {
 			ingress_byte_rate = "1048576"  # 1 MB/s
@@ -257,7 +257,7 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigUpdated(endpoint, quotaResource
 			id = "%s"
 		}
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		throughput {
 			ingress_byte_rate = "2097152"  # 2 MB/s

--- a/internal/provider/resource_kafka_client_quota_live_test.go
+++ b/internal/provider/resource_kafka_client_quota_live_test.go
@@ -195,7 +195,7 @@ func testAccCheckKafkaClientQuotaLiveConfig(endpoint, quotaResourceLabel, quotaD
 			id = "%s"
 		}
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		throughput {
 			ingress_byte_rate = "1048576"  # 1 MB/s
@@ -203,7 +203,7 @@ func testAccCheckKafkaClientQuotaLiveConfig(endpoint, quotaResourceLabel, quotaD
 		}
 		principals = ["<default>"]
 	}
-	`, endpoint, apiKey, apiSecret, quotaResourceLabel, quotaDisplayName, kafkaClusterId)
+	`, endpoint, apiKey, apiSecret, quotaResourceLabel, quotaDisplayName, kafkaClusterId, liveTestEnvironmentId)
 }
 
 func testAccCheckKafkaClientQuotaUpdateLiveConfigWithSA(endpoint, quotaResourceLabel, quotaDisplayName, kafkaClusterId, apiKey, apiSecret string) string {
@@ -226,7 +226,7 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigWithSA(endpoint, quotaResourceL
 			id = "%s"
 		}
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		throughput {
 			ingress_byte_rate = "1048576"  # 1 MB/s
@@ -234,7 +234,7 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigWithSA(endpoint, quotaResourceL
 		}
 		principals = [confluent_service_account.quota_test_sa.id]
 	}
-	`, endpoint, apiKey, apiSecret, quotaDisplayName, quotaResourceLabel, quotaDisplayName, kafkaClusterId)
+	`, endpoint, apiKey, apiSecret, quotaDisplayName, quotaResourceLabel, quotaDisplayName, kafkaClusterId, liveTestEnvironmentId)
 }
 
 func testAccCheckKafkaClientQuotaUpdateLiveConfigUpdated(endpoint, quotaResourceLabel, quotaDisplayName, kafkaClusterId, apiKey, apiSecret string) string {
@@ -257,7 +257,7 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigUpdated(endpoint, quotaResource
 			id = "%s"
 		}
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		throughput {
 			ingress_byte_rate = "2097152"  # 2 MB/s
@@ -265,5 +265,5 @@ func testAccCheckKafkaClientQuotaUpdateLiveConfigUpdated(endpoint, quotaResource
 		}
 		principals = [confluent_service_account.quota_test_sa.id]
 	}
-	`, endpoint, apiKey, apiSecret, quotaDisplayName, quotaResourceLabel, quotaDisplayName, kafkaClusterId)
+	`, endpoint, apiKey, apiSecret, quotaDisplayName, quotaResourceLabel, quotaDisplayName, kafkaClusterId, liveTestEnvironmentId)
 }

--- a/internal/provider/resource_kafka_mirror_topic_live_test.go
+++ b/internal/provider/resource_kafka_mirror_topic_live_test.go
@@ -138,7 +138,7 @@ func testAccCheckKafkaMirrorTopicLiveConfig(endpoint, mirrorTopicResourceLabel, 
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 	}
 
@@ -198,5 +198,5 @@ func testAccCheckKafkaMirrorTopicLiveConfig(endpoint, mirrorTopicResourceLabel, 
 			}
 		}
 	}
-	`, endpoint, apiKey, apiSecret, standardClusterId, standardClusterId, sourceTopic, standardRestEndpoint, standardApiKey, standardApiSecret, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret, mirrorTopicResourceLabel, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
+	`, endpoint, apiKey, apiSecret, standardClusterId, liveTestEnvironmentId, standardClusterId, sourceTopic, standardRestEndpoint, standardApiKey, standardApiSecret, linkName, standardClusterId, standardApiKey, standardApiSecret, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret, mirrorTopicResourceLabel, dedicatedClusterId, dedicatedRestEndpoint, dedicatedApiKey, dedicatedApiSecret)
 }

--- a/internal/provider/resource_kafka_mirror_topic_live_test.go
+++ b/internal/provider/resource_kafka_mirror_topic_live_test.go
@@ -138,7 +138,7 @@ func testAccCheckKafkaMirrorTopicLiveConfig(endpoint, mirrorTopicResourceLabel, 
 	data "confluent_kafka_cluster" "standard_cluster" {
 		id = "%s"
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 	}
 

--- a/internal/provider/resource_ksql_cluster_live_test.go
+++ b/internal/provider/resource_ksql_cluster_live_test.go
@@ -142,7 +142,7 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 	resource "confluent_role_binding" "live_ksql_sa_rb" {
 		principal   = "User:${confluent_service_account.live_ksql_sa.id}"
 		role_name   = "CloudClusterAdmin"
-		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=`+liveTestEnvironmentId+`/cloud-cluster=%s"
+		crn_pattern = "crn://confluent.cloud/organization=%s/environment=%s/cloud-cluster=%s"
 	}
 
 	resource "confluent_ksql_cluster" "%s" {
@@ -155,11 +155,11 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 			id = confluent_service_account.live_ksql_sa.id
 		}
 		environment {
-			id = "`+liveTestEnvironmentId+`"
+			id = "%s"
 		}
 		depends_on = [
 			confluent_role_binding.live_ksql_sa_rb
 		]
 	}
-	`, endpoint, apiKey, apiSecret, ksqlClusterDisplayName, kafkaClusterId, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId)
+	`, endpoint, apiKey, apiSecret, ksqlClusterDisplayName, liveTestOrganizationId, liveTestEnvironmentId, kafkaClusterId, ksqlClusterResourceLabel, ksqlClusterDisplayName, kafkaClusterId, liveTestEnvironmentId)
 }

--- a/internal/provider/resource_ksql_cluster_live_test.go
+++ b/internal/provider/resource_ksql_cluster_live_test.go
@@ -73,7 +73,7 @@ func TestAccKsqlClusterLive(t *testing.T) {
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "csu", "4"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "use_detailed_processing_log", "true"),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "kafka_cluster.0.id", kafkaClusterId),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", "env-zyg27z"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "environment.0.id", liveTestEnvironmentId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "id"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "rest_endpoint"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_ksql_cluster.%s", ksqlClusterResourceLabel), "topic_prefix"),
@@ -142,7 +142,7 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 	resource "confluent_role_binding" "live_ksql_sa_rb" {
 		principal   = "User:${confluent_service_account.live_ksql_sa.id}"
 		role_name   = "CloudClusterAdmin"
-		crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539/environment=env-zyg27z/cloud-cluster=%s"
+		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=`+liveTestEnvironmentId+`/cloud-cluster=%s"
 	}
 
 	resource "confluent_ksql_cluster" "%s" {
@@ -155,7 +155,7 @@ func testAccCheckKsqlClusterLiveConfig(endpoint, ksqlClusterResourceLabel, ksqlC
 			id = confluent_service_account.live_ksql_sa.id
 		}
 		environment {
-			id = "env-zyg27z"
+			id = "`+liveTestEnvironmentId+`"
 		}
 		depends_on = [
 			confluent_role_binding.live_ksql_sa_rb

--- a/internal/provider/resource_provider_integration_setup_live_test.go
+++ b/internal/provider/resource_provider_integration_setup_live_test.go
@@ -40,7 +40,7 @@ func TestAccProviderIntegrationSetupAzureLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := liveTestEnvironmentId // Hardcoded test environment
+	environmentId := liveTestEnvironmentId
 	azureTenantId := os.Getenv("AZURE_TENANT_ID")
 
 	// Validate required environment variables are present
@@ -252,7 +252,7 @@ func TestAccProviderIntegrationSetupGcpLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := liveTestEnvironmentId                                                                   // Hardcoded test environment
+	environmentId := liveTestEnvironmentId
 	gcpServiceAccount := fmt.Sprintf("test-sa-%d@test-project-123456.iam.gserviceaccount.com", randomSuffix) // Unique test service account
 
 	// Validate required environment variables are present

--- a/internal/provider/resource_provider_integration_setup_live_test.go
+++ b/internal/provider/resource_provider_integration_setup_live_test.go
@@ -40,7 +40,7 @@ func TestAccProviderIntegrationSetupAzureLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := "env-zyg27z" // Hardcoded test environment
+	environmentId := liveTestEnvironmentId // Hardcoded test environment
 	azureTenantId := os.Getenv("AZURE_TENANT_ID")
 
 	// Validate required environment variables are present
@@ -252,7 +252,7 @@ func TestAccProviderIntegrationSetupGcpLive(t *testing.T) {
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")
 	endpoint := os.Getenv("CONFLUENT_CLOUD_ENDPOINT")
-	environmentId := "env-zyg27z"                                                                            // Hardcoded test environment
+	environmentId := liveTestEnvironmentId                                                                   // Hardcoded test environment
 	gcpServiceAccount := fmt.Sprintf("test-sa-%d@test-project-123456.iam.gserviceaccount.com", randomSuffix) // Unique test service account
 
 	// Validate required environment variables are present

--- a/internal/provider/resource_role_binding_live_test.go
+++ b/internal/provider/resource_role_binding_live_test.go
@@ -144,9 +144,9 @@ func testAccCheckRoleBindingLiveConfig(endpoint, serviceAccountResourceLabel, se
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
+		crn_pattern = "crn://confluent.cloud/organization=%s"
 	}
-	`, endpoint, apiKey, apiSecret, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel)
+	`, endpoint, apiKey, apiSecret, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, liveTestOrganizationId)
 }
 
 func testAccCheckRoleBindingEnvironmentLiveConfig(endpoint, environmentResourceLabel, environmentDisplayName, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, apiKey, apiSecret string) string {
@@ -169,9 +169,9 @@ func testAccCheckRoleBindingEnvironmentLiveConfig(endpoint, environmentResourceL
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=${confluent_environment.%s.id}"
+		crn_pattern = "crn://confluent.cloud/organization=%s/environment=${confluent_environment.%s.id}"
 	}
-	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, environmentResourceLabel)
+	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, liveTestOrganizationId, environmentResourceLabel)
 }
 
 func testAccCheckRoleBindingLiveExists(resourceName string) resource.TestCheckFunc {

--- a/internal/provider/resource_role_binding_live_test.go
+++ b/internal/provider/resource_role_binding_live_test.go
@@ -64,7 +64,7 @@ func TestAccRoleBindingLive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleBindingLiveExists(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "role_name", "MetricsViewer"),
-					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "crn_pattern", "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "crn_pattern", "crn://confluent.cloud/organization="+liveTestOrganizationId),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "id"),
 					resource.TestCheckResourceAttrSet(fmt.Sprintf("confluent_role_binding.%s", roleBindingResourceLabel), "principal"),
 				),
@@ -144,7 +144,7 @@ func testAccCheckRoleBindingLiveConfig(endpoint, serviceAccountResourceLabel, se
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"
+		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
 	}
 	`, endpoint, apiKey, apiSecret, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel)
 }
@@ -169,7 +169,7 @@ func testAccCheckRoleBindingEnvironmentLiveConfig(endpoint, environmentResourceL
 	resource "confluent_role_binding" "%s" {
 		principal   = "User:${confluent_service_account.%s.id}"
 		role_name   = "MetricsViewer"
-		crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539/environment=${confluent_environment.%s.id}"
+		crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`/environment=${confluent_environment.%s.id}"
 	}
 	`, endpoint, apiKey, apiSecret, environmentResourceLabel, environmentDisplayName, serviceAccountResourceLabel, serviceAccountDisplayName, roleBindingResourceLabel, serviceAccountResourceLabel, environmentResourceLabel)
 }

--- a/internal/provider/resource_rtce_topic_live_test.go
+++ b/internal/provider/resource_rtce_topic_live_test.go
@@ -83,7 +83,7 @@ resource "confluent_service_account" "prerequisite" {
 resource "confluent_role_binding" "prerequisite" {
   principal   = "User:${confluent_service_account.prerequisite.id}"
   role_name   = "OrganizationAdmin"
-  crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"
+  crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
 }
 
 resource "confluent_api_key" "prerequisite" {

--- a/internal/provider/resource_rtce_topic_live_test.go
+++ b/internal/provider/resource_rtce_topic_live_test.go
@@ -83,7 +83,7 @@ resource "confluent_service_account" "prerequisite" {
 resource "confluent_role_binding" "prerequisite" {
   principal   = "User:${confluent_service_account.prerequisite.id}"
   role_name   = "OrganizationAdmin"
-  crn_pattern = "crn://confluent.cloud/organization=`+liveTestOrganizationId+`"
+  crn_pattern = "crn://confluent.cloud/organization=%s"
 }
 
 resource "confluent_api_key" "prerequisite" {
@@ -159,7 +159,7 @@ resource "confluent_schema" "prerequisite" {
     secret = confluent_api_key.prerequisite_sr.secret
   }
 }
-`, randomSuffix, randomSuffix, cloud, region, randomSuffix, randomSuffix, randomSuffix, randomSuffix)
+`, randomSuffix, randomSuffix, cloud, region, randomSuffix, liveTestOrganizationId, randomSuffix, randomSuffix, randomSuffix)
 }
 
 func testAccRtceTopicPrerequisiteWithProviderConfig(endpoint, apiKey, apiSecret string, randomSuffix int) string {

--- a/internal/provider/resource_rtce_topic_live_test.go
+++ b/internal/provider/resource_rtce_topic_live_test.go
@@ -80,12 +80,10 @@ resource "confluent_service_account" "prerequisite" {
   display_name = "tf-live-prereq-sa-%d"
 }
 
-data "confluent_organization" "prerequisite" {}
-
 resource "confluent_role_binding" "prerequisite" {
   principal   = "User:${confluent_service_account.prerequisite.id}"
   role_name   = "OrganizationAdmin"
-  crn_pattern = replace(data.confluent_organization.prerequisite.resource_name, "/[a-z]+\\.cpdev\\.cloud/", "confluent.cloud")
+  crn_pattern = "crn://confluent.cloud/organization=424fb7bf-40c2-433f-81a5-c45942a6a539"
 }
 
 resource "confluent_api_key" "prerequisite" {


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- [Internal-only] Fix TF Live test failure with `TestAccRtceTopicLive`, and refactor hardcoded string literals into shared constants

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Live Test passing 
```
❯ TF_ACC=1 TF_ACC_PROD=1 go test -tags="live_test,all" \
  -run TestAccRtceTopicLive \
  ./internal/provider/ -v -mod=readonly -timeout 30m

=== RUN   TestAccRtceTopicLive
=== PAUSE TestAccRtceTopicLive
=== CONT  TestAccRtceTopicLive
    resource_rtce_topic_live_test.go:218: Waiting 5 minutes for prerequisite resources to propagate...
--- PASS: TestAccRtceTopicLive (506.00s)
PASS
ok      github.com/confluentinc/terraform-provider-confluent/internal/provider  506.727s
```

Centralize the use of literal `org_id` and `env_id` string in the repo
<img width="2228" height="1038" alt="Screenshot 2026-05-27 at 1 00 44 PM" src="https://github.com/user-attachments/assets/fde8df90-9de2-4377-86d4-3df3326e07fe" />
