### PR TITLE
Fix doc typo: confluent_network data source misspelled private_link_service_alias

### DIFF
--- a/docs/data-sources/confluent_network.md
+++ b/docs/data-sources/confluent_network.md
@@ -94,7 +94,7 @@ In addition to the preceding arguments, the following attributes are exported:
 - `azure` - (Optional Configuration Block) The Azure-specific network details if available. It supports the following:
   - `private_link_service_aliases` - (Optional Map) The mapping of zones to Private Link Service Aliases if available. Keys are zones and values are [Azure Private Link Service Aliases](https://docs.microsoft.com/en-us/azure/private-link/private-link-service-overview#share-your-service).
     - `zone` - (Required String) The zone name, for example, `1`.
-    - `private_link_service_aliase` - (Required String) The Private Link Service Alias, for example, `s-aa11a-privatelink-1.1c12abc3-695c-1234-bc35-11fe6abb303a.centralus.azure.privatelinkservice`.
+    - `private_link_service_alias` - (Required String) The Private Link Service Alias, for example, `s-aa11a-privatelink-1.1c12abc3-695c-1234-bc35-11fe6abb303a.centralus.azure.privatelinkservice`.
 - `gcp` - (Optional Configuration Block) The GCP-specific network details if available. It supports the following:
   - `project` - (Required String) The GCP Project ID associated with the Confluent Cloud VPC.
   - `vpc_network` - (Required String) The network name of the Confluent Cloud VPC.


### PR DESCRIPTION
Release Notes
---------
Bug Fixes
- Fixed a typo in the `confluent_network` data source doc, which misspelled `private_link_service_alias` as `private_link_service_aliase` in an example sub-bullet.

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — docs-only change, no code modified)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A — no functional change)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A — see Test & Review)
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. (N/A — no new resource/data source/functionality)
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A — docs typo fix)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A — docs-only fix, not a feature)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
`docs/data-sources/confluent_network.md` describes the `private_link_service_aliases` map's per-entry value with a sub-bullet that spelled the singular form as `private_link_service_aliase` instead of `private_link_service_alias`. This is illustrative text (not a real Terraform argument name a user would type), but it's a plain misspelling. Fixed the spelling.

Blast Radius
----
None. This is a documentation-only fix with no code changes, correcting a cosmetic typo in descriptive text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
