### PR TITLE
Use the conventional LoggingKey name for DNS Record log fields

### DIFF
--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -109,7 +109,7 @@ const (
 		"Refer to the Upgrade Guide at https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/guides/version-3-upgrade for more details. " +
 		"The guide will be published once version 3.0.0 is released."
 	dnsForwarderKey                                      = "dns_forwarder_id"
-	dnsRecordKey                                         = "dns_record_id"
+	dnsRecordLoggingKey                                  = "dns_record_id"
 	docsClusterConfigUrl                                 = "https://docs.confluent.io/cloud/current/clusters/broker-config.html#change-cluster-settings-for-dedicated-clusters"
 	docsClusterLinkConfigUrl                             = "https://docs.confluent.io/cloud/current/multi-cloud/cluster-linking/cluster-links-cc.html#configuring-cluster-link-behavior"
 	docsUrl                                              = "https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_topic"

--- a/internal/provider/data_source_dns_record.go
+++ b/internal/provider/data_source_dns_record.go
@@ -82,7 +82,7 @@ func dnsRecordDataSourceRead(ctx context.Context, d *schema.ResourceData, meta i
 	dnsRecordId := d.Get(paramId).(string)
 	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading DNS Record %q=%q", paramId, dnsRecordId), map[string]interface{}{dnsRecordKey: dnsRecordId})
+	tflog.Debug(ctx, fmt.Sprintf("Reading DNS Record %q=%q", paramId, dnsRecordId), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 
 	c := meta.(*Client)
 	request := c.networkingAccessPointV1Client.DNSRecordsNetworkingV1Api.GetNetworkingV1DnsRecord(c.networkingAccessPointV1ApiContext(ctx), dnsRecordId).Environment(environmentId)
@@ -94,7 +94,7 @@ func dnsRecordDataSourceRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.Errorf("error reading DNS Record %q: error marshaling %#v to json: %s", dnsRecordId, dnsRecord, createDescriptiveError(err))
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Fetched DNS Record %q: %s", dnsRecordId, dnsRecordJson), map[string]interface{}{dnsRecordKey: dnsRecordId})
+	tflog.Debug(ctx, fmt.Sprintf("Fetched DNS Record %q: %s", dnsRecordId, dnsRecordJson), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 
 	if _, err := setDnsRecordAttributes(d, dnsRecord); err != nil {
 		return diag.FromErr(createDescriptiveError(err))

--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -126,7 +126,7 @@ func dnsRecordCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.Errorf("error creating DNS Record %q: error marshaling %#v to json: %s", d.Id(), createdDnsRecord, createDescriptiveError(err))
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Finished creating DNS Record %q: %s", d.Id(), createdDnsRecordJson), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished creating DNS Record %q: %s", d.Id(), createdDnsRecordJson), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	return dnsRecordRead(ctx, d, meta)
 }
@@ -137,7 +137,7 @@ func executeDnsRecordRead(ctx context.Context, c *Client, environmentId string, 
 }
 
 func dnsRecordRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	tflog.Debug(ctx, fmt.Sprintf("Reading DNS Record %q", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Reading DNS Record %q", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	dnsRecordId := d.Id()
 	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
@@ -154,10 +154,10 @@ func readDnsRecordAndSetAttributes(ctx context.Context, d *schema.ResourceData, 
 
 	dnsRecord, resp, err := executeDnsRecordRead(c.networkingAccessPointV1ApiContext(ctx), c, environmentId, dnsRecordId)
 	if err != nil {
-		tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err)), map[string]interface{}{dnsRecordKey: d.Id()})
+		tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err)), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 		isResourceNotFound := isNonKafkaRestApiResourceNotFound(resp)
 		if isResourceNotFound && !d.IsNewResource() {
-			tflog.Warn(ctx, fmt.Sprintf("Removing DNS Record %q in TF state because DNS Record could not be found on the server", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+			tflog.Warn(ctx, fmt.Sprintf("Removing DNS Record %q in TF state because DNS Record could not be found on the server", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 			d.SetId("")
 			return nil, nil
 		}
@@ -168,19 +168,19 @@ func readDnsRecordAndSetAttributes(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return nil, fmt.Errorf("error reading DNS Record %q: error marshaling %#v to json: %s", dnsRecordId, dnsRecord, createDescriptiveError(err))
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Fetched DNS Record %q: %s", d.Id(), dnsRecordJson), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Fetched DNS Record %q: %s", d.Id(), dnsRecordJson), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	if _, err := setDnsRecordAttributes(d, dnsRecord); err != nil {
 		return nil, createDescriptiveError(err)
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished reading DNS Record %q", dnsRecordId), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished reading DNS Record %q", dnsRecordId), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	return []*schema.ResourceData{d}, nil
 }
 
 func dnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	tflog.Debug(ctx, fmt.Sprintf("Deleting DNS Record %q", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Deleting DNS Record %q", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 	environmentId := extractStringValueFromBlock(d, paramEnvironment, paramId)
 	c := meta.(*Client)
 
@@ -195,7 +195,7 @@ func dnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.Errorf("error waiting for DNS Record %q to be deleted: %s", d.Id(), createDescriptiveError(err, resp))
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Finished deleting DNS Record %q", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished deleting DNS Record %q", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	return nil
 }
@@ -228,7 +228,7 @@ func dnsRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.Errorf("error updating DNS Record %q: error marshaling %#v to json: %s", d.Id(), updateDnsRecordRequestJson, createDescriptiveError(err))
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Updating DNS Record %q: %s", d.Id(), updateDnsRecordRequestJson), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Updating DNS Record %q: %s", d.Id(), updateDnsRecordRequestJson), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	c := meta.(*Client)
 	req := c.networkingAccessPointV1Client.DNSRecordsNetworkingV1Api.UpdateNetworkingV1DnsRecord(c.networkingAccessPointV1ApiContext(ctx), d.Id()).NetworkingV1DnsRecordUpdate(*updateDnsRecord)
@@ -242,12 +242,12 @@ func dnsRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.Errorf("error updating DNS Record %q: error marshaling %#v to json: %s", d.Id(), updatedDnsRecord, createDescriptiveError(err))
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Finished updating DNS Record %q: %s", d.Id(), updatedDnsRecordJson), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished updating DNS Record %q: %s", d.Id(), updatedDnsRecordJson), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 	return dnsRecordRead(ctx, d, meta)
 }
 
 func dnsRecordImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	tflog.Debug(ctx, fmt.Sprintf("Importing DNS Record %q", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Importing DNS Record %q", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 
 	envIDAndDnsRecordId := d.Id()
 	parts := strings.Split(envIDAndDnsRecordId, "/")
@@ -265,7 +265,7 @@ func dnsRecordImport(ctx context.Context, d *schema.ResourceData, meta interface
 	if _, err := readDnsRecordAndSetAttributes(ctx, d, meta, environmentId, dnsRecordId); err != nil {
 		return nil, fmt.Errorf("error importing DNS Record %q: %s", d.Id(), err)
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Finished importing DNS Record %q", d.Id()), map[string]interface{}{dnsRecordKey: d.Id()})
+	tflog.Debug(ctx, fmt.Sprintf("Finished importing DNS Record %q", d.Id()), map[string]interface{}{dnsRecordLoggingKey: d.Id()})
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -277,7 +277,7 @@ func waitForDnsRecordToProvision(ctx context.Context, c *Client, environmentId, 
 		PollInterval: pollInterval,
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q provisioning status to become %q", dnsRecordId, stateCreated), map[string]interface{}{dnsRecordKey: dnsRecordId})
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q provisioning status to become %q", dnsRecordId, stateCreated), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 	if _, err := stateConf.WaitForStateContext(c.networkingAccessPointV1ApiContext(ctx)); err != nil {
 		return err
 	}
@@ -589,7 +589,7 @@ func waitForDnsRecordToBeDeleted(ctx context.Context, c *Client, environmentId, 
 		PollInterval: pollInterval,
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q to be deleted", dnsRecordId), map[string]interface{}{dnsRecordKey: dnsRecordId})
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q to be deleted", dnsRecordId), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 	if _, err := stateConf.WaitForStateContext(c.networkingAccessPointV1ApiContext(ctx)); err != nil {
 		return err
 	}
@@ -1104,11 +1104,11 @@ func dnsRecordProvisionStatus(ctx context.Context, c *Client, environmentId stri
 	return func() (result interface{}, s string, err error) {
 		dnsRecord, resp, err := executeDnsRecordRead(c.networkingAccessPointV1ApiContext(ctx), c, environmentId, dnsRecordId)
 		if err != nil {
-			tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err, resp)), map[string]interface{}{dnsRecordKey: dnsRecordId})
+			tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err, resp)), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 			return nil, stateUnknown, err
 		}
 
-		tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q provisioning status to become %q or %q: current status is %q", dnsRecordId, stateReady, stateCreated, dnsRecord.Status.GetPhase()), map[string]interface{}{dnsRecordKey: dnsRecordId})
+		tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Record %q provisioning status to become %q or %q: current status is %q", dnsRecordId, stateReady, stateCreated, dnsRecord.Status.GetPhase()), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 		if dnsRecord.Status.GetPhase() == stateProvisioning || dnsRecord.Status.GetPhase() == stateReady || dnsRecord.Status.GetPhase() == stateCreated {
 			return dnsRecord, dnsRecord.Status.GetPhase(), nil
 		} else if dnsRecord.Status.GetPhase() == stateFailed {
@@ -1127,7 +1127,7 @@ func dnsForwarderProvisionStatus(ctx context.Context, c *Client, environmentId s
 			return nil, stateUnknown, err
 		}
 
-		tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Forwarder %q provisioning status to become %q or %q: current status is %q", dnsForwarderId, stateReady, stateCreated, dnsForwarder.Status.GetPhase()), map[string]interface{}{dnsRecordKey: dnsForwarderId})
+		tflog.Debug(ctx, fmt.Sprintf("Waiting for DNS Forwarder %q provisioning status to become %q or %q: current status is %q", dnsForwarderId, stateReady, stateCreated, dnsForwarder.Status.GetPhase()), map[string]interface{}{dnsForwarderKey: dnsForwarderId})
 		if dnsForwarder.Status.GetPhase() == stateProvisioning || dnsForwarder.Status.GetPhase() == stateReady || dnsForwarder.Status.GetPhase() == stateCreated {
 			return dnsForwarder, dnsForwarder.Status.GetPhase(), nil
 		} else if dnsForwarder.Status.GetPhase() == stateFailed {
@@ -1571,18 +1571,18 @@ func dnsRecordDeleteStatus(ctx context.Context, c *Client, environmentId, dnsRec
 	return func() (result interface{}, s string, err error) {
 		dnsRecord, resp, err := executeDnsRecordRead(c.networkingAccessPointV1ApiContext(ctx), c, environmentId, dnsRecordId)
 		if err != nil {
-			tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err, resp)), map[string]interface{}{dnsRecordKey: dnsRecordId})
+			tflog.Warn(ctx, fmt.Sprintf("Error reading DNS Record %q: %s", dnsRecordId, createDescriptiveError(err, resp)), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 
 			isResourceNotFound := isNonKafkaRestApiResourceNotFound(resp)
 			if isResourceNotFound {
-				tflog.Debug(ctx, fmt.Sprintf("Finishing DNS Record %q deletion process: Received %d status code when reading %q DNS Record", dnsRecordId, resp.StatusCode, dnsRecordId), map[string]interface{}{dnsRecordKey: dnsRecordId})
+				tflog.Debug(ctx, fmt.Sprintf("Finishing DNS Record %q deletion process: Received %d status code when reading %q DNS Record", dnsRecordId, resp.StatusCode, dnsRecordId), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 				return 0, stateDone, nil
 			} else {
-				tflog.Debug(ctx, fmt.Sprintf("Exiting DNS Record %q deletion process: Failed when reading DNS Record: %s: %s", dnsRecordId, createDescriptiveError(err, resp), dnsRecord.Status.GetErrorMessage()), map[string]interface{}{dnsRecordKey: dnsRecordId})
+				tflog.Debug(ctx, fmt.Sprintf("Exiting DNS Record %q deletion process: Failed when reading DNS Record: %s: %s", dnsRecordId, createDescriptiveError(err, resp), dnsRecord.Status.GetErrorMessage()), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 				return nil, stateFailed, err
 			}
 		}
-		tflog.Debug(ctx, fmt.Sprintf("Performing DNS Record %q deletion process: DNS Record %d's status is %q", dnsRecordId, resp.StatusCode, dnsRecord.Status.GetPhase()), map[string]interface{}{dnsRecordKey: dnsRecordId})
+		tflog.Debug(ctx, fmt.Sprintf("Performing DNS Record %q deletion process: DNS Record %d's status is %q", dnsRecordId, resp.StatusCode, dnsRecord.Status.GetPhase()), map[string]interface{}{dnsRecordLoggingKey: dnsRecordId})
 		return dnsRecord, stateInProgress, nil
 	}
 }


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- DNS Forwarder provisioning log lines are now searchable by `dns_forwarder_id`; they were previously tagged with `dns_record_id`.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. — *rename plus one log field; no runtime behavior to verify.*
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. — *no new resource or data source; `tflog` field names have no test surface.*
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR. — *none needed; no user-facing surface changes.*
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag

What
----
Two small things, both about `TF_LOG` structured-logging field names.

**1. Naming consistency.** `constants.go` declares 55 logging keys named `<resource>LoggingKey`. DNS Record is the only one named `<resource>Key`. Renamed `dnsRecordKey` → `dnsRecordLoggingKey`.

**2. A copy-paste slip.** One call in `waitForDnsForwarderToProvision` logged a DNS *Forwarder* id under the DNS *Record* key, so those lines couldn't be found by `dns_forwarder_id`. Every other call in that function already used `dnsForwarderKey`.

The rename is mechanical; the second is a one-word fix. No behavior change.

Found while migrating `confluent_dns_record` to generated code (the generator emits `dnsRecordLoggingKey`, which is what exposed the inconsistency), split out because it stands alone.

Blast Radius
----
None for Terraform behavior — these names appear only in `TF_LOG=DEBUG` output, never in state, plans, or the API. Anyone grepping provider debug logs for `dns_record_id` in a DNS Forwarder context would now find nothing there; that is the point of the fix.

References
----------
- [APIE-1431](https://confluentinc.atlassian.net/browse/APIE-1431)
- Stacked on #1105

Test & Review
-------------
`go build ./...`, `go vet ./internal/...`, `go vet -tags "live_test all" ./internal/...` and `go test ./internal/provider/ -run TestProvider` (which runs the SDK's `InternalValidate`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APIE-1431]: https://confluentinc.atlassian.net/browse/APIE-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