### PR TITLE
DOCS-39436: Clarify force must be unset when using terraform import

### DIFF
--- a/docs/resources/confluent_schema_registry_cluster_mode.md
+++ b/docs/resources/confluent_schema_registry_cluster_mode.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 !> **Warning:** Use Option #2 to avoid exposing sensitive `credentials` value in a state file. When using Option #1, Terraform doesn't encrypt the sensitive `credentials` value of the `confluent_kafka_cluster_mode` resource, so you must keep your state file secure to avoid exposing it. Refer to the [Terraform documentation](https://www.terraform.io/docs/language/state/sensitive-data.html) to learn more about securing your state file.
 
 - `mode` - (Optional String) The global Schema Registry mode. Accepted values are: `READWRITE`, `READONLY`, `READONLY_OVERRIDE`, and `IMPORT`.
-- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/cloud/current/sr/schema-linking.html). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when importing.
+- `force` - (Optional Boolean) An optional flag to force a mode change even if the Schema Registry has existing schemas. This can be useful in disaster recovery (DR) scenarios using [Schema Linking](https://docs.confluent.io/cloud/current/sr/schema-linking.html). Defaults to `false`, which does not allow a mode change to `IMPORT` if Schema Registry has registered schemas. Must be unset when using `terraform import`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Clarify the `force` argument on `confluent_schema_registry_cluster_mode`. It ended with "Must be unset when importing," which is ambiguous on a page that also discusses SR `IMPORT` mode. Changed to "Must be unset when using `terraform import`."

Jira: https://confluentinc.atlassian.net/browse/DOCS-39436
