### PR TITLE
Retry transient failures against the Access Point API, and test that every client is wired

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -671,6 +671,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	providerIntegrationV1Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
 	providerIntegrationV2Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
 	kafkaQuotasV1Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
+	networkingAccessPointV1Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
 	rtceV1Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
 	srcmV3Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
 	ssoV2Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -15,6 +15,9 @@
 package provider
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -94,6 +97,113 @@ func TestProviderGoContainsTfgenMarkers(t *testing.T) {
 			t.Errorf("provider.go is missing required marker %q (needed by cli-terraform-generator --provider-dir)", marker)
 		}
 	}
+}
+
+// TestEverySDKClientConfigGetsARetryableHTTPClient asserts that every SDK client configuration
+// built in providerConfigure is also given a retryable HTTP client.
+//
+// providerConfigure declares one `<name>Cfg := <sdk>.NewConfiguration()` per Confluent API, and
+// then assigns each one a retryable client from a separate block further down. Nothing ties the
+// two lists together, so a config can be added without its retryable client and every existing
+// test still passes — which is how networkingAccessPointV1Cfg ended up as the only one of 32
+// without one, leaving confluent_access_point and confluent_dns_record as the only resources that
+// failed immediately on a transient 429 or 5xx instead of retrying.
+//
+// factory_utils_test.go already covers whether the retryable client itself works. This covers
+// whether every API is actually given one.
+func TestEverySDKClientConfigGetsARetryableHTTPClient(t *testing.T) {
+	const (
+		configConstructor = "NewConfiguration"
+		httpClientField   = "HTTPClient"
+		retryableFactory  = "NewRetryableClientFactory"
+	)
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed: unable to determine test file path")
+	}
+	providerGoPath := filepath.Join(filepath.Dir(thisFile), "provider.go")
+
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, providerGoPath, nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse provider.go: %s", err)
+	}
+
+	var providerConfigureBody *ast.BlockStmt
+	for _, decl := range parsed.Decls {
+		if fn, isFunc := decl.(*ast.FuncDecl); isFunc && fn.Name.Name == "providerConfigure" {
+			providerConfigureBody = fn.Body
+			break
+		}
+	}
+	if providerConfigureBody == nil {
+		t.Fatal("provider.go no longer declares providerConfigure; this test needs updating")
+	}
+
+	// declared preserves source order so the failure message points at the offending line.
+	var declared []string
+	declaredAt := make(map[string]token.Pos)
+	retryable := make(map[string]bool)
+
+	ast.Inspect(providerConfigureBody, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+
+		switch assign.Tok {
+		case token.DEFINE:
+			// <name>Cfg := <sdk package>.NewConfiguration()
+			name, isIdent := assign.Lhs[0].(*ast.Ident)
+			if !isIdent {
+				return true
+			}
+			call, isCall := assign.Rhs[0].(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			if selector, isSelector := call.Fun.(*ast.SelectorExpr); isSelector && selector.Sel.Name == configConstructor {
+				declared = append(declared, name.Name)
+				declaredAt[name.Name] = name.Pos()
+			}
+		case token.ASSIGN:
+			// <name>Cfg.HTTPClient = NewRetryableClientFactory(...).CreateRetryableClient()
+			selector, isSelector := assign.Lhs[0].(*ast.SelectorExpr)
+			if !isSelector || selector.Sel.Name != httpClientField {
+				return true
+			}
+			name, isIdent := selector.X.(*ast.Ident)
+			if !isIdent {
+				return true
+			}
+			// Require the retryable factory specifically — assigning some other client would
+			// otherwise satisfy this test while reintroducing the bug.
+			ast.Inspect(assign.Rhs[0], func(rhs ast.Node) bool {
+				if ident, isIdent := rhs.(*ast.Ident); isIdent && ident.Name == retryableFactory {
+					retryable[name.Name] = true
+					return false
+				}
+				return true
+			})
+		}
+		return true
+	})
+
+	if len(declared) == 0 {
+		t.Fatalf("found no `<name>Cfg := <sdk>.%s()` declarations in providerConfigure; this test needs updating", configConstructor)
+	}
+
+	for _, name := range declared {
+		if !retryable[name] {
+			t.Errorf("%s: %s is never assigned a %s.\n"+
+				"Every SDK client configuration needs one, or requests to that API fail immediately on a "+
+				"transient 429 or 5xx instead of retrying. Add:\n"+
+				"\t%s.%s = %s(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()",
+				fileSet.Position(declaredAt[name]), name, retryableFactory, name, httpClientField, retryableFactory)
+		}
+	}
+	t.Logf("checked %d SDK client configurations", len(declared))
 }
 
 func TestSleepIfNotTestMode(t *testing.T) {


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Requests to the Access Point API now retry on transient failures, matching every other Confluent API the provider calls. Affects `confluent_access_point` and `confluent_dns_record`.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. — *full CRUD of `confluent_access_point`; see `Test & Review`.*
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. — *added `TestEverySDKClientConfigGetsARetryableHTTPClient`; see below.*
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing. — [testing thread](https://confluent.slack.com/archives/C02TG07V058/p1786146991511209)
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR. — *none needed; no user-facing surface changes.*
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag

What
----
`providerConfigure` builds 32 SDK client configurations and gives 31 of them a retryable HTTP client. `networkingAccessPointV1Cfg` was missed, so the Access Point API was the only Confluent API where a transient 429 or 5xx failed the apply immediately instead of being retried.

This adds the one missing line, identical to the 31 around it, **plus a test that fails without it**.

### The test

The two lists live 150 lines apart in `providerConfigure` and nothing tied them together, so a config could be added without its retryable client and every existing test would still pass. That is exactly how this bug happened, so the fix is not much use without something to keep it fixed.

`TestEverySDKClientConfigGetsARetryableHTTPClient` parses `provider.go`, collects the `*Cfg` identifiers declared in `providerConfigure`, collects those assigned `HTTPClient` from `NewRetryableClientFactory`, and fails on any in the first set missing from the second. On `master` it reports:

```
provider.go:550:2: networkingAccessPointV1Cfg is never assigned a NewRetryableClientFactory.
Every SDK client configuration needs one, or requests to that API fail immediately on a
transient 429 or 5xx instead of retrying. Add:
	networkingAccessPointV1Cfg.HTTPClient = NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries)).CreateRetryableClient()
```

It is source-level rather than runtime because the `Client` struct's SDK client fields are unexported, so reflecting over them to reach `GetConfig().HTTPClient` would need `unsafe`. `TestProviderGoContainsTfgenMarkers` already asserts against `provider.go`'s source in the same file, so this is the established pattern here.

Note this deliberately does *not* re-test retry behavior — `factory_utils_test.go` already covers that with 7 tests. The untested gap was the wiring.

Found while migrating `confluent_dns_record` to generated code — the generator emits this wiring automatically, which is how the gap surfaced. Split out because it is a pre-existing bug, independent of that migration and worth landing on its own.

Blast Radius
----
Users of `confluent_access_point` and `confluent_dns_record` currently see spurious apply failures on transient API errors. After this change those requests retry like every other resource's.

If the change is wrong, the failure mode is retrying a request that should not be retried — but this is the same `NewRetryableClientFactory(ctx, WithMaxRetries(maxRetries))` construction used by all 31 other clients, including the rest of the networking APIs.

Test & Review
-------------
**Manual.** Full CRUD of `confluent_access_point` against Confluent Cloud — [testing thread](https://confluent.slack.com/archives/C02TG07V058/p1786146991511209). It is one of only two resources on this client (the other is `confluent_dns_record`) and they share every path it touches, so either covers the change. A real transient 429/5xx can't be forced on demand, so this confirms the swap left normal request handling intact; the test below covers the wiring.

**Test.** `TestEverySDKClientConfigGetsARetryableHTTPClient` fails on `master` (naming the unwired variable and line), passes here, and also catches a config added without the line or given a plain non-retryable client. Runs in CI — Semaphore's `make all` includes `make test` and `make testacc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
