### PR TITLE
Show a referenced schema's new version in the first plan

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -269,7 +269,9 @@ func metadataSchema() *schema.Schema {
 
 func SetSchemaDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if !diff.HasChange(paramSchema) {
-		return nil
+		// The schema definition itself is unchanged, but a change of the references / ruleset / metadata
+		// still re-registers the schema (see schemaUpdate()) and therefore still bumps its version.
+		return setSchemaOutputsKnownAfterApply(diff)
 	}
 
 	oldObj, newObj := diff.GetChange(paramSchema)
@@ -353,6 +355,15 @@ func SetSchemaDiff(ctx context.Context, diff *schema.ResourceDiff, meta interfac
 		createSchemaRequest.SetMetadata(*metadata)
 	}
 
+	// A referenced schema that will be (re)registered during the same apply doesn't have its new version yet at
+	// plan time, so schema_reference reads back either as unknown or with a zero version here. Neither the
+	// validation nor the lookup check below can run against a schema version that doesn't exist yet, so skip both:
+	// they run again during apply, once every referenced version is known.
+	if hasUnresolvedSchemaReferences(diff, schemaReferences) {
+		tflog.Debug(ctx, fmt.Sprintf("Skipping validation and lookup checks for Schema %q: it references a schema version that isn't known yet during plan", subjectName))
+		return setSchemaOutputsKnownAfterApply(diff)
+	}
+
 	// SetSchemaDiff() function is invoked during terraform plan
 	// Having schema validation check during plan empowers customers to review schema changes before applying
 	// paramSkipValidationDuringPlan = true -> skipping schema validation during 'terraform plan'
@@ -389,7 +400,63 @@ func SetSchemaDiff(ctx context.Context, diff *schema.ResourceDiff, meta interfac
 	if shouldRecreateOnUpdate && hasSemanticSchemaUpdate {
 		return fmt.Errorf("error updating Schema %q: reimport the current resource instance and set %s = false to evolve a schema using the same resource instance.\nIn this case, on an update resource instance will reference the updated (latest) schema by overriding %s, %s and %s attributes and the old schema will be orphaned.", diff.Id(), paramRecreateOnUpdate, paramSchemaIdentifier, paramSchema, paramVersion)
 	}
+
+	// Deliberately after schemaLookupCheck(): a semantically equivalent schema (see the newline / tab drift
+	// described in https://github.com/confluentinc/terraform-provider-confluent/issues/378) has already been
+	// reverted to its old value at this point, so it's not reported as a version bump.
+	return setSchemaOutputsKnownAfterApply(diff)
+}
+
+// setSchemaOutputsKnownAfterApply marks the attributes that Schema Registry assigns during apply as unknown
+// ("known after apply") whenever the plan implies that the schema will be re-registered.
+//
+// schemaUpdate() forwards a change of paramSchema, paramSchemaReference, paramRuleset or paramMetadata to
+// schemaCreate(), which registers a new schema version, so both paramVersion and paramSchemaIdentifier change.
+// Since both are Computed-only, Terraform otherwise keeps their prior state values throughout the plan, and a
+// resource that interpolates them (most commonly another schema's schema_reference.version) sees no change until
+// the next plan / apply cycle: https://github.com/confluentinc/terraform-provider-confluent/issues/269
+func setSchemaOutputsKnownAfterApply(diff *schema.ResourceDiff) error {
+	// A schema that hasn't been created yet already has unknown computed attributes.
+	if diff.Id() == "" {
+		return nil
+	}
+
+	// recreate_on_update = true rejects a schema update instead of registering a new version (see above).
+	if diff.Get(paramRecreateOnUpdate).(bool) {
+		return nil
+	}
+
+	// These are exactly the attributes that schemaUpdate() forwards to schemaCreate().
+	if !diff.HasChanges(paramSchema, paramSchemaReference, paramRuleset, paramMetadata) {
+		return nil
+	}
+
+	if err := diff.SetNewComputed(paramVersion); err != nil {
+		return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
+	}
+	if err := diff.SetNewComputed(paramSchemaIdentifier); err != nil {
+		return fmt.Errorf("error customizing diff Schema: %s", createDescriptiveError(err))
+	}
 	return nil
+}
+
+// hasUnresolvedSchemaReferences reports whether this schema references another schema whose version isn't known
+// yet during plan, which is the case when the referenced schema is created or updated within the same apply.
+func hasUnresolvedSchemaReferences(diff *schema.ResourceDiff, references []schemaregistryv1.SchemaReference) bool {
+	// An unknown value inside a set makes the whole set unknown, in which case diff.Get(paramSchemaReference)
+	// returned an empty list rather than the configured references.
+	if !diff.NewValueKnown(paramSchemaReference) {
+		return true
+	}
+
+	// Schema Registry versions start at 1, and an unknown version reads back as the zero value of its type, so a
+	// zero version is a reference to a schema version that doesn't exist yet.
+	for _, reference := range references {
+		if reference.GetVersion() == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func schemaLookupCheck(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRegistryRestClient, createSchemaRequest *schemaregistryv1.RegisterSchemaRequest, subjectName, oldSchema string) error {


### PR DESCRIPTION
> **Draft.** This is the fix *pattern*, not a finished change: it builds and vets clean, but it has not been run
> against a real Schema Registry and it doesn't add an acceptance test yet. See "Verified / not verified" below.

## Problem

Addresses #269, which keeps getting reported again (most recently for a PROTOBUF setup with `count` and
`skip_validation_during_plan = true`).

When schema B references schema A:

```hcl
resource "confluent_schema" "b" {
  subject_name = "create_event.proto"
  format       = "PROTOBUF"
  schema       = file("${path.module}/data_contracts/create_event.proto")
  # ...

  schema_reference {
    name         = "affiliate_data.proto"
    subject_name = "affiliate_data.proto"
    version      = confluent_schema.a[0].version
  }
}
```

editing A's definition produces a first plan that updates **only A**. B's `schema_reference.version` interpolates
A's *old* version, which is exactly what's already in B's state, so B shows no diff. The apply registers A's new
version; the *next* plan finally shows a change for B. Reaching the desired state takes two plan/apply cycles,
which is easy to miss in a pipeline.

## Root cause

* `version` and `schema_identifier` are `Computed`-only. Terraform SDKv2 plans a computed attribute as its
  **prior state value** unless the provider explicitly marks it unknown during `CustomizeDiff` — and
  `SetSchemaDiff` never did. There were no `SetNewComputed` calls anywhere in `internal/provider`.
* Both attributes *do* change on apply: `schemaUpdate` forwards a change of `schema`, `schema_reference`,
  `ruleset` or `metadata` to `schemaCreate`, which registers a new schema version.

So the plan is missing a "known after apply" marker on the provider side. It isn't a limitation of how Terraform
core evaluates dependencies during plan — core propagates an unknown into dependent resources fine, it just never
received one here.

## Change

All in `internal/provider/resource_schema.go`.

**1. `setSchemaOutputsKnownAfterApply(diff)`** — marks `version` and `schema_identifier` via `SetNewComputed`
whenever the plan implies the schema will be re-registered. Guards, in order:

* `diff.Id() == ""` → nothing to do, a new resource's computed attributes are already unknown;
* `recreate_on_update = true` → that path errors out instead of registering a new version;
* `HasChanges(schema, schema_reference, ruleset, metadata)` → exactly the set `schemaUpdate` forwards to
  `schemaCreate`, so what the plan marks unknown and what apply actually changes stay in lockstep.

**2. Two call sites, chosen for ordering.**

* At the end of `SetSchemaDiff`, deliberately *after* `schemaLookupCheck` — a semantically equivalent edit
  (the newline / tab drift from #378) has already been reverted to its old value there, so it isn't reported as a
  version bump and doesn't cascade a spurious update to referencing schemas.
* In the early `!HasChange(schema)` return at the top, so a reference chain (C → B → A) still cascades in one
  plan: B's own definition is untouched, only its references changed.

**3. `hasUnresolvedSchemaReferences(diff, references)` + a guard before the validate / lookup block.** This is
what makes (1) shippable rather than a regression. Once A's version is unknown, B's plan reads
`schema_reference` back either as unknown (an unknown inside a `TypeSet` makes the whole set unknown, so
`diff.Get` returns an empty list) or with `version = 0`. `schemaValidateCheck` would then POST a validation
request for a schema version that doesn't exist yet and **fail the plan** — and `skip_validation_during_plan`
defaults to `false`. The guard detects both shapes (`NewValueKnown`, then a zero version — Schema Registry
versions start at 1 and an unknown reads back as its type's zero value) and skips validation *and* lookup. Both
run again during apply, once every referenced version is known.

That's also why the `skip_validation_during_plan = true` workaround suggested on the issue is load-bearing
today, and why it stops being required for this case.

Both shapes reported in #269 are covered: a direct `confluent_schema.a.version` reference, and the
`data.confluent_schema.a` indirection — once `schema_identifier` is unknown, the data source read is deferred to
apply instead of returning the stale version at plan time.

## Verified / not verified

Done: `go build -mod=mod ./internal/provider/`, `go vet -mod=mod ./internal/provider/` (which also compiles the
`_test.go` files) and `gofmt -l` are all clean. (`-mod=mod` only because my local `vendor/` directory is stale —
nothing in this change touches `go.mod`/`go.sum`.)

Not done, on purpose, since this is a draft to show the shape of the fix:

* **The existing schema acceptance tests were not run** — `resource_schema_test.go`,
  `resource_schema_latest_test.go` and `data_source_schema_test.go` need `TF_ACC=1` and WireMock containers, and
  I had no Docker daemon available. They are the cheapest next check: they already exercise `SetSchemaDiff` on
  schema-evolution updates, and the SDKv2 framework asserts an empty plan after every apply step — exactly what
  would catch a spurious `version = (known after apply)`.
* No run against a real Schema Registry, and no `terraform plan` output captured.
* No new acceptance test for the cascade itself. When one is added, that same built-in empty-plan check is the
  whole assertion: a WireMock step with B referencing A, bump A's content, apply once — pre-fix the plan isn't
  empty and the step fails.

## Open questions before this leaves draft

* **Unknowns inside a `TypeSet`.** `schema_reference` is a `TypeSet`, so core will likely render the whole block
  as `(known after apply)` rather than a per-attribute diff, and unknowns-in-sets under SDKv2 are a known source
  of `Provider produced inconsistent final plan`. This is the one place a real two-schema plan/apply could
  surprise us and it should be checked first.
* **`ruleset` / `metadata` in the `HasChanges` list.** Correct in principle (both re-register the schema), but
  `metadata` is `Optional+Computed` with computed sub-attributes — worth confirming it doesn't report a
  steady-state change and pin `version` to `(known after apply)` on every plan.
* **The reference guard skips the `recreate_on_update` plan-time error** while a referenced version is unknown;
  that user now sees the error during apply instead. Acceptable, but it is a behavior change.
