### PR TITLE
[APIE-1104] Add distribution.kind field and mark as required when distribution is specified 

### DIFF
--- a/docs/data-sources/confluent_flink_materialized_table.md
+++ b/docs/data-sources/confluent_flink_materialized_table.md
@@ -115,6 +115,8 @@ In addition to the preceding arguments, the following attributes are exported:
     - `kind` - (String) The kind of distribution, for example, `HASH`.
     - `keys` - (Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Integer) The number of buckets the table is distributed by.
+- `table_options` - (Map) Configuration properties for the Materialized Table, equivalent to the SQL `WITH` clause.
+- `session_options` - (Map) Session configurations equivalent to the SQL `SET` statement.
 - `stopped` - (Boolean) Whether the Materialized Table is stopped.
 - `columns` - (List of Blocks) The column definitions of the Materialized Table, including physical, computed, and metadata columns.
 - `constraints` - (List of Blocks) The table constraints of the Materialized Table. Each `constraints` block supports the following:

--- a/docs/data-sources/confluent_flink_materialized_table.md
+++ b/docs/data-sources/confluent_flink_materialized_table.md
@@ -112,6 +112,7 @@ In addition to the preceding arguments, the following attributes are exported:
     - `column` - (String) The name of the watermark column.
     - `expression` - (String) The watermark expression.
 - `distribution` - (Configuration Block) The distribution definition for the Materialized Table. This value could be derived automatically by Confluent Cloud (for example, from the query's primary key when a `GROUP BY` is present). Supports the following:
+    - `kind` - (String) The kind of distribution, for example, `HASH`.
     - `keys` - (Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Integer) The number of buckets the table is distributed by.
 - `stopped` - (Boolean) Whether the Materialized Table is stopped.

--- a/docs/resources/confluent_flink_materialized_table.md
+++ b/docs/resources/confluent_flink_materialized_table.md
@@ -137,6 +137,7 @@ The following arguments are supported:
     - `column` - (Optional String) The name of the watermark column.
     - `expression` - (Optional String) The watermark expression, for example, `event_time - INTERVAL '5' SECOND`.
 - `distribution` - (Optional Configuration Block, max 1 item) The distribution definition for the Materialized Table. If omitted, Confluent Cloud could derive it automatically (for example, from the query's primary key when a `GROUP BY` is present) and populate it in state. Supports the following:
+    - `kind` - (Required String) The kind of distribution. Required when the `distribution` block is specified. The only currently supported value is `HASH`.
     - `keys` - (Optional Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Optional Integer) The number of buckets the table is distributed by.
 - `stopped` - (Optional Boolean) Indicates whether the Materialized Table is stopped. Defaults to `false`. Update it to `true` to stop the Materialized Table; subsequently update it to `false` to resume it.

--- a/docs/resources/confluent_flink_materialized_table.md
+++ b/docs/resources/confluent_flink_materialized_table.md
@@ -140,6 +140,8 @@ The following arguments are supported:
     - `kind` - (Required String) The kind of distribution. Required when the `distribution` block is specified. The only currently supported value is `HASH`.
     - `keys` - (Optional Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Optional Integer) The number of buckets the table is distributed by.
+- `table_options` - (Optional Map) Defines configuration properties for the Materialized Table, equivalent to the SQL `WITH` clause.
+- `session_options` - (Optional Map) Session configurations equivalent to the SQL `SET` statement. Only applicable on creation; ignored on update.
 - `stopped` - (Optional Boolean) Indicates whether the Materialized Table is stopped. Defaults to `false`. Update it to `true` to stop the Materialized Table; subsequently update it to `false` to resume it.
 - `rest_endpoint` - (Optional String) The REST endpoint of the Flink region, for example, `https://flink.us-east-1.aws.confluent.cloud`.
 - `credentials` (Optional Configuration Block) supports the following:

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -356,6 +356,7 @@ const (
 	paramDistribution                                    = "distribution"
 	paramDistributionBucketCount                         = "bucket_count"
 	paramDistributionKeys                                = "keys"
+	paramDistributionKind                                = "kind"
 	paramDnsConfig                                       = "dns_config"
 	paramDnsDomain                                       = "dns_domain"
 	paramDnsServerIps                                    = "dns_server_ips"

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -580,6 +580,7 @@ const (
 	paramService                                         = "service"
 	paramServiceKey                                      = "service_key"
 	paramServices                                        = "services"
+	paramSessionOptions                                  = "session_options"
 	paramShared                                          = "shared"
 	paramSharedDefaultValue                              = false
 	paramSkipValidationDuringPlan                        = "skip_validation_during_plan"
@@ -604,6 +605,7 @@ const (
 	paramSubscription                                    = "subscription"
 	paramSuspended                                       = "suspended"
 	paramTableFormats                                    = "table_formats"
+	paramTableOptions                                    = "table_options"
 	paramTablePath                                       = "table_path"
 	paramTagName                                         = "tag_name"
 	paramTags                                            = "tags"

--- a/internal/provider/data_source_flink_materialized_table.go
+++ b/internal/provider/data_source_flink_materialized_table.go
@@ -248,6 +248,11 @@ func distributionSchemaDataSource() *schema.Schema {
 					Description: "The number of buckets the table is distributed by.",
 					Computed:    true,
 				},
+				paramDistributionKind: {
+					Type:        schema.TypeString,
+					Description: "The kind of distribution.",
+					Computed:    true,
+				},
 			},
 		},
 	}

--- a/internal/provider/data_source_flink_materialized_table.go
+++ b/internal/provider/data_source_flink_materialized_table.go
@@ -43,6 +43,16 @@ func flinkMaterializedTableDataSource() *schema.Resource {
 			},
 			paramWatermark:    watermarkSchemaDataSource(),
 			paramDistribution: distributionSchemaDataSource(),
+			paramTableOptions: {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			paramSessionOptions: {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
 			paramStopped: {
 				Type:     schema.TypeBool,
 				Computed: true,

--- a/internal/provider/data_source_flink_materialized_table_test.go
+++ b/internal/provider/data_source_flink_materialized_table_test.go
@@ -90,6 +90,10 @@ func TestAccDataSourceFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullTableDataSourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullTableDataSourceLabel, "distribution.0.keys.*", "passwords"),
+					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "table_options.%", "1"),
+					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "table_options.changelog_mode", "upsert"),
+					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "session_options.%", "1"),
+					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "session_options.sql_local_time_zone", "UTC"),
 
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "columns.0.columns_physical.0.column_physical_name", "user_id"),
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "columns.0.columns_physical.0.column_physical_kind", "Physical"),

