### PR TITLE
chore(deps): upgrade x/net to v0.55.0 and x/crypto to v0.52.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
Release Notes
---------
None — this PR only touches a transitive dependency. No user-facing or runtime changes.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. <!-- N/A: dependency-only change -->
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. <!-- N/A -->

What
----
This PR resolves all 13 currently open Dependabot alerts (#83-#95) by bumping `golang.org/x/crypto` from `v0.51.0` to `v0.52.0`, which is the first patched version for every advisory below:

| Alert | Severity | CVE | Summary |
|---|---|---|---|
| [#83](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/83) | critical | CVE-2026-39831 | FIDO/U2F security key physical presence check can be bypassed |
| [#84](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/84) | critical | CVE-2026-46595 | `VerifiedPublicKeyCallback` permissions skip enforcement |
| [#85](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/85) | critical | CVE-2026-42508 | Auth bypass via unenforced `@revoked` status |
| [#86](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/86) | high | CVE-2026-46597 | Byte arithmetic causes underflow and panic |
| [#87](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/87) | medium | CVE-2026-39828 | Bypass of certificate restrictions |
| [#88](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/88) | critical | CVE-2026-39832 | Doesn't drop agent constraints when forwarding keys |
| [#89](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/89) | critical | CVE-2026-39830 | Client can cause server deadlock on unexpected responses |
| [#90](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/90) | medium | CVE-2026-46598 | Pathological inputs can lead to client panic |
| [#91](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/91) | high | CVE-2026-39829 | Pathological RSA/DSA parameters may cause DoS |
| [#92](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/92) | critical | CVE-2026-39834 | Infinite loop on large channel writes |
| [#93](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/93) | critical | CVE-2026-39833 | Doesn't enforce key constraints |
| [#94](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/94) | medium | CVE-2026-39835 | Server panic during `CheckHostKey`/`Authenticate` flow |
| [#95](https://github.com/confluentinc/terraform-provider-confluent/security/dependabot/95) | medium | CVE-2026-39827 | Memory leak when rejecting channels can lead to DoS |

`golang.org/x/crypto` is an indirect (transitive) dependency, not called directly by the provider. `golang.org/x/net` is already pinned to `v0.55.0` on `master` via #1043, so no further change is needed there.

Blast Radius
----
None for customers. `golang.org/x/crypto` is a transitive dependency only; no provider resource/data-source code changes.

References
----------
- Resolves Dependabot alerts: #83, #84, #85, #86, #87, #88, #89, #90, #91, #92, #93, #94, #95
- https://github.com/confluentinc/terraform-provider-confluent/security/dependabot

Test & Review
-------------
- `go mod tidy` and `go build ./...` pass cleanly with the upgraded dependency.
