### PR TITLE
QUESTION-1249: Add configurable timeouts to confluent_access_point resource

### DIFF
--- a/internal/provider/resource_access_point.go
+++ b/internal/provider/resource_access_point.go
@@ -47,8 +47,8 @@ func accessPointResource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			paramGateway:                                requiredGateway(),
-			paramEnvironment:                            environmentSchema(),
+			paramGateway:                                 requiredGateway(),
+			paramEnvironment:                             environmentSchema(),
 			paramAwsEgressPrivateLinkEndpoint:            paramAwsEgressPrivateLinkEndpointSchema(),
 			paramAwsIngressPrivateLinkEndpoint:           paramAwsIngressPrivateLinkEndpointSchema(),
 			paramAzureEgressPrivateLinkEndpoint:          paramAzureEgressPrivateLinkEndpointSchema(),
@@ -56,6 +56,10 @@ func accessPointResource() *schema.Resource {
 			paramGcpEgressPrivateServiceConnectEndpoint:  paramGcpEgressPrivateServiceConnectEndpointSchema(),
 			paramGcpIngressPrivateServiceConnectEndpoint: paramGcpIngressPrivateServiceConnectEndpointSchema(),
 			paramAwsPrivateNetworkInterface:              paramAwsPrivateNetworkInterfaceSchema(),
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(networkingAPICreateTimeout),
+			Delete: schema.DefaultTimeout(networkingAPIDeleteTimeout),
 		},
 	}
 }
@@ -307,9 +311,9 @@ func paramAwsPrivateNetworkInterfaceSchema() *schema.Schema {
 					Description: "The AWS account ID associated with the ENIs you are using for the Confluent Private Network Interface.",
 				},
 				paramRoutes: {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 10,
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    10,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 					Description: "List of egress CIDR routes for the Confluent Private Network Interface.",
 				},
@@ -393,7 +397,7 @@ func accessPointCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		spec.SetConfig(config)
 	} else if isGcpIngressPrivateServiceConnectEndpoint {
 		config.NetworkingV1GcpIngressPrivateServiceConnectEndpoint = &networkingaccesspointv1.NetworkingV1GcpIngressPrivateServiceConnectEndpoint{
-			Kind:                             gcpIngressPrivateServiceConnectEndpoint,
+			Kind:                              gcpIngressPrivateServiceConnectEndpoint,
 			PrivateServiceConnectConnectionId: extractStringValueFromBlock(d, paramGcpIngressPrivateServiceConnectEndpoint, paramPrivateServiceConnectConnectionId),
 		}
 		spec.SetConfig(config)
@@ -633,7 +637,7 @@ func setAccessPointAttributes(d *schema.ResourceData, accessPoint networkingacce
 		if err := d.Set(paramGcpIngressPrivateServiceConnectEndpoint, []interface{}{map[string]interface{}{
 			paramPrivateServiceConnectConnectionId:      accessPoint.Spec.Config.NetworkingV1GcpIngressPrivateServiceConnectEndpoint.GetPrivateServiceConnectConnectionId(),
 			paramPrivateServiceConnectServiceAttachment: accessPoint.Status.Config.NetworkingV1GcpIngressPrivateServiceConnectEndpointStatus.GetPrivateServiceConnectServiceAttachment(),
-			paramDnsDomain:                             accessPoint.Status.Config.NetworkingV1GcpIngressPrivateServiceConnectEndpointStatus.GetDnsDomain(),
+			paramDnsDomain: accessPoint.Status.Config.NetworkingV1GcpIngressPrivateServiceConnectEndpointStatus.GetDnsDomain(),
 		}}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Raised the default create/delete timeouts, so slow `PROVISIONING -> READY` transitions no longer fail `terraform apply` with `context deadline exceeded` for the `confluent_access_point` resource.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.

What
----
Creating a `confluent_access_point` could fail with `error waiting for Access Point to provision: context deadline exceeded` when the access point stayed in `PROVISIONING` for more than ~20 minutes, even though it was still provisioning normally and would eventually reach `READY`.

**Root cause:** the resource had no `Timeouts` block. When one isn't defined, terraform-plugin-sdk applies its built-in default of 20 minutes as the create context deadline, which cancels the `PROVISIONING -> READY` wait early.

**Fix:** add a `Timeouts` block with the standard networking create/delete defaults (2h / 5h):

```go
Timeouts: &schema.ResourceTimeout{
    Create: schema.DefaultTimeout(networkingAPICreateTimeout),
    Delete: schema.DefaultTimeout(networkingAPIDeleteTimeout),
},
```

This is the same pattern already used by the other networking resources — `confluent_network`, `confluent_peering`, and `confluent_private_link_access` all define this identical block. It also makes the timeout user-overridable, consistent with those resources.

We've resolved the same class of issue before: #462 fixed `confluent_schema_exporter` failing at the same 20-minute SDK default by giving it a longer configurable timeout.

Blast Radius
----
Low / positive. The change only adds timeout configuration to `confluent_access_point`. No change to resource arguments, state, or behavior beyond a longer wait ceiling.

References
----------
- QUESTION-1249
- Prior similar fix: #462 (confluent_schema_exporter timeout)

Test & Review
-------------
- `gofmt -l internal/provider/resource_access_point.go` — clean.
- `go build ./internal/provider/` — passes.
- This is a schema-only change identical to the block already shipped on `confluent_network` / `confluent_peering` / `confluent_private_link_access`, and matches the previously-validated fix in #462, so it carries no new runtime logic to exercise. A full acceptance test isn't practical here since it would require a real access point that takes >20 minutes to provision.