--- a/internal/provider/data_source_flink_materialized_table_test.go
+++ b/internal/provider/data_source_flink_materialized_table_test.go
@@ -86,6 +86,7 @@ func TestAccDataSourceFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, paramStopped, "false"),
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "distribution.#", "1"),
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "distribution.0.bucket_count", "10"),
+					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "distribution.0.kind", "HASH"),
 					resource.TestCheckResourceAttr(fullTableDataSourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullTableDataSourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullTableDataSourceLabel, "distribution.0.keys.*", "passwords"),

--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -44,6 +44,21 @@ func flinkMaterializedTableResource() *schema.Resource {
 			},
 			paramWatermark:    watermarkSchema(),
 			paramDistribution: distributionSchema(),
+			paramTableOptions: {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				Description: "Defines configuration properties for the materialized table, equivalent to the SQL `WITH` clause.",
+			},
+			paramSessionOptions: {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Session configurations equivalent to the SQL `SET` statement. Only applicable on creation; ignored on update.",
+			},
 			paramRestEndpoint: {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -344,6 +359,14 @@ func materializedTableCreate(ctx context.Context, d *schema.ResourceData, meta i
 		table.Spec.Distribution = distribution
 	}
 
+	if tableOptions := convertToStringStringMap(d.Get(paramTableOptions).(map[string]interface{})); len(tableOptions) > 0 {
+		table.Spec.SetTableOptions(tableOptions)
+	}
+
+	if sessionOptions := convertToStringStringMap(d.Get(paramSessionOptions).(map[string]interface{})); len(sessionOptions) > 0 {
+		table.Spec.SetSessionOptions(sessionOptions)
+	}
+
 	constraints := expandMaterializedTableConstraints(d, paramConstraints)
 	if len(constraints) > 0 {
 		table.Spec.SetConstraints(constraints)
@@ -518,6 +541,13 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 		if err := d.Set(paramDistribution, []interface{}{}); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := d.Set(paramTableOptions, materializedTable.Spec.GetTableOptions()); err != nil {
+		return nil, err
+	}
+	if err := d.Set(paramSessionOptions, materializedTable.Spec.GetSessionOptions()); err != nil {
+		return nil, err
 	}
 
 	err := d.Set(paramStopped, materializedTable.Spec.GetStopped())
@@ -719,8 +749,8 @@ func materializedTableImport(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func materializedTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints) {
-		return diag.Errorf("error updating Flink Materialized Table %q: only %q, %q, %q, %q, %q, %q, and %q attributes can be updated for Flink Materialized Table", d.Id(), paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints)
+	if d.HasChangesExcept(paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints, paramTableOptions) {
+		return diag.Errorf("error updating Flink Materialized Table %q: only %q, %q, %q, %q, %q, %q, %q, and %q attributes can be updated for Flink Materialized Table", d.Id(), paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints, paramTableOptions)
 	}
 
 	restEndpoint, err := extractFlinkRestEndpoint(meta.(*Client), d, false)
@@ -790,6 +820,10 @@ func materializedTableUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			constraints = []flinkgatewayv1.SqlV1Constraint{}
 		}
 		table.Spec.SetConstraints(constraints)
+	}
+
+	if d.HasChange(paramTableOptions) {
+		table.Spec.SetTableOptions(convertToStringStringMap(d.Get(paramTableOptions).(map[string]interface{})))
 	}
 
 	updateMaterializedTableRequestJson, err := json.Marshal(table)

--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -240,6 +240,13 @@ func distributionSchema() *schema.Schema {
 					Computed:    true,
 					ForceNew:    true,
 				},
+				paramDistributionKind: {
+					Type:        schema.TypeString,
+					Description: "The kind of distribution. Required when the distribution block is specified.",
+					Optional:    true,
+					Computed:    true,
+					ForceNew:    true,
+				},
 			},
 		},
 	}
