### PR TITLE
[INC-12169]Add Computed annotation for the distribution block and individual fields

### DIFF
--- a/docs/data-sources/confluent_flink_materialized_table.md
+++ b/docs/data-sources/confluent_flink_materialized_table.md
@@ -111,7 +111,7 @@ In addition to the preceding arguments, the following attributes are exported:
 - `watermark` - (Configuration Block) The watermark definition for the Materialized Table. Supports the following:
     - `column` - (String) The name of the watermark column.
     - `expression` - (String) The watermark expression.
-- `distribution` - (Configuration Block) The distribution definition for the Materialized Table. Supports the following:
+- `distribution` - (Configuration Block) The distribution definition for the Materialized Table. This value could be derived automatically by Confluent Cloud (for example, from the query's primary key when a `GROUP BY` is present). Supports the following:
     - `keys` - (Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Integer) The number of buckets the table is distributed by.
 - `stopped` - (Boolean) Whether the Materialized Table is stopped.

--- a/docs/resources/confluent_flink_materialized_table.md
+++ b/docs/resources/confluent_flink_materialized_table.md
@@ -136,10 +136,10 @@ The following arguments are supported:
 - `watermark` - (Optional Configuration Block, max 1 item) The watermark definition for the Materialized Table. Supports the following:
     - `column` - (Optional String) The name of the watermark column.
     - `expression` - (Optional String) The watermark expression, for example, `event_time - INTERVAL '5' SECOND`.
-- `distribution` - (Optional Configuration Block, max 1 item) The distribution definition for the Materialized Table. Supports the following:
+- `distribution` - (Optional Configuration Block, max 1 item) The distribution definition for the Materialized Table. If omitted, Confluent Cloud could derive it automatically (for example, from the query's primary key when a `GROUP BY` is present) and populate it in state. Supports the following:
     - `keys` - (Optional Set of Strings) The names of the columns the table is distributed by.
     - `bucket_count` - (Optional Integer) The number of buckets the table is distributed by.
-- `stopped` - (Optional Boolean) Indicates whether the Materialized Table is stopped. Defaults to `false`. Update it to `true` to stop the Materialized Table. Subsequently update it to `false` to resume it.
+- `stopped` - (Optional Boolean) Indicates whether the Materialized Table is stopped. Defaults to `false`. Update it to `true` to stop the Materialized Table; subsequently update it to `false` to resume it.
 - `rest_endpoint` - (Optional String) The REST endpoint of the Flink region, for example, `https://flink.us-east-1.aws.confluent.cloud`.
 - `credentials` (Optional Configuration Block) supports the following:
     - `key` - (Required String) The Flink API Key.

--- a/internal/provider/data_source_flink_materialized_table.go
+++ b/internal/provider/data_source_flink_materialized_table.go
@@ -43,14 +43,12 @@ func flinkMaterializedTableDataSource() *schema.Resource {
 			},
 			paramWatermark:    watermarkSchemaDataSource(),
 			paramDistribution: distributionSchemaDataSource(),
-
 			paramStopped: {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			paramColumns:     columnsSchemaDataSource(),
-			paramConstraints: constraintsSchemaDataSource(),
-
+			paramColumns:      columnsSchemaDataSource(),
+			paramConstraints:  constraintsSchemaDataSource(),
 			paramOrganization: optionalIdBlockSchema(),
 			paramEnvironment:  optionalIdBlockSchema(),
 			paramComputePool:  optionalIdBlockSchemaUpdatable(),

--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -220,8 +220,9 @@ func distributionSchema() *schema.Schema {
 		Type:        schema.TypeList,
 		MaxItems:    1,
 		Optional:    true,
+		Computed:    true,
 		ForceNew:    true,
-		Description: "The distribution definition for the materialized table.",
+		Description: "The distribution definition for the materialized table. If omitted, Confluent Cloud could derive it from the query automatically.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				paramDistributionKeys: {
@@ -229,12 +230,14 @@ func distributionSchema() *schema.Schema {
 					Elem:        &schema.Schema{Type: schema.TypeString},
 					Description: "The names of the columns the table is distributed by.",
 					Optional:    true,
+					Computed:    true,
 					ForceNew:    true,
 				},
 				paramDistributionBucketCount: {
 					Type:        schema.TypeInt,
 					Description: "The number of buckets the table is distributed by.",
 					Optional:    true,
+					Computed:    true,
 					ForceNew:    true,
 				},
 			},

--- a/internal/provider/resource_flink_materialized_table_live_test.go
+++ b/internal/provider/resource_flink_materialized_table_live_test.go
@@ -76,6 +76,10 @@ func TestAccFlinkMaterializedTableLive(t *testing.T) {
 
 	randomSuffix := rand.Intn(100000)
 	tableDisplayName := fmt.Sprintf("tf_live_mat_table_%d", randomSuffix)
+	// A distinct name for the GROUP BY step. Because display_name is ForceNew, using a new
+	// name recreates the table as a fresh create rather than an in-place update, which avoids
+	// Flink's schema-evolution restrictions (dropping persisted columns, etc.).
+	groupByTableDisplayName := fmt.Sprintf("tf_live_mat_table_gb_%d", randomSuffix)
 	tableResourceLabel := "test_live_flink_materialized_table"
 	saResourceLabel := "live_flink_mt_sa"
 	poolResourceLabel := "live_flink_mt_pool"
@@ -130,6 +134,30 @@ func TestAccFlinkMaterializedTableLive(t *testing.T) {
 					testAccCheckFlinkMaterializedTableLiveExists(fullTableResourceLabel),
 					resource.TestCheckResourceAttr(fullTableResourceLabel, paramDisplayName, tableDisplayName),
 					resource.TestCheckResourceAttr(fullTableResourceLabel, paramStopped, "true"),
+				),
+			},
+			{
+				// Regression coverage for server-derived distribution: a GROUP BY query gives the
+				// table a primary key, so Confluent Cloud derives a `distribution` even though the
+				// config omits it. The config never declares `distribution`, so the framework's
+				// post-apply plan check also asserts the resource is NOT recreated on the next plan
+				// (the bug fixed by marking `distribution` Optional+Computed).
+				Config: testAccCheckFlinkMaterializedTableLiveConfig(
+					endpoint, apiKey, apiSecret, region, kafkaClusterId,
+					saResourceLabel, poolResourceLabel, apiKeyResourceLabel,
+					flinkRegionId, flinkRegionRestEndpoint,
+					tableResourceLabel, groupByTableDisplayName, randomSuffix,
+					"SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id",
+					false,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlinkMaterializedTableLiveExists(fullTableResourceLabel),
+					resource.TestCheckResourceAttr(fullTableResourceLabel, paramDisplayName, groupByTableDisplayName),
+					// The server-derived distribution must be populated in state even though the config omitted it.
+					resource.TestCheckResourceAttr(fullTableResourceLabel, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(fullTableResourceLabel, "distribution.0.keys.#", "1"),
+					resource.TestCheckTypeSetElemAttr(fullTableResourceLabel, "distribution.0.keys.*", "customer_id"),
+					resource.TestCheckResourceAttrSet(fullTableResourceLabel, "distribution.0.bucket_count"),
 				),
 			},
 			{

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -431,3 +431,126 @@ func testAccCheckMaterializedTableDestroy(s *terraform.State, url string) error 
 	}
 	return nil
 }
+
+// TestAccFlinkMaterializedTableServerDerivedDistribution is a regression test for the bug where a
+// server-derived `distribution` (populated by Confluent Cloud when the query has a primary key,
+// e.g. a GROUP BY) forced the resource to be recreated on every apply because the config omits the
+// `distribution` block. The provider only ever sees the API response, not the query semantics, so
+// the invariant under test is purely provider-side: when the read response contains a
+// `distribution` that the config did not declare, the plan must be empty (no destroy-and-recreate).
+// The distribution values below mirror a real server response (bucket_count=6, keys=[customer_id]).
+// Before marking `distribution` (and its keys/bucket_count) Optional+Computed, the second PlanOnly
+// step below would show a `-/+` replacement and fail.
+func TestAccFlinkMaterializedTableServerDerivedDistribution(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockTestServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	const scenarioName = "confluent_flink_materialized_table Server-Derived Distribution"
+	const groupByDisplayName = "table_group_by"
+	readGroupByPath := fmt.Sprintf("/sql/v1/organizations/%s/environments/%s/databases/%s/materialized-tables/%s", flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkMaterializedTableDatabase, groupByDisplayName)
+
+	createResponse, _ := os.ReadFile("../testdata/flink_materialized_table/create_materialized_table_server_derived_distribution.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	readResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_materialized_table_server_derived_distribution.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readGroupByPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusOK))
+
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readGroupByPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+
+	readDeletedResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_deleted_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readGroupByPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn(string(readDeletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	resourceLabel := "test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_materialized_table.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckMaterializedTableDestroy(s, mockTestServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				// The config omits `distribution` entirely; the server response supplies it.
+				Config: testAccCheckMaterializedTableServerDerivedDistributionConfig(mockTestServerUrl, resourceLabel, groupByDisplayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramDisplayName, groupByDisplayName),
+					// The server-derived distribution must land in state even though the config omitted it.
+					resource.TestCheckResourceAttr(fullResourceLabel, "distribution.#", "1"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "distribution.0.bucket_count", "6"),
+					resource.TestCheckResourceAttr(fullResourceLabel, "distribution.0.keys.#", "1"),
+					resource.TestCheckTypeSetElemAttr(fullResourceLabel, "distribution.0.keys.*", "customer_id"),
+				),
+			},
+			{
+				// Re-planning the same config (still omitting `distribution`) must be a no-op.
+				// Without distribution being Optional+Computed, this produces a `-/+` replacement and fails.
+				Config:   testAccCheckMaterializedTableServerDerivedDistributionConfig(mockTestServerUrl, resourceLabel, groupByDisplayName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMaterializedTableServerDerivedDistributionConfig(mockServerUrl, resourceLabel, displayName string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+    	endpoint = "%s"
+	}
+
+	resource "confluent_flink_materialized_table" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+      display_name  = "%s"
+	  kafka_cluster {
+	    id = "%s"
+	  }
+      stopped = false
+	  query = "SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;"
+	  # NOTE: no distribution block on purpose - Confluent Cloud derives it from the query's primary key.
+}
+	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
+}

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -512,8 +512,9 @@ func TestAccFlinkMaterializedTableServerDerivedDistribution(t *testing.T) {
 			{
 				// Re-planning the same config (still omitting `distribution`) must be a no-op.
 				// Without distribution being Optional+Computed, this produces a `-/+` replacement and fails.
-				Config:   testAccCheckMaterializedTableServerDerivedDistributionConfig(mockTestServerUrl, resourceLabel, groupByDisplayName),
-				PlanOnly: true,
+				Config:             testAccCheckMaterializedTableServerDerivedDistributionConfig(mockTestServerUrl, resourceLabel, groupByDisplayName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})

--- a/internal/testdata/flink_materialized_table/create_materialized_table_server_derived_distribution.json
+++ b/internal/testdata/flink_materialized_table/create_materialized_table_server_derived_distribution.json
@@ -1,0 +1,30 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_group_by",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {},
+    "session_options": {},
+    "distribution": {
+      "keys": [
+        "customer_id"
+      ],
+      "bucket_count": 6
+    },
+    "query": "SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_group_by AS SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/read_materialized_table_server_derived_distribution.json
+++ b/internal/testdata/flink_materialized_table/read_materialized_table_server_derived_distribution.json
@@ -1,0 +1,30 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_group_by",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {},
+    "session_options": {},
+    "distribution": {
+      "keys": [
+        "customer_id"
+      ],
+      "bucket_count": 6
+    },
+    "query": "SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;"
+  },
+  "status": {
+    "phase": "RUNNING",
+    "detail": "Materialized table is running.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_group_by AS SELECT customer_id, COUNT(*) AS order_count FROM examples.marketplace.orders GROUP BY customer_id;",
+    "scaling_status": {},
+    "version": 1
+  }
+}


### PR DESCRIPTION
Release Notes
---------
<!-- If this PR introduces any user-facing changes, document them below as a summary. Delete unused section titles and placeholders. Match the style of previous release notes: https://github.com/confluentinc/terraform-provider-confluent/releases -->

New Features
- [Briefly describe new features introduced in this PR].

Bug Fixes
- Fixed a bug that triggers Terraform state drift for `confluent_flink_materialized_table` resource.

Examples
- [Briefly describe any Terraform configuration example updates in this PR].

Checklist
---------
<!-- 
Check each item in the checklist to ensure high-quality Terraform development practices are followed. PR approval won't be granted until the checklist is carefully reviewed.
-->
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
<!--
Briefly describe **what** you have changed and **why** these changes are necessary.
Optionally include: 
- The problem being solved or the feature being added. 
- The implementation strategy or approach taken. 
- Key technical details, design decisions, or any additional context reviewers should be aware of.
-->
Fix the missing `Computed: True` schema annotation for `confluent_flink_materialized_table` resource, `distribution` block causes Terraform state drift when the Flink backend server can derive `distribution` block field values from the query, such as when the query has `GROUP BY` clause.

Add the associated acceptance and live tests as well.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using `confluent_kafka_cluster` resource/data-source will be blocked.
- Confluent Cloud customers who are using `confluent_schema` resource for schema validation will be blocked.
- All customers who are using `terraform import` function for resources will be impacted.
-->
The users using `confluent_flink_materialized_table` resource will get impacted.

References
----------
<!-- Include links to relevant resources for this PR, such as: 
- Related GitHub issues 
- Tickets (JIRA, etc.) 
- Internal documentation or design specs 
- Other related PRs 
Copy and paste the links below for easy reference.
-->
JIRA
https://confluentinc.atlassian.net/browse/INC-12169

Slack Thread
https://confluent.slack.com/archives/C0BHJBBLL5T/p1784240921519659?thread_ts=1784223474.464269&cid=C0BHJBBLL5T

Test & Review
-------------
<!-- Has this PR been tested? If so, explain **how** it was tested. Include: 
- Steps taken to verify the changes. 
- Links to manual verification documents, logs, or screenshots to save reviewers' time. 
- Any additional notes on testing (e.g., environments used, edge cases tested). 
- Screenshot showing successful resource creation.
Example: - [Manual Verification Document](https://docs.google.com/document/d/1dutVZmbEwJBBqMzx57uCXqllV1SEr2vxnjUrtTPCwBk/edit?tab=t.0#heading=h.6zajc95mev5j)
-->
Validation result can be found here:
https://confluent.slack.com/archives/C02TG07V058/p1784328958370269