### PR TITLE
Sync confluent_identity_provider data source with cli-terraform-generator's display-name lookup refactor

### DIFF
--- a/internal/provider/data_source_identity_provider.go
+++ b/internal/provider/data_source_identity_provider.go
@@ -91,25 +91,29 @@ func identityProviderDataSourceReadUsingDisplayName(ctx context.Context, d *sche
 	if err != nil {
 		return diag.Errorf("error reading identity provider %q: %s", displayName, createDescriptiveError(err))
 	}
-	var matchedIdentityProvider identityproviderv2.IamV2IdentityProvider
-	matchCount := 0
-	for _, identityProvider := range identityProviders {
-		if identityProvider.GetDisplayName() == displayName {
-			matchedIdentityProvider = identityProvider
-			matchCount++
-		}
-	}
-	if matchCount == 0 {
-		return diag.Errorf("error reading identity provider: identity provider with %q=%q was not found", paramDisplayName, displayName)
-	}
-	if matchCount > 1 {
+	if hasMultipleIdentityProvidersWithDisplayName(identityProviders, displayName) {
 		return diag.Errorf("error reading identity provider: there are multiple identity providers with %q=%q", paramDisplayName, displayName)
 	}
-
-	if _, err := setIdentityProviderAttributes(d, matchedIdentityProvider); err != nil {
-		return diag.FromErr(createDescriptiveError(err))
+	for _, identityProvider := range identityProviders {
+		if identityProvider.GetDisplayName() == displayName {
+			if _, err := setIdentityProviderAttributes(d, identityProvider); err != nil {
+				return diag.FromErr(createDescriptiveError(err))
+			}
+			return nil
+		}
 	}
-	return nil
+
+	return diag.Errorf("error reading identity provider: identity provider with %q=%q was not found", paramDisplayName, displayName)
+}
+
+func hasMultipleIdentityProvidersWithDisplayName(identityProviders []identityproviderv2.IamV2IdentityProvider, displayName string) bool {
+	count := 0
+	for _, identityProvider := range identityProviders {
+		if identityProvider.GetDisplayName() == displayName {
+			count += 1
+		}
+	}
+	return count > 1
 }
 
 func identityProviderDataSourceReadUsingId(ctx context.Context, d *schema.ResourceData, meta interface{}, identityProviderId string) diag.Diagnostics {


### PR DESCRIPTION
Release Notes
---------

No user-facing release notes — this is an internal codegen sync with no behavior changes.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent. (`go build ./...` succeeds)
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. (n/a — no new functionality, pure refactor)
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (n/a)
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results. (n/a — no new API calls)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR. (n/a — docs/schema unchanged)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (n/a — no new backend API surface, this only changes how the existing `confluent_identity_provider` data source's display-name lookup is implemented)
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`confluent_service_account` (#1046/#1049/#1051), `confluent_identity_provider` (#1053), `confluent_role_binding` (#1055), and `confluent_group_mapping` (#1058) were all previously migrated to generated code via `cli-terraform-generator`. To check for drift since those migrations, I regenerated all four from the current `cli-terraform-generator` (`main`) into a scratch branch and diffed against committed code.

Result: every resource/data-source `.go` file regenerated byte-identical **except** `data_source_identity_provider.go`. This PR isolates just that one file; tests, live tests, docs, and fixtures are intentionally left untouched (reverted back to committed versions after the full regen) to keep this scoped to the one real diff.

The change: `identityProviderDataSourceReadUsingDisplayName`'s duplicate-match check (previously an inline `matchCount`/`matchedIdentityProvider` loop) is now extracted into a dedicated `hasMultipleIdentityProvidersWithDisplayName(...)` helper — the same shape `data_source_group_mapping.go` already has (`hasMultipleGroupMappingsWithDisplayName`). The generator's template for this was refactored in `cli-terraform-generator` commit `51578cc` ("Fix nested-object docs/tests and add SDK-aware display_name lookup fallback", confluentinc/cli-terraform-generator#241), which landed after `confluent_identity_provider`'s original migration (#1053) but before `confluent_group_mapping`'s (#1058) — this PR just brings `identity_provider` in line with the generator's current output.

Behavior changes: None. Not-found / multiple-match / success semantics are byte-for-byte identical to the previous implementation, confirmed via diff — this is purely a code-structure refactor (extracting a helper function), not a logic change.

Not changed: `resource_identity_provider.go` (unaffected by this refactor), tests, live tests, docs, fixtures.

Blast Radius
----
Scoped entirely to `confluent_identity_provider` data source's `display_name` lookup path (used only when looking up by `display_name` instead of `id`). Since the change is a behavior-preserving refactor, risk is minimal — if something is wrong, it would surface as an error looking up `confluent_identity_provider` data sources by `display_name`.

References
----------
- confluentinc/cli-terraform-generator#241

Test & Review
-------------
* **Manual verification**: https://confluent.slack.com/archives/C02TG07V058/p1784674516765829
* **Automated verification**: existing acceptance and live tests for `confluent_identity_provider` are unmodified by this PR (not regenerated — `--skip-acceptance-test`/`--skip-live-test` equivalent, reverted after the drift-check regen):
  - `TestAccIdentityProvider` (`resource_identity_provider_test.go`)
  - `TestAccDataSourceIdentityProvider` (`data_source_identity_provider_test.go`)
  - `TestAccIdentityProviderLive` / `TestAccDataSourceIdentityProviderLive` (live tests, build tags `live_test`)
  - `TestAccIdentityProviderDriftDetection` (`resource_identity_provider_drift_test.go`)