@@ -501,6 +508,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 			{
 				paramDistributionKeys:        keysSet,
 				paramDistributionBucketCount: materializedTable.Spec.Distribution.GetBucketCount(),
+				paramDistributionKind:        materializedTable.Spec.Distribution.GetKind(),
 			},
 		}
 		if err := d.Set(paramDistribution, distributionBlock); err != nil {
@@ -903,7 +911,8 @@ func expandMaterializedTableDistribution(d *schema.ResourceData) *flinkgatewayv1
 		}
 	}
 	bucketCount, _ := m[paramDistributionBucketCount].(int)
-	if bucketCount == 0 && len(keys) == 0 {
+	kind, _ := m[paramDistributionKind].(string)
+	if bucketCount == 0 && len(keys) == 0 && kind == "" {
 		return nil
 	}
 	dist := &flinkgatewayv1.SqlV1Distribution{}
@@ -912,6 +921,9 @@ func expandMaterializedTableDistribution(d *schema.ResourceData) *flinkgatewayv1
 	}
 	if bucketCount != 0 {
 		dist.SetBucketCount(int32(bucketCount))
+	}
+	if kind != "" {
+		dist.SetKind(kind)
 	}
 	return dist
 }

--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -258,8 +258,7 @@ func distributionSchema() *schema.Schema {
 				paramDistributionKind: {
 					Type:        schema.TypeString,
 					Description: "The kind of distribution. Required when the distribution block is specified.",
-					Optional:    true,
-					Computed:    true,
+					Required:    true,
 					ForceNew:    true,
 				},
 			},
@@ -477,6 +476,23 @@ func readMaterializedTableAndSetAttributes(ctx context.Context, d *schema.Resour
 	return []*schema.ResourceData{d}, nil
 }
 
