### PR TITLE
Add error_message to confluent_connect_artifact resource/data source

### DIFF
--- a/docs/data-sources/confluent_connect_artifact.md
+++ b/docs/data-sources/confluent_connect_artifact.md
@@ -60,3 +60,5 @@ In addition to the arguments listed above, the following computed attributes are
 * `display_name` - (String) The unique name of the Connect Artifact per cloud, environment scope.
 * `content_format` - (String) Archive format of the Connect Artifact. Supported formats are `JAR` and `ZIP`.
 * `description` - (String) Description of the Connect Artifact.
+* `status` - (String) Status of the Connect Artifact.
+* `error_message` - (String) An error message for the Connect Artifact when the status is `FAILED`.

--- a/docs/resources/confluent_connect_artifact.md
+++ b/docs/resources/confluent_connect_artifact.md
@@ -46,6 +46,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `id` - (String) The ID of the Connect Artifact.
+* `status` - (String) Status of the Connect Artifact.
+* `error_message` - (String) An error message for the Connect Artifact when the status is `FAILED`.
 
 ## Import
 

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -385,6 +385,7 @@ const (
 	paramEnvironment                                     = "environment"
 	paramEnvironments                                    = "environments"
 	paramErrorHandling                                   = "error_handling"
+	paramErrorMessage                                    = "error_message"
 	paramExpirationDates                                 = "expiration_dates"
 	paramExpiresAt                                       = "expires_at"
 	paramExpr                                            = "expr"

--- a/internal/provider/data_source_connect_artifact.go
+++ b/internal/provider/data_source_connect_artifact.go
@@ -53,6 +53,16 @@ func connectArtifactDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "Description of the Connect Artifact.",
 			},
+			paramStatus: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of the Connect Artifact.",
+			},
+			paramErrorMessage: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An error message for the Connect Artifact when the status is FAILED.",
+			},
 		},
 	}
 }

--- a/internal/provider/resource_connect_artifact.go
+++ b/internal/provider/resource_connect_artifact.go
@@ -84,6 +84,11 @@ func connectArtifactResource() *schema.Resource {
 				Computed:    true,
 				Description: "Status of the Connect Artifact.",
 			},
+			paramErrorMessage: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An error message for the Connect Artifact when the status is FAILED.",
+			},
 		},
 	}
 }
@@ -249,6 +254,13 @@ func setConnectArtifactAttributes(d *schema.ResourceData, artifact camv1.CamV1Co
 		}
 	}
 
+	// Set the error_message attribute if it exists in the schema
+	if _, ok := d.GetOk(paramErrorMessage); ok && artifact.Status != nil {
+		if err := d.Set(paramErrorMessage, artifact.Status.GetErrorMessage()); err != nil {
+			return nil, err
+		}
+	}
+
 	d.SetId(artifact.GetId())
 
 	return d, nil
@@ -341,7 +353,7 @@ func connectArtifactProvisionStatus(ctx context.Context, c *Client, environmentI
 		if phase == stateProcessing || phase == stateWaitingForProcessing || phase == stateProvisioning || phase == stateProvisioned || phase == stateReady {
 			return artifact, phase, nil
 		} else if phase == stateFailed {
-			return nil, stateFailed, fmt.Errorf("connect artifact %q provisioning status is %q", artifactId, stateFailed)
+			return nil, stateFailed, fmt.Errorf("connect artifact %q provisioning status is %q: %s", artifactId, stateFailed, artifact.Status.GetErrorMessage())
 		}
 		// Connect Artifact is in an unexpected state
 		return nil, stateUnexpected, fmt.Errorf("connect artifact %q is in an unexpected state %q", artifactId, phase)


### PR DESCRIPTION
## Summary
Surfaces the new `error_message` field from `CamV1ConnectArtifactStatus` (Connect Artifact) so users see why artifact inspection failed instead of just `status: FAILED`. Also adds the `status` attribute to the data source (`data_source_connect_artifact.go`), which didn't expose it at all before, and threads the error message into the provisioning-failure error so `terraform apply` shows the actual reason.

## Note
Draft: this depends on a `ccloud-sdk-go-v2/cam` bump that hasn't been released yet, so it won't build until that lands. Opening early for review of the provider-side change itself.

Jira: CC-40048

## Test plan
- [ ] Update acceptance tests / recorded fixtures once the SDK bump lands