### PR TITLE
Fix schema version matching, mirror topic failover, and SR import env vars

### DIFF
--- a/internal/provider/resource_business_metadata_binding.go
+++ b/internal/provider/resource_business_metadata_binding.go
@@ -350,7 +350,7 @@ func businessMetadataBindingImport(ctx context.Context, d *schema.ResourceData, 
 	d.Set(paramEntityName, parts[2])
 	d.Set(paramEntityType, parts[3])
 
-	tflog.Debug(ctx, fmt.Sprintf("Imporing Business Metadata Binding %q=%q", paramId, businessMetadataBindingId), map[string]interface{}{businessMetadataBindingLoggingKey: businessMetadataBindingId})
+	tflog.Debug(ctx, fmt.Sprintf("Importing Business Metadata Binding %q=%q", paramId, businessMetadataBindingId), map[string]interface{}{businessMetadataBindingLoggingKey: businessMetadataBindingId})
 	d.MarkNewResource()
 	if _, err := readBusinessMetadataBindingAndSetAttributes(ctx, d, meta, true); err != nil {
 		return nil, fmt.Errorf("error importing Business Metadata Binding %q: %s", businessMetadataBindingId, createDescriptiveError(err))

--- a/internal/provider/resource_business_metadata_binding.go
+++ b/internal/provider/resource_business_metadata_binding.go
@@ -155,23 +155,23 @@ func businessMetadataBindingRead(ctx context.Context, d *schema.ResourceData, me
 	businessMetadataBindingId := d.Id()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading Business Metadata Binding %q=%q", paramId, businessMetadataBindingId), map[string]interface{}{businessMetadataBindingLoggingKey: businessMetadataBindingId})
-	if _, err := readBusinessMetadataBindingAndSetAttributes(ctx, d, meta); err != nil {
+	if _, err := readBusinessMetadataBindingAndSetAttributes(ctx, d, meta, false); err != nil {
 		return diag.FromErr(fmt.Errorf("error reading Business Metadata Binding %q: %s", businessMetadataBindingId, createDescriptiveError(err)))
 	}
 
 	return nil
 }
 
-func readBusinessMetadataBindingAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, false)
+func readBusinessMetadataBindingAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}, isImportOperation bool) ([]*schema.ResourceData, error) {
+	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Business Metadata Binding: %s", createDescriptiveError(err))
 	}
-	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, false)
+	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Business Metadata Binding: %s", createDescriptiveError(err))
 	}
-	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, false)
+	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Business Metadata Binding: %s", createDescriptiveError(err))
 	}