+// If the config manages a subset, we persist only the user's keys
+// (intersected with the server map) so those server-added defaults don't show up
+// as perpetual drift. This mirrors loadTopicConfigs for confluent_kafka_topic.
+func setServerManagedOptionsMap(d *schema.ResourceData, key string, serverOptions map[string]string) error {
+	userOptions := d.Get(key).(map[string]interface{})
+	if len(userOptions) == 0 {
+		return d.Set(key, serverOptions)
+	}
+	managedOptions := make(map[string]string, len(userOptions))
+	for optionKey := range userOptions {
+		if value, ok := serverOptions[optionKey]; ok {
+			managedOptions[optionKey] = value
+		}
+	}
+	return d.Set(key, managedOptions)
+}
+
 func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable flinkgatewayv1.SqlV1MaterializedTable, c *FlinkRestClient) (*schema.ResourceData, error) {
 	if err := d.Set(paramDisplayName, materializedTable.GetName()); err != nil {
 		return nil, err
@@ -543,10 +559,10 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 		}
 	}
 
-	if err := d.Set(paramTableOptions, materializedTable.Spec.GetTableOptions()); err != nil {
+	if err := setServerManagedOptionsMap(d, paramTableOptions, materializedTable.Spec.GetTableOptions()); err != nil {
 		return nil, err
 	}
-	if err := d.Set(paramSessionOptions, materializedTable.Spec.GetSessionOptions()); err != nil {
+	if err := setServerManagedOptionsMap(d, paramSessionOptions, materializedTable.Spec.GetSessionOptions()); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -158,6 +158,7 @@ func TestAccFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, paramStopped, "false"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.#", "1"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.bucket_count", "10"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.kind", "HASH"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "passwords"),
@@ -194,6 +195,7 @@ func TestAccFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, paramStopped, "true"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.#", "1"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.bucket_count", "10"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.kind", "HASH"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "passwords"),
@@ -286,6 +288,7 @@ func testAccCheckMaterializedTableConfig(mockServerUrl, resourceLabel string) st
 	  }
 	  distribution {
 	    bucket_count = 10
+	    kind = "HASH"
 	    keys = [
 	      "keys",
 	      "passwords",
@@ -346,6 +349,7 @@ func testAccCheckMaterializedTableConfigUpdated(mockServerUrl, resourceLabel str
 	  }
 	  distribution {
 	    bucket_count = 10
+	    kind = "HASH"
 	    keys = [
 	      "keys",
 	      "passwords",

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -162,6 +162,10 @@ func TestAccFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "passwords"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "table_options.%", "1"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "table_options.changelog_mode", "upsert"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "session_options.%", "1"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "session_options.sql_local_time_zone", "UTC"),
 
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "columns.0.columns_physical.0.column_physical_name", "user_id"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "columns.0.columns_physical.0.column_physical_kind", "Physical"),
@@ -199,6 +203,11 @@ func TestAccFlinkMaterializedTable(t *testing.T) {
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "keys"),
 					resource.TestCheckTypeSetElemAttr(fullMaterializedTableResourceLabel, "distribution.0.keys.*", "passwords"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "table_options.%", "2"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "table_options.changelog_mode", "upsert"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "table_options.scan_startup_mode", "earliest-offset"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "session_options.%", "1"),
+					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "session_options.sql_local_time_zone", "UTC"),
 
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "columns.#", "3"),
 					resource.TestCheckResourceAttr(fullMaterializedTableResourceLabel, "columns.0.columns_physical.0.column_physical_name", "user_id"),
@@ -294,6 +303,12 @@ func testAccCheckMaterializedTableConfig(mockServerUrl, resourceLabel string) st
 	      "passwords",
 	    ]
 	  }
