### PR TITLE
Fix doc bug: confluent_dns_forwarder doc used wrong GCP DNS zones block name

### DIFF
--- a/docs/resources/confluent_dns_forwarder.md
+++ b/docs/resources/confluent_dns_forwarder.md
@@ -52,7 +52,7 @@ resource "confluent_dns_forwarder" "main" {
   gateway {
     id = confluent_network.main.gateway[0].id
   }
-  forward_via_gcp_zones {
+  forward_via_gcp_dns_zones {
     domain_mappings = {
         "example.com" = "zone-1,project-1"
     }
@@ -73,10 +73,10 @@ The following arguments are supported:
 - `domains` (Required String List) List of domains for the DNS forwarder to use.
 - `forward_via_ip` (Optional Configuration Block) supports the following:
   - `dns_server_ips` (Required String List) List of IP addresses of the DNS server.
-- `forward_via_gcp_zones` (Optional Configuration Block) supports the following:
+- `forward_via_gcp_dns_zones` (Optional Configuration Block) supports the following:
   - `domain_mappings` (Required Map List) List of Maps which contains the domain to zone and project mapping.
   
--> **Note:** The `forward_via_gcp_zones` and `forward_via_ip` blocks are mutually exclusive, and one of them must be provided.
+-> **Note:** The `forward_via_gcp_dns_zones` and `forward_via_ip` blocks are mutually exclusive, and one of them must be provided.
 
 -> **Note:** The zone and project must be specified in the correct order, separated by a comma, to ensure accurate `domain_mappings`.
 


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed the `confluent_dns_forwarder` resource doc, which referenced a non-existent `forward_via_gcp_zones` block in its example usage, argument reference, and note callouts instead of the actual `forward_via_gcp_dns_zones` block.

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — docs-only change, no code modified)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A — no functional change)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A — see Test & Review)
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. (N/A — no new resource/data source/functionality)
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A — docs typo fix)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A — docs-only fix, not a feature)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`docs/resources/confluent_dns_forwarder.md`'s "Option #2" example usage, Argument Reference, and two Note callouts all use a `forward_via_gcp_zones` block name. The actual schema attribute (verified via the real `confluent_dns_forwarder` resource schema, using `paramForwardViaGcp = "forward_via_gcp_dns_zones"` in `internal/provider/constants.go`) is `forward_via_gcp_dns_zones` — there is no `forward_via_gcp_zones` alias. This is more than a cosmetic typo: a user who copy-pastes the documented example gets a Terraform error (`Blocks of type "forward_via_gcp_zones" are not expected here`) instead of a working configuration. This PR corrects all four references to the real attribute name.

Blast Radius
----
None. This is a documentation-only fix with no code changes. If anything, it reduces customer impact going forward, since the previous doc text would cause `terraform plan`/`apply` to fail for anyone following the "Option #2: Create using ForwardViaGcpDnsZones method" example as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
