### PR TITLE
INC-12271: Fix missing comma in composite literal in kafka cluster live test

### DIFF
--- a/internal/provider/resource_kafka_cluster_live_test.go
+++ b/internal/provider/resource_kafka_cluster_live_test.go
@@ -581,7 +581,7 @@ func TestAccKafkaClusterDeletionProtectionTrueLive(t *testing.T) {
 					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "deletion_protection", "false"),
 				),
-			}
+			},
 		},
 	})
 }


### PR DESCRIPTION
Release Notes
---------

No user-facing changes. Internal test-only fix.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`internal/provider/resource_kafka_cluster_live_test.go` had a missing comma after the last `TestStep` element in the composite literal inside `TestAccKafkaClusterDeletionProtectionTrueLive`. This is a compile-time syntax error (`missing ',' before newline in composite literal`), which broke compilation of the entire `internal/provider` package and caused `make live-test` to fail with a setup error before any tests could run.

Fix: added the missing trailing comma.

Blast Radius
----
None. This only fixes a compile error in a test file; it does not touch any resource/data source implementation, so there is no runtime or customer impact. Prior to this fix, `make live-test` could not run at all because the package failed to build.

References
----------
N/A

Test & Review
-------------
- Ran `gofmt -l internal/provider/resource_kafka_cluster_live_test.go` — no formatting issues.
- Ran `go vet ./internal/provider/...` — passes cleanly.
- Confirmed the package now compiles (previously failed with `missing ',' before newline in composite literal`).