### PR TITLE
Fix "400 Bad Request: Cannot create Enterprise clusters with low durability" in Kafka cluster deletion protection live test

### DIFF
--- a/internal/provider/resource_kafka_cluster_live_test.go
+++ b/internal/provider/resource_kafka_cluster_live_test.go
@@ -572,6 +572,8 @@ func TestAccKafkaClusterDeletionProtectionTrueLive(t *testing.T) {
 					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "display_name", clusterDisplayName),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "deletion_protection", "true"),
+					// Enterprise clusters require high-durability availability; guards against regressing to SINGLE_ZONE.
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "HIGH"),
 				),
 			},
 			{
@@ -580,6 +582,7 @@ func TestAccKafkaClusterDeletionProtectionTrueLive(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel)),
 					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "deletion_protection", "false"),
+					resource.TestCheckResourceAttr(fmt.Sprintf("confluent_kafka_cluster.%s", clusterResourceLabel), "availability", "HIGH"),
 				),
 			},
 		},

--- a/internal/provider/resource_kafka_cluster_live_test.go
+++ b/internal/provider/resource_kafka_cluster_live_test.go
@@ -1077,7 +1077,7 @@ func testAccCheckKafkaClusterDeletionProtectionLiveConfig(endpoint, environmentR
 
 	resource "confluent_kafka_cluster" "%s" {
 		display_name        = "%s"
-		availability        = "SINGLE_ZONE"
+		availability        = "HIGH"
 		cloud               = "AWS"
 		region              = "us-east-1"
 		enterprise {max_ecku     = 5}


### PR DESCRIPTION
Release Notes
---------

New Features
- N/A

Bug Fixes
- Fixed `TestAccKafkaClusterDeletionProtectionTrueLive` failing with `400 Bad Request: Cannot create Enterprise clusters with low durability` by changing the test config's `availability` from `SINGLE_ZONE` to `HIGH`, since Enterprise clusters require high-durability availability.

Examples
- N/A

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`TestAccKafkaClusterDeletionProtectionTrueLive` creates an `enterprise` Kafka cluster but its config set `availability = "SINGLE_ZONE"`, which the backend rejects for Enterprise clusters because they require high-durability availability. This PR changes the config to use `availability = "HIGH"`, matching the durability requirements of Enterprise clusters, so the test can create the cluster successfully.

Note on why this wasn't caught earlier: this test was added in #986, but a missing comma in a composite literal broke compilation from the start, so it never actually ran until that syntax bug was fixed in #1064 (2026-07-21). Once the test could finally compile and execute, this pre-existing availability/durability mismatch surfaced for the first time.

Blast Radius
----
Test-only change (`internal/provider/resource_kafka_cluster_live_test.go`). No production code paths are affected; no customer-facing impact.

References
----------
N/A

Test & Review
-------------
Ran `TestAccKafkaClusterDeletionProtectionTrueLive` against Confluent Cloud with `TF_ACC_PROD=1`; cluster creation with `deletion_protection=true` now succeeds, followed by the update to `deletion_protection=false` and cleanup.