+	  table_options = {
+	    "changelog_mode" = "upsert"
+	  }
+	  session_options = {
+	    "sql_local_time_zone" = "UTC"
+	  }
 	constraints {
       name = "pk_orders"
       type = "PRIMARY_KEY"
@@ -354,6 +369,13 @@ func testAccCheckMaterializedTableConfigUpdated(mockServerUrl, resourceLabel str
 	      "keys",
 	      "passwords",
 	    ]
+	  }
+	  table_options = {
+	    "changelog_mode"    = "upsert"
+	    "scan_startup_mode" = "earliest-offset"
+	  }
+	  session_options = {
+	    "sql_local_time_zone" = "UTC"
 	  }
 	constraints {
       name = "pk_orders"
@@ -555,6 +577,128 @@ func testAccCheckMaterializedTableServerDerivedDistributionConfig(mockServerUrl,
       stopped = false
 	  query = "SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;"
 	  # NOTE: no distribution block on purpose - Confluent Cloud derives it from the query's primary key.
+}
+	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
+}
+
+// TestAccFlinkMaterializedTableUnmanagedTableAndSessionOptions verifies backward compatibility for
+// configs written before `table_options`/`session_options` existed in the schema: the config omits
+// both entirely, while the server response returns non-empty values for both (e.g. an existing table
+// created before these fields were exposed in Terraform). Because both are Optional+Computed, the
+// provider must accept the API values without proposing a diff. Without Computed, the second PlanOnly
+// step below would show a change (and, for `session_options`, a ForceNew replacement) and fail.
+func TestAccFlinkMaterializedTableUnmanagedTableAndSessionOptions(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockTestServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	const scenarioName = "confluent_flink_materialized_table Unmanaged Table And Session Options"
+	const unmanagedDisplayName = "table_unmanaged_options"
+	readUnmanagedPath := fmt.Sprintf("/sql/v1/organizations/%s/environments/%s/databases/%s/materialized-tables/%s", flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkMaterializedTableDatabase, unmanagedDisplayName)
+
+	createResponse, _ := os.ReadFile("../testdata/flink_materialized_table/create_materialized_table_unmanaged_options.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	readResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_materialized_table_unmanaged_options.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readUnmanagedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusOK))
+
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readUnmanagedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+
+	readDeletedResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_deleted_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readUnmanagedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn(string(readDeletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	resourceLabel := "test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_materialized_table.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckMaterializedTableDestroy(s, mockTestServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				// The config omits `table_options`/`session_options` entirely; the server response supplies both.
+				Config: testAccCheckMaterializedTableUnmanagedOptionsConfig(mockTestServerUrl, resourceLabel, unmanagedDisplayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramDisplayName, unmanagedDisplayName),
+					// The server-returned values must land in state even though the config omitted them.
+					resource.TestCheckResourceAttr(fullResourceLabel, "table_options.%", "1"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "table_options.changelog_mode", "upsert"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "session_options.%", "1"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "session_options.sql_local_time_zone", "UTC"),
+				),
+			},
+			{
+				// Re-planning the same config (still omitting both) must be a no-op: no update, and no
+				// ForceNew replacement despite `session_options` being ForceNew.
+				Config:             testAccCheckMaterializedTableUnmanagedOptionsConfig(mockTestServerUrl, resourceLabel, unmanagedDisplayName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMaterializedTableUnmanagedOptionsConfig(mockServerUrl, resourceLabel, displayName string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+    	endpoint = "%s"
+	}
+
+	resource "confluent_flink_materialized_table" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+      display_name  = "%s"
+	  kafka_cluster {
+	    id = "%s"
+	  }
+      stopped = false
+	  query = "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+	  # NOTE: no table_options/session_options blocks on purpose - simulates a config written
+	  # before these fields existed, against a table that already has them set server-side.
 }
 	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -582,6 +582,132 @@ func testAccCheckMaterializedTableServerDerivedDistributionConfig(mockServerUrl,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
 }
 
+// TestAccFlinkMaterializedTableManagedOptionsSuperset locks in the fix for
+// table_options/session_options drift. The config manages only a SUBSET of the
+// options while the API read returns the FULL effective option set. The provider must persist only the user-managed keys
+// so the follow-up plan is a no-op.
+func TestAccFlinkMaterializedTableManagedOptionsSuperset(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockTestServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	const scenarioName = "confluent_flink_materialized_table Managed Options Superset"
+	const supersetDisplayName = "table_options_superset"
+	readSupersetPath := fmt.Sprintf("/sql/v1/organizations/%s/environments/%s/databases/%s/materialized-tables/%s", flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkMaterializedTableDatabase, supersetDisplayName)
+
+	createResponse, _ := os.ReadFile("../testdata/flink_materialized_table/create_materialized_table_options_superset.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	readResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_materialized_table_options_superset.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSupersetPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusOK))
+
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readSupersetPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+
+	readDeletedResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_deleted_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readSupersetPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn(string(readDeletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	resourceLabel := "test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_materialized_table.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckMaterializedTableDestroy(s, mockTestServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMaterializedTableManagedOptionsSupersetConfig(mockTestServerUrl, resourceLabel, supersetDisplayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramDisplayName, supersetDisplayName),
+					// Only the user-managed keys are persisted, even though the read
+					// returned a larger server-computed map.
+					resource.TestCheckResourceAttr(fullResourceLabel, "table_options.%", "1"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "table_options.kafka.retention.time", "7 d"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "session_options.%", "1"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "session_options.sql.local-time-zone", "UTC"),
+				),
+			},
+			{
+				// Re-planning the same config must be a no-op: the server-added option
+				// keys must not surface as drift (and session_options, being ForceNew,
+				// must not propose a replacement).
+				Config:             testAccCheckMaterializedTableManagedOptionsSupersetConfig(mockTestServerUrl, resourceLabel, supersetDisplayName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMaterializedTableManagedOptionsSupersetConfig(mockServerUrl, resourceLabel, displayName string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+    	endpoint = "%s"
+	}
+
+	resource "confluent_flink_materialized_table" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+      display_name  = "%s"
+	  kafka_cluster {
+	    id = "%s"
+	  }
+      stopped = false
+	  query = "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+      # Config manages only a SUBSET of options; the API read returns a superset.
+      table_options = {
+        "kafka.retention.time" = "7 d"
+      }
+      session_options = {
+        "sql.local-time-zone" = "UTC"
+      }
+}
+	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
+}
+
 // TestAccFlinkMaterializedTableUnmanagedTableAndSessionOptions verifies backward compatibility for
 // configs written before `table_options`/`session_options` existed in the schema: the config omits
 // both entirely, while the server response returns non-empty values for both (e.g. an existing table

--- a/internal/testdata/flink_materialized_table/create_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/create_materialized_table.json
@@ -39,7 +39,8 @@
         "keys",
         "passwords"
       ],
-      "bucket_count": 10
+      "bucket_count": 10,
+      "kind": "HASH"
     },
     "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
   },

--- a/internal/testdata/flink_materialized_table/create_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/create_materialized_table.json
@@ -9,8 +9,12 @@
     "compute_pool_id": "lfcp-x7rgx1",
     "principal": "u-yo9j87",
     "stopped": false,
-    "table_options": {},
-    "session_options": {},
+    "table_options": {
+      "changelog_mode": "upsert"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
     "columns": [
       {
         "name": "user_id",

--- a/internal/testdata/flink_materialized_table/create_materialized_table_options_superset.json
+++ b/internal/testdata/flink_materialized_table/create_materialized_table_options_superset.json
@@ -1,0 +1,36 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_options_superset",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {
+      "kafka.retention.time": "7 d",
+      "connector": "confluent",
+      "changelog.mode": "append",
+      "key.format": "avro-registry",
+      "value.format": "avro-registry",
+      "scan.startup.mode": "earliest-offset",
+      "scan.bounded.mode": "unbounded"
+    },
+    "session_options": {
+      "sql.local-time-zone": "UTC",
+      "sql.state-ttl": "0 ms",
+      "sql.tables.scan.idle-timeout": "0 ms"
+    },
+    "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_options_superset AS SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/create_materialized_table_unmanaged_options.json
+++ b/internal/testdata/flink_materialized_table/create_materialized_table_unmanaged_options.json
@@ -1,0 +1,28 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_unmanaged_options",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {
+      "changelog_mode": "upsert"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
+    "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_unmanaged_options AS SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/read_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table.json
@@ -39,7 +39,8 @@
         "keys",
         "passwords"
       ],
-      "bucket_count": 10
+      "bucket_count": 10,
+      "kind": "HASH"
     },
     "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
   },

--- a/internal/testdata/flink_materialized_table/read_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table.json
@@ -9,8 +9,12 @@
     "compute_pool_id": "lfcp-x7rgx1",
     "principal": "u-yo9j87",
     "stopped": false,
-    "table_options": {},
-    "session_options": {},
+    "table_options": {
+      "changelog_mode": "upsert"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
     "columns": [
       {
         "name": "user_id",

--- a/internal/testdata/flink_materialized_table/read_materialized_table_list.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_list.json
@@ -47,7 +47,8 @@
             "keys",
             "passwords"
           ],
-          "bucket_count": 10
+          "bucket_count": 10,
+          "kind": "HASH"
         },
         "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
       },

--- a/internal/testdata/flink_materialized_table/read_materialized_table_options_superset.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_options_superset.json
@@ -1,0 +1,36 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_options_superset",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {
+      "kafka.retention.time": "7 d",
+      "connector": "confluent",
+      "changelog.mode": "append",
+      "key.format": "avro-registry",
+      "value.format": "avro-registry",
+      "scan.startup.mode": "earliest-offset",
+      "scan.bounded.mode": "unbounded"
+    },
+    "session_options": {
+      "sql.local-time-zone": "UTC",
+      "sql.state-ttl": "0 ms",
+      "sql.tables.scan.idle-timeout": "0 ms"
+    },
+    "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_options_superset AS SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/read_materialized_table_unmanaged_options.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_unmanaged_options.json
@@ -1,0 +1,28 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_unmanaged_options",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {
+      "changelog_mode": "upsert"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
+    "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_unmanaged_options AS SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/read_materialized_table_updated.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_updated.json
@@ -9,8 +9,13 @@
     "compute_pool_id": "lfcp-x7rgx2",
     "principal": "sa-yo9j87",
     "stopped": true,
