### PR TITLE
docs: Render identity_pool's ObjectRef description as prose

### DIFF
--- a/internal/provider/resource_identity_pool.go
+++ b/internal/provider/resource_identity_pool.go
@@ -263,7 +263,7 @@ func identityProviderSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Required:    true,
 					ForceNew:    true,
-					Description: "The unique identifier for the identity_provider.",
+					Description: "The unique identifier for the identity provider.",
 				},
 			},
 		},


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Fixed the `confluent_identity_pool` schema description for `identity_provider.id`, which rendered the raw attribute name (`identity_provider`) instead of readable prose ("identity provider").

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
  - `go build ./...` and `go vet ./...` pass. Not exercised against live infrastructure — the change is a static string in a schema literal with no runtime code path (see `Blast Radius`).
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
  - N/A — no request, response, or state-handling path is touched.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
  - N/A — there is no runtime behavior to observe; the diff is shown in full below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
  - No new functionality here. Regression coverage lives with the code that generates this string — confluentinc/cli-terraform-generator#272 adds four tests, including a source-level guard asserting every ObjectRef description site renders as prose.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
  - N/A — no new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
  - N/A — no configuration change can exercise this; the string is not addressable from HCL.
- [ ] I have included rate limit/load testing results.
  - N/A — no API calls added or altered.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
  - Only a `Description` field changes. No attribute name, type, requiredness, `ForceNew`, or validation change; no effect on plan, apply, state, or import.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
  - No documentation change is required. Verified that `docs/resources/confluent_identity_pool.md` documents this field with its own curated text ("The ID of the Identity Provider associated with the Identity Pool, for example, `op-abc123`.") and does not reuse the generated string.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - N/A — not a feature; no gating involved.
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

`internal/provider/resource_identity_pool.go` is generator-managed (`// Code generated by cli-terraform-generator; DO NOT EDIT.`) and carried:

```go
Description: "The unique identifier for the identity_provider.",
```

A schema `Description` is user-facing text — it is published in `terraform providers schema -json` and surfaced by editor/LSP tooling — so it should read **"identity provider"**, matching the prose form hand-written resources nearby already use (e.g. `confluent_private_link_attachment_connection`: `"The unique identifier for the private link attachment."`).

**Why it went unnoticed.** The generator rendered this description with `toSnakeCase`. Every *single*-word ObjectRef (`environment`, `network`, `gateway`, `cluster`) renders identically under snake_case or prose, so the defect was invisible until a resource with a *multi*-word ObjectRef was generated. `confluent_identity_pool` is currently the only resource on `master` that exposes it.

**Why now.** The generator has been fixed to render this via `toLowerWords` (companion PR confluentinc/cli-terraform-generator#272). This PR syncs the already-generated file so the next regeneration of `confluent_identity_pool` produces a **zero diff** rather than an unexplained one-line change.

**Scope — deliberately one line.** Two related occurrences are intentionally excluded:
- `internal/provider/resource_rtce_topic.go:472` has the same pattern (`kafka_cluster`), but that file is **not** generator-managed (no `DO NOT EDIT` header — added by hand in #1018), so editing it is a different category of change.
- `confluent_network_link_endpoint` has the same defect on `network_link_service`, but only on the in-flight migration branch (#1082), not on `master`. It is already listed there as a known cosmetic item and is best fixed in that PR.

Blast Radius
----

**Effectively zero.** The only observable change is the wording of a help string:

- Customers running `terraform providers schema -json` (or tooling that consumes it, such as editor autocomplete/hover) will see `identity provider` instead of `identity_provider` in the description of `confluent_identity_pool.identity_provider.id`.
- No customer is blocked or impacted operationally. There is no change to the attribute's name, type, requiredness, validation, or `ForceNew` behavior, and therefore no change to plan, apply, refresh, state, or `terraform import` for `confluent_identity_pool` or any other resource.

If this change were somehow wrong, the worst outcome is a cosmetically incorrect description string.

References
----------

- Companion generator fix: confluentinc/cli-terraform-generator#272
- How the string originally shipped: #1079 (`Generate confluent_identity_pool resource via cli-terraform-generator`)
- Related, same defect on an in-flight branch: #1082 (`Generate confluent_network_link_endpoint resource and data source via cli-terraform-generator`)

Test & Review
-------------

Full diff (1 file, 1 line):

```diff
--- a/internal/provider/resource_identity_pool.go
+++ b/internal/provider/resource_identity_pool.go
@@ -263,7 +263,7 @@ func identityProviderSchema() *schema.Schema {
                                        Type:        schema.TypeString,
                                        Required:    true,
                                        ForceNew:    true,
-                                       Description: "The unique identifier for the identity_provider.",
+                                       Description: "The unique identifier for the identity provider.",
                                },
                        },
                },
```

Verification performed:

| Step | Result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./internal/provider/ -run TestProvider` | pass — `TestProvider_InternalValidate`, `TestProviderGoContainsTfgenMarkers` |
| `go.mod` / `go.sum` / `provider.go` diff | none |

Also confirmed the change matches generator output exactly: diffed the regenerated `identity_pool` artifact (with cli-terraform-generator#272 applied) against this file and the description line is the only substantive difference — everything else is expected standalone-vs-merge-mode variance (deduped `param*` constants, `c.iamClient` vs `c.identityProviderV2Client`).

Note on `TestAccIdentityPool`: it is a WireMock acceptance test requiring Docker, which is unavailable on the machine used here. It fails with `rootless Docker not found` **identically on unmodified `master`**, so it is unaffected by this change.



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