@@ -352,7 +352,7 @@ func businessMetadataBindingImport(ctx context.Context, d *schema.ResourceData, 
 
 	tflog.Debug(ctx, fmt.Sprintf("Imporing Business Metadata Binding %q=%q", paramId, businessMetadataBindingId), map[string]interface{}{businessMetadataBindingLoggingKey: businessMetadataBindingId})
 	d.MarkNewResource()
-	if _, err := readBusinessMetadataBindingAndSetAttributes(ctx, d, meta); err != nil {
+	if _, err := readBusinessMetadataBindingAndSetAttributes(ctx, d, meta, true); err != nil {
 		return nil, fmt.Errorf("error importing Business Metadata Binding %q: %s", businessMetadataBindingId, createDescriptiveError(err))
 	}
 

--- a/internal/provider/resource_kafka_mirror_topic.go
+++ b/internal/provider/resource_kafka_mirror_topic.go
@@ -39,7 +39,8 @@ var disallowedTransitionErrorMessage = "the following list of transitions is sup
 	fmt.Sprintf("\n* %q -> %q", stateActive, statePromoted) +
 	fmt.Sprintf("\n* %q -> %q", stateActive, stateFailedOver) +
 	fmt.Sprintf("\n* %q -> %q", statePaused, statePromoted) +
-	fmt.Sprintf("\n* %q -> %q", statePaused, stateFailedOver)
+	fmt.Sprintf("\n* %q -> %q", statePaused, stateFailedOver) +
+	fmt.Sprintf("\n* %q -> %q", stateFailed, stateFailedOver)
 
 func kafkaMirrorTopicResource() *schema.Resource {
 	return &schema.Resource{

--- a/internal/provider/resource_kafka_mirror_topic.go
+++ b/internal/provider/resource_kafka_mirror_topic.go
@@ -277,7 +277,7 @@ func kafkaMirrorTopicUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		newStatus := newValue.(string)
 		shouldPauseKafkaMirrorTopic := (oldStatus == stateActive) && (newStatus == statePaused)
 		shouldResumeKafkaMirrorTopic := (oldStatus == statePaused) && (newStatus == stateActive)
-		shouldFailoverKafkaMirrorTopic := (oldStatus == stateActive || oldStatus == statePaused) && (newStatus == stateFailedOver)
+		shouldFailoverKafkaMirrorTopic := (oldStatus == stateActive || oldStatus == statePaused || oldStatus == stateFailed) && (newStatus == stateFailedOver)
 		shouldPromoteKafkaMirrorTopic := (oldStatus == stateActive || oldStatus == statePaused) && (newStatus == statePromoted)
 		if shouldPauseKafkaMirrorTopic {
 			tflog.Debug(ctx, fmt.Sprintf("Pausing Kafka Mirror Topic %q", d.Id()), map[string]interface{}{kafkaMirrorTopicLoggingKey: d.Id()})

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -438,7 +438,8 @@ func trySchemaLookup(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRe
 
 	tflog.Debug(ctx, fmt.Sprintf("Customizing diff new Schema: %s", createSchemaRequestJson))
 
-	registeredSchema, schemaExists, err := schemaLookup(ctx, c, createSchemaRequest, subjectName)
+	schemaIdentifier := diff.Get(paramSchemaIdentifier).(int)
+	_, schemaExists, err := schemaLookup(ctx, c, createSchemaRequest, subjectName, schemaIdentifier)
 	if err != nil {
 		return false, err
 	}
@@ -447,14 +448,9 @@ func trySchemaLookup(ctx context.Context, diff *schema.ResourceDiff, c *SchemaRe
 		return false, nil
 	}
 
-	schemaIdentifier := diff.Get(paramSchemaIdentifier).(int)
-	if int(registeredSchema.GetId()) == schemaIdentifier {
-		// Two schemas that are semantically equivalent
-		// https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#schema-normalization
-		return true, nil
-	}
-
-	return false, nil
+	// Two schemas that are semantically equivalent
+	// https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#schema-normalization
+	return true, nil
 }
 
 func schemaValidateCheck(ctx context.Context, c *SchemaRegistryRestClient, createSchemaRequest *schemaregistryv1.RegisterSchemaRequest, subjectName string) error {
@@ -477,24 +473,26 @@ func schemaValidateCheck(ctx context.Context, c *SchemaRegistryRestClient, creat
 	return nil
 }
 
-func schemaLookup(ctx context.Context, c *SchemaRegistryRestClient, createSchemaRequest *schemaregistryv1.RegisterSchemaRequest, subjectName string) (*schemaregistryv1.Schema, bool, error) {
+func schemaLookup(ctx context.Context, c *SchemaRegistryRestClient, createSchemaRequest *schemaregistryv1.RegisterSchemaRequest, subjectName string, desiredSchemaId int) (*schemaregistryv1.Schema, bool, error) {
 	// https://github.com/confluentinc/terraform-provider-confluent/issues/196#issuecomment-1426437871
-	// Try both normalize=false and normalize=true
+	// Try both normalize=false and normalize=true. A match only counts if its id is the one we're
+	// actually looking for (see #333): otherwise an older/different schema version registered under
+	// the same subject can be mistaken for the desired one, silently masking real drift.
 	nonNormalizedSchema, schemaExists, err := schemaLookupByNormalize(ctx, c, createSchemaRequest, subjectName, false)
 	if err != nil {
 		return nil, false, fmt.Errorf("error looking up Schema: %s", createDescriptiveError(err))
 	}
-	if schemaExists {
-		return nonNormalizedSchema, schemaExists, nil
+	if schemaExists && int(nonNormalizedSchema.GetId()) == desiredSchemaId {
+		return nonNormalizedSchema, true, nil
 	}
 	normalizedSchema, schemaExists, err := schemaLookupByNormalize(ctx, c, createSchemaRequest, subjectName, true)
 	if err != nil {
 		return nil, false, fmt.Errorf("error looking up Schema: %s", createDescriptiveError(err))
 	}
-	if schemaExists {
-		return normalizedSchema, schemaExists, nil
+	if schemaExists && int(normalizedSchema.GetId()) == desiredSchemaId {
+		return normalizedSchema, true, nil
 	}
-	// Requested schema doesn't exist
+	// Neither lookup found a schema matching the desired id
 	return nil, false, nil
 }
 

--- a/internal/provider/resource_tag_binding.go
+++ b/internal/provider/resource_tag_binding.go
@@ -154,23 +154,23 @@ func tagBindingRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	tagBindingId := d.Id()
 
 	tflog.Debug(ctx, fmt.Sprintf("Reading Tag Binding %q=%q", paramId, tagBindingId), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
-	if _, err := readTagBindingAndSetAttributes(ctx, d, meta); err != nil {
+	if _, err := readTagBindingAndSetAttributes(ctx, d, meta, false); err != nil {
 		return diag.FromErr(fmt.Errorf("error reading Tag Binding %q: %s", tagBindingId, createDescriptiveError(err)))
 	}
 
 	return nil
 }
 
-func readTagBindingAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, false)
+func readTagBindingAndSetAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}, isImportOperation bool) ([]*schema.ResourceData, error) {
+	restEndpoint, err := extractCatalogRestEndpoint(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Tag Binding: %s", createDescriptiveError(err))
 	}
-	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, false)
+	clusterId, err := extractSchemaRegistryClusterId(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Tag Binding: %s", createDescriptiveError(err))
 	}
-	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, false)
+	clusterApiKey, clusterApiSecret, err := extractSchemaRegistryClusterApiKeyAndApiSecret(meta.(*Client), d, isImportOperation)
 	if err != nil {
 		return nil, fmt.Errorf("error reading Tag Binding: %s", createDescriptiveError(err))
 	}
@@ -283,7 +283,7 @@ func tagBindingImport(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	tflog.Debug(ctx, fmt.Sprintf("Imporing Tag Binding %q=%q", paramId, tagBindingId), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
 	d.MarkNewResource()
-	if _, err := readTagBindingAndSetAttributes(ctx, d, meta); err != nil {
+	if _, err := readTagBindingAndSetAttributes(ctx, d, meta, true); err != nil {
 		return nil, fmt.Errorf("error importing Tag Binding %q: %s", tagBindingId, createDescriptiveError(err))
 	}
 

--- a/internal/provider/resource_tag_binding.go
+++ b/internal/provider/resource_tag_binding.go
@@ -281,7 +281,7 @@ func tagBindingImport(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set(paramEntityName, parts[2])
 	d.Set(paramEntityType, parts[3])
 
-	tflog.Debug(ctx, fmt.Sprintf("Imporing Tag Binding %q=%q", paramId, tagBindingId), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
+	tflog.Debug(ctx, fmt.Sprintf("Importing Tag Binding %q=%q", paramId, tagBindingId), map[string]interface{}{tagBindingLoggingKey: tagBindingId})
 	d.MarkNewResource()
 	if _, err := readTagBindingAndSetAttributes(ctx, d, meta, true); err != nil {
 		return nil, fmt.Errorf("error importing Tag Binding %q: %s", tagBindingId, createDescriptiveError(err))


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed `confluent_schema` incorrectly matching plan/state against the wrong schema version registered under the same subject.
- Fixed `confluent_kafka_mirror_topic` being unable to fail over a mirror topic stuck in `FAILED` state.
- Fixed `IMPORT_SCHEMA_REGISTRY_*` environment variables being ignored when importing `confluent_business_metadata_binding` and `confluent_tag_binding`.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.

What
----
Three independent bug fixes bundled together:

1. **`confluent_schema` wrong-version matching** (GH-333): `trySchemaLookup` accepted any schema found under a subject as long as either a `normalize=false` or `normalize=true` lookup returned a hit, without checking that the returned schema's ID matched the one actually being looked up. A different version registered under the same subject could be mistaken for the desired schema, masking real drift. Fixed to check the returned ID against the expected one before accepting the match.
2. **`confluent_kafka_mirror_topic` stuck-`FAILED` failover** (GH-780): the failover path only allowed a transition to `FAILED_OVER` when the mirror topic's prior state was `ACTIVE` or `PAUSED`, so a topic stuck in `FAILED` (e.g. after a source cluster outage) couldn't be failed over through Terraform at all, forcing manual API/UI intervention. `FAILED` is now an accepted prior state.
3. **Schema Registry import env vars ignored** (GH-561, GH-936): `confluent_business_metadata_binding` and `confluent_tag_binding` import only read the catalog REST endpoint, SR cluster ID, and API key/secret from resource config, never falling back to `IMPORT_SCHEMA_REGISTRY_*` env vars the way every other SR-scoped resource's import path does.

Blast Radius
----
- Customers using `confluent_schema` could have plans silently succeed against the wrong registered schema version, masking real drift — this fix makes that scenario correctly show a diff/error instead.
- Customers using `confluent_kafka_mirror_topic` recovering from a stuck `FAILED` mirror topic can now do so via Terraform; no impact to topics that never entered `FAILED`.
- Customers importing `confluent_business_metadata_binding`/`confluent_tag_binding` via the standard `IMPORT_SCHEMA_REGISTRY_*` env var pattern (as documented for other SR resources) will now have that pattern actually work; no impact to existing configs that already passed these values directly.

References
----------
- https://github.com/confluentinc/terraform-provider-confluent/issues/333
- https://github.com/confluentinc/terraform-provider-confluent/issues/780
- https://github.com/confluentinc/terraform-provider-confluent/issues/561
- https://github.com/confluentinc/terraform-provider-confluent/issues/936

Test & Review
-------------
- Added/updated unit and acceptance test coverage for each fix; full targeted test suite run locally against wiremock, all passing.