### PR TITLE
#minor Prepare for 2.79.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 [Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.78.0...v2.79.0)
 
 **Bug fixes:**
-* Resolved 14 Dependabot alerts ([#1047](https://github.com/confluentinc/terraform-provider-confluent/issues/1047)).
+* Fixed a bug that caused Terraform state drift for the `confluent_flink_materialized_table` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_materialized_table) by adding the missing `Computed` annotation to the `distribution` block.
 
 ## 2.78.0 (July 13th, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.79.0 (July 22nd, 2026)
+
+[Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.78.0...v2.79.0)
+
+**Bug fixes:**
+* Resolved 14 Dependabot alerts ([#1047](https://github.com/confluentinc/terraform-provider-confluent/issues/1047)).
+
 ## 2.78.0 (July 13th, 2026)
 
 [Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.77.0...v2.78.0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/advanced-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/authentication-using-oauth/azure-entra-id/main.tf
+++ b/examples/configurations/authentication-using-oauth/azure-entra-id/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/authentication-using-oauth/okta/main.tf
+++ b/examples/configurations/authentication-using-oauth/okta/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/authentication-using-oauth/schema-exporter/main.tf
+++ b/examples/configurations/authentication-using-oauth/schema-exporter/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/azure-key-vault/main.tf
+++ b/examples/configurations/azure-key-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/basic-kafka-acls-with-alias/main.tf
+++ b/examples/configurations/basic-kafka-acls-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/basic-kafka-acls/main.tf
+++ b/examples/configurations/basic-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/cloud-importer/main.tf
+++ b/examples/configurations/cloud-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
+++ b/examples/configurations/cluster-link-over-aws-private-link-networks/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
 
     aws = {

--- a/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/advanced-bidirectional-cluster-link-using-oauth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/destination-initiated-cluster-link-using-oauth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
+++ b/examples/configurations/cluster-link-using-oauth/regular-bidirectional-cluster-link-using-oauth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connect-artifact/main.tf
+++ b/examples/configurations/connect-artifact/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/custom-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/custom-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/dynamo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
+++ b/examples/configurations/connectors/elasticsearch-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/manage-offsets-github-source-connector/main.tf
+++ b/examples/configurations/connectors/manage-offsets-github-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/manage-offsets-mongo-db-source-connector/main.tf
+++ b/examples/configurations/connectors/manage-offsets-mongo-db-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/manage-offsets-mysql-sink-connector/main.tf
+++ b/examples/configurations/connectors/manage-offsets-mysql-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/managed-datagen-source-connector/main.tf
+++ b/examples/configurations/connectors/managed-datagen-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-sink-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/mongo-db-source-connector/main.tf
+++ b/examples/configurations/connectors/mongo-db-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/postgre-sql-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/s3-sink-connector-assume-role/main.tf
+++ b/examples/configurations/connectors/s3-sink-connector-assume-role/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/s3-sink-connector/main.tf
+++ b/examples/configurations/connectors/s3-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/snowflake-sink-connector/main.tf
+++ b/examples/configurations/connectors/snowflake-sink-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
+++ b/examples/configurations/connectors/sql-server-cdc-debezium-source-connector/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
+++ b/examples/configurations/create-default-topic-and-return-kafka-api-keys-to-consume-and-produce/confluent_kafka_topic_api_keys_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-private-service-connect-gcp-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-aws-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-privatelink-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-aws-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
 
     aws = {

--- a/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-azure-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
 
     azurerm = {

--- a/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-gcp-byok-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
 
     google = {

--- a/examples/configurations/dedicated-public-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-public-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-public-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-public-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-transit-gateway-attachment-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vnet-peering-azure-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-aws-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-gcp-kafka-rbac/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
+++ b/examples/configurations/dedicated-vpc-peering-v2-aws-kafka-acls/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/destination-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/dns-forwarder/main.tf
+++ b/examples/configurations/dns-forwarder/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/enterprise-ingress-azure/main.tf
+++ b/examples/configurations/enterprise-ingress-azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/enterprise-ingress-gcp/main.tf
+++ b/examples/configurations/enterprise-ingress-gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
+++ b/examples/configurations/enterprise-pni-aws-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/configurations/enterprise-pni-aws-kafka-rbac/outputs.tf
+++ b/examples/configurations/enterprise-pni-aws-kafka-rbac/outputs.tf
@@ -65,7 +65,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-aws-kafka-acls/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
+++ b/examples/configurations/enterprise-privatelinkattachment-azure-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
 
     azurerm = {

--- a/examples/configurations/field-level-encryption-schema/main.tf
+++ b/examples/configurations/field-level-encryption-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/flink-carry-over-offset-between-statements/main.tf
+++ b/examples/configurations/flink-carry-over-offset-between-statements/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/flink-connection/main.tf
+++ b/examples/configurations/flink-connection/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/flink-quickstart-2/main.tf
+++ b/examples/configurations/flink-quickstart-2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/flink-quickstart/main.tf
+++ b/examples/configurations/flink-quickstart/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/flink_artifact/main.tf
+++ b/examples/configurations/flink_artifact/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/freight-aws-kafka-rbac/main.tf
+++ b/examples/configurations/freight-aws-kafka-rbac/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/configurations/freight-aws-kafka-rbac/outputs.tf
+++ b/examples/configurations/freight-aws-kafka-rbac/outputs.tf
@@ -65,7 +65,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/hashicorp-vault/main.tf
+++ b/examples/configurations/hashicorp-vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
     vault = {
       source  = "hashicorp/vault"

--- a/examples/configurations/kafka-importer/main.tf
+++ b/examples/configurations/kafka-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/env-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-env-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-admin-product-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
+++ b/examples/configurations/kafka-ops-kafka-admin-product-team/kafka-ops-team/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/ksql-acls/main.tf
+++ b/examples/configurations/ksql-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/ksql-rbac/main.tf
+++ b/examples/configurations/ksql-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
+++ b/examples/configurations/manage-topics-via-json/confluent_kafka_topics_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/managing-single-kafka-cluster/main.tf
+++ b/examples/configurations/managing-single-kafka-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/managing-single-schema-registry-cluster/main.tf
+++ b/examples/configurations/managing-single-schema-registry-cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-avro-schema/main.tf
+++ b/examples/configurations/multiple-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/multiple-event-types-proto-schema/main.tf
+++ b/examples/configurations/multiple-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/network-access-point-gcp-private-service-connect/main.tf
+++ b/examples/configurations/network-access-point-gcp-private-service-connect/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/private-flink-quickstart/main.tf
+++ b/examples/configurations/private-flink-quickstart/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/private-link-schema-registry/main.tf
+++ b/examples/configurations/private-link-schema-registry/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/provider-integration-aws/main.tf
+++ b/examples/configurations/provider-integration-aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
+++ b/examples/configurations/regular-bidirectional-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/schema-linking/main.tf
+++ b/examples/configurations/schema-linking/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/schema-registry-importer/main.tf
+++ b/examples/configurations/schema-registry-importer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-avro-schema/main.tf
+++ b/examples/configurations/single-event-types-avro-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
+++ b/examples/configurations/single-event-types-proto-schema-with-alias/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/single-event-types-proto-schema/main.tf
+++ b/examples/configurations/single-event-types-proto-schema/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/source-initiated-cluster-link-rbac/main.tf
+++ b/examples/configurations/source-initiated-cluster-link-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-acls/main.tf
+++ b/examples/configurations/standard-kafka-acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/standard-kafka-rbac/main.tf
+++ b/examples/configurations/standard-kafka-rbac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/stream-catalog/main.tf
+++ b/examples/configurations/stream-catalog/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/tableflow/byob-aws-storage/main.tf
+++ b/examples/configurations/tableflow/byob-aws-storage/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/tableflow/confluent-managed-storage/main.tf
+++ b/examples/configurations/tableflow/confluent-managed-storage/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/tableflow/datagen-connector-byob-aws-storage/main.tf
+++ b/examples/configurations/tableflow/datagen-connector-byob-aws-storage/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/tableflow/datagen-connector-confluent-managed-storage/main.tf
+++ b/examples/configurations/tableflow/datagen-connector-confluent-managed-storage/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
+++ b/examples/configurations/topic-as-a-service/topic_as_a_service_module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = "2.78.0"
+      version = "2.79.0"
     }
   }
 }

--- a/internal/provider/resource_tf_importer.go
+++ b/internal/provider/resource_tf_importer.go
@@ -579,7 +579,7 @@ func createHclFileWithHeader(mode ImporterMode) *hclwrite.File {
 	requiredProvidersBlock := tfBlock.Body().AppendNewBlock("required_providers", nil)
 	requiredProvidersBlock.Body().SetAttributeValue("confluent", zclCty.ObjectVal(map[string]zclCty.Value{
 		"source":  zclCty.StringVal("confluentinc/confluent"),
-		"version": zclCty.StringVal("2.78.0"),
+		"version": zclCty.StringVal("2.79.0"),
 	}))
 
 	providerBlock := body.AppendNewBlock("provider", []string{"confluent"})


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed a bug that caused Terraform state drift for the `confluent_flink_materialized_table` resource by adding the missing `Computed` annotation to the `distribution` block ([#1060](https://github.com/confluentinc/terraform-provider-confluent/pull/1060)).

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [ ] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
This is a release PR, the checklist items above don't apply.

Bumps the provider version references (`docs/index.md`, `examples/**/main.tf`, `internal/provider/resource_tf_importer.go`) from `2.78.0` to `2.79.0` and adds the corresponding `CHANGELOG.md` entry.

Blast Radius
----
None. Version string bump and changelog only — no provider resource/data-source code changes.

References
----------
- https://github.com/confluentinc/terraform-provider-confluent/pull/1060

Test & Review
-------------