-    "table_options": {},
-    "session_options": {},
+    "table_options": {
+      "changelog_mode": "upsert",
+      "scan_startup_mode": "earliest-offset"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
     "columns": [
       {
         "name": "user_id",

--- a/internal/testdata/flink_materialized_table/read_materialized_table_updated.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_updated.json
@@ -62,7 +62,8 @@
         "keys",
         "passwords"
       ],
-      "bucket_count": 10
+      "bucket_count": 10,
+      "kind": "HASH"
     },
     "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 100;"
   },

--- a/internal/testdata/flink_materialized_table/update_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/update_materialized_table.json
@@ -9,8 +9,13 @@
     "compute_pool_id": "lfcp-x7rgx2",
     "principal": "sa-yo9j87",
     "stopped": true,
-    "table_options": {},
-    "session_options": {},
+    "table_options": {
+      "changelog_mode": "upsert",
+      "scan_startup_mode": "earliest-offset"
+    },
+    "session_options": {
+      "sql_local_time_zone": "UTC"
+    },
     "columns": [
       {
         "name": "user_id",

--- a/internal/testdata/flink_materialized_table/update_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/update_materialized_table.json
@@ -62,7 +62,8 @@
         "keys",
         "passwords"
       ],
-      "bucket_count": 10
+      "bucket_count": 10,
+      "kind": "HASH"
     },
     "query": "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 100;"
   },


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- Add `table_options` and `session_options`, and update `distribution.kind` as required when the `distribution` block is specified for the `confluent_flink_materialized_table` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_materialized_table) 

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
This is a follow-up PR for [INC-12087](https://confluent.slack.com/archives/C0BG2PELHK9/p1783940928467009). 

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
Minimal blast radius, as this is a bug fix. 

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Acceptance Tests 
```
❯ TF_ACC=1 go test ./internal/provider -run 'MaterializedTable' -v -timeout 20m
...
2026/07/24 16:54:08 🐳 Starting container: 16af2f78643d
2026/07/24 16:54:08 ✅ Container started: 16af2f78643d
2026/07/24 16:54:08 ⏳ Waiting for container id 16af2f78643d image: wiremock/wiremock:2.32.0-alpine. Waiting for: port 8080 to be listening
2026/07/24 16:54:09 🔔 Container is ready: 16af2f78643d
2026/07/24 16:54:11 🐳 Stopping container: 16af2f78643d
2026/07/24 16:54:12 ✅ Container stopped: 16af2f78643d
2026/07/24 16:54:12 🐳 Terminating container: 16af2f78643d
2026/07/24 16:54:12 🚫 Container terminated: 16af2f78643d
--- PASS: TestAccFlinkMaterializedTableUnmanagedTableAndSessionOptions (4.02s)
PASS
ok      github.com/confluentinc/terraform-provider-conf
```

Manual Verification (in PROD) 
[link to test outputs](https://confluent.slack.com/archives/C02TG07V058/p1784936762378299)

[INC-12087]: https://confluentinc.atlassian.net/browse/INC-12087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