### PR TITLE
[APIE-1308][GH-377] Fix invalid HCL example and document service account name limit

### DIFF
--- a/docs/resources/confluent_private_link_attachment_connection.md
+++ b/docs/resources/confluent_private_link_attachment_connection.md
@@ -28,7 +28,7 @@ resource "confluent_private_link_attachment_connection" "aws" {
   }
 }
 
-resource confluent_private_link_attachment_connection "azure" {
+resource "confluent_private_link_attachment_connection" "azure" {
   display_name = "prod-azure-central-us-az1-connection"
   environment {
     id = "env-12345"
@@ -41,7 +41,7 @@ resource confluent_private_link_attachment_connection "azure" {
   }
 }
 
-resource confluent_private_link_attachment_connection "gcp" {
+resource "confluent_private_link_attachment_connection" "gcp" {
   display_name = "prod-gcp-uscentral1-connection"
   environment {
     id = "env-12345"

--- a/docs/resources/confluent_service_account.md
+++ b/docs/resources/confluent_service_account.md
@@ -26,7 +26,7 @@ resource "confluent_service_account" "example-sa" {
 
 The following arguments are supported:
 
-- `display_name` - (Required String) A human-readable name for the Service Account.
+- `display_name` - (Required String) A human-readable name for the Service Account. Must be 64 characters or fewer.
 - `description` - (Optional String) A free-form description of the Service Account.
 
 ## Attributes Reference


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Fixed invalid HCL (missing quotes around the resource type) in two of the three example blocks in `confluent_private_link_attachment_connection.md`. (APIE-1308)
- Documented the 64-character limit on `confluent_service_account`'s `display_name`, confirmed against the live API. (GH-377)

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

**Unchecked items need human follow-up before merge** — no Go toolchain was available in this environment, so the provider binary itself could not be built, and no Terraform acceptance tests or the Slack testing thread could be done. Both fixes are docs-only, so this is lower-stakes than a code change, but flagging for completeness. Not feature-flagged. Opening as a draft for that reason.

What
----
Two independent, unrelated doc fixes bundled as one small batch, both Confluent Cloud:

1. **APIE-1308** — `docs/resources/confluent_private_link_attachment_connection.md`: the `"azure"` and `"gcp"` example blocks wrote `resource confluent_private_link_attachment_connection "azure" {` — missing the quotes around the resource type that HCL requires (`resource "confluent_private_link_attachment_connection" "azure" {`). The `"aws"` block already had it right; matched that pattern for all three.
2. **GH-377** (github.com/confluentinc/terraform-provider-confluent/issues/377) — `docs/resources/confluent_service_account.md` didn't mention any length limit on `display_name`. Added a note that it's capped at 64 characters.

Blast Radius
----
Both changes are documentation-only — no code, schema, or behavior changes. Zero risk to existing `terraform apply`/`plan` runs. The only "risk" is if either doc statement is itself inaccurate, which is why both were independently verified (see Test & Review) rather than taken on faith.

References
----------
- https://confluentinc.atlassian.net/browse/APIE-1308
- https://github.com/confluentinc/terraform-provider-confluent/issues/377

Test & Review
-------------
No Go toolchain was available in this environment, so the provider binary could not be built here.

What was actually verified:
- **APIE-1308**: installed Terraform (v1.15.8) and ran `terraform init && terraform validate` against the exact corrected example (using the real published `confluentinc/confluent` v2.80.0 provider) — result: `Success! The configuration is valid.`
- **GH-377**: the 64-character limit is *not* declared in this provider's own schema validation (`resource_service_account.go` only checks `StringIsNotEmpty`), nor in the authoritative `iam.v2.ServiceAccount` OpenAPI schema (`display_name` has no `maxLength`, unlike the `id` field two lines above it which explicitly has one) — so it can't be confirmed by reading source alone. Verified empirically instead: authenticated directly against the Confluent Cloud staging API (`api.stag.cpdev.cloud`) and attempted `POST /iam/v2/service-accounts` with `display_name` at 64, 65, 100, 255, and 256 characters. 64 succeeded (`201`); every length above it failed with `400: "Service name limited to 64 characters"` — confirming the limit is real and exactly 64, just enforced in application logic rather than the schema. Test service account was created and (attempted) cleanup in staging only, never touched production.
