### PR TITLE
improve(CI): Write per-test Terraform debug logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ prebuilt/
 # JUnit XML written by gotestsum under CI and consumed by `test-results publish`
 *-report.xml
 
+# Per-test terraform debug logs written by TF_LOG_PATH_MASK under CI, and the artifact tarball
+tflogs/
+tflogs.tar.gz
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,11 +40,15 @@ blocks:
       epilogue:
         always:
           commands:
-            # Epilogue so a failed run still reports (a timed-out or canceled one won't).
-            # --ignore-missing covers `make all` failing before testacc writes its report.
-            # --trim-output-to is set explicitly because trimming keeps the LAST N characters, and
-            # TF_LOG=debug emits ~1.7k chars of teardown noise after the assertion error; the
-            # default window would keep only that noise and drop the error itself.
+            # First: a non-zero epilogue command skips the rest, and the runs most likely to fail
+            # the publish below are exactly the ones whose debug logs matter. Tarred so ~699
+            # per-test files cost one upload rather than 699. The agent is ephemeral, so this is
+            # the only thing preserving them.
+            - if [ -d tflogs ]; then tar -czf tflogs.tar.gz tflogs && artifact push job tflogs.tar.gz --force; else echo "no terraform debug logs to push"; fi
+            # Epilogue so a failed run still reports; a timed-out or canceled one won't, which now
+            # costs the debug logs above too. --ignore-missing covers `make all` failing before
+            # testacc writes its report. --trim-output-to is a backstop for the stdout that
+            # TF_LOG_PATH_MASK doesn't capture, since trimming keeps the LAST N characters.
             - test-results publish unit-report.xml acceptance-report.xml -N "build-test-release" --ignore-missing --trim-output-to 20000
 
 after_pipeline:

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,15 @@ endif
 # shared stderr stream, so a failure's captured output is the assertion error alone instead of
 # whatever the other parallel tests happened to be logging. .semaphore/semaphore.yml tars
 # $(TFLOG_DIR) into a job artifact; without that push these files die with the agent.
+# The mask must be absolute: go test runs each binary from its own package directory, so a
+# relative path resolves under internal/provider rather than here, and the SDK treats a mask it
+# cannot open as fatal and kills the whole run.
 .PHONY: testacc
 testacc:
 ifeq ($(CI),true)
 	@$(MAKE) gotestsum
 	mkdir -p $(TFLOG_DIR)
-	TF_LOG=debug TF_LOG_PATH_MASK='$(TFLOG_DIR)/%s.log' TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- $(TEST) $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
+	TF_LOG=debug TF_LOG_PATH_MASK='$(CURDIR)/$(TFLOG_DIR)/%s.log' TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- $(TEST) $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 else
 	TF_LOG=debug TF_ACC=1 $(GOCMD) test $(TEST) -v $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 endif

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ GOENV         := GO111MODULE=on
 GOCMD         := $(GOENV) go
 # Pinned rather than @latest: the JUnit XML it emits is a contract with `test-results publish`.
 GOTESTSUM_VERSION := v1.13.0
+# Per-test terraform debug logs under CI; pushed as a job artifact by .semaphore/semaphore.yml.
+TFLOG_DIR     := tflogs
 GOBUILD       ?= CGO_ENABLED=0 $(GOCMD) build -mod=vendor
 GOOS          ?= $(shell go env GOOS)
 GOARCH        ?= $(shell go env GOARCH)
@@ -115,11 +117,16 @@ else
 	$(GOCMD) test ./...
 endif
 
+# TF_LOG_PATH_MASK routes each test's terraform debug output to its own file rather than the
+# shared stderr stream, so a failure's captured output is the assertion error alone instead of
+# whatever the other parallel tests happened to be logging. .semaphore/semaphore.yml tars
+# $(TFLOG_DIR) into a job artifact; without that push these files die with the agent.
 .PHONY: testacc
 testacc:
 ifeq ($(CI),true)
 	@$(MAKE) gotestsum
-	TF_LOG=debug TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- $(TEST) $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
+	mkdir -p $(TFLOG_DIR)
+	TF_LOG=debug TF_LOG_PATH_MASK='$(TFLOG_DIR)/%s.log' TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- $(TEST) $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 else
 	TF_LOG=debug TF_ACC=1 $(GOCMD) test $(TEST) -v $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 endif


### PR DESCRIPTION
> Stacked on #1119. Review that one first.

Release Notes
---------

No user-facing changes. This is CI configuration only.

Checklist
---------

Most items below concern provider behavior and don't apply: this PR changes only `.semaphore/semaphore.yml`, the `Makefile`'s CI test invocation, and `.gitignore`. No provider code ships.

- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

With #1119 you can see which test failed. The detail attached to it is less trustworthy: `make testacc` runs with `TF_LOG=debug`, terraform writes that to the shared stderr stream, and Go's test runner attributes stray stderr to whichever test happens to be current. In a local reproduction a failing test's captured output held 10,429 characters of a _different, passing_ test's debug logging sitting after the real error.

`TF_LOG_PATH_MASK` gives each test its own log file, so a failure's captured output is the assertion error rather than whatever else was running. The debug output isn't discarded: the epilogue tars the directory and pushes it as a job artifact.

Blast Radius
----

None for customers. No provider code, no resource or data-source behavior, nothing in the released binary.

CI-side, terraform's debug output moves out of the job log and into a job artifact. That is the point (the job log has been exceeding Semaphore's 16 MB cap), but it does mean the artifact push is now the only thing preserving it, so it runs first in the epilogue rather than after the report publish. A job that times out or is cancelled skips the epilogue entirely and loses both, which is a pre-existing limitation this inherits.

References
----------

- Parent PR: #1119
- `TF_LOG_PATH_MASK` in the SDK this repo already depends on: https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.16.0/website/docs/plugin/sdkv2/testing/acceptance-tests/index.mdx
- Implementation that names the file after the test: https://github.com/hashicorp/terraform-plugin-log/blob/v0.4.0/tfsdklog/sink.go#L99-L104

Test & Review
-------------

Verified against the same `terraform-plugin-log v0.4.0` this repo depends on, in a throwaway module with two parallel tests each logging through `tflog`:

| file            | own lines | foreign lines |
| --------------- | --------- | ------------- |
| `TestAlpha.log` | 50        | 0             |
| `TestBravo.log` | 0         | 50            |

Zero cross-contamination, and zero debug lines left on the console (20 bytes of console output total). Also confirmed `make -n testacc` is byte-identical to the parent branch outside CI, so local runs keep their existing behavior and log destination.

**Observed on a real CI run** ([workflow](https://semaphore.ci.confluent.io/workflows/211e5f40-6ee2-417a-99a7-4677325ea247/summary)), using a deliberately failing acceptance test that has since been dropped. The same test was also run against #1119 without this change, so the two are directly comparable on identical input.

Without the per-test split, the assertion arrives wrapped in about four seconds of that test's provider debug output, with roughly 2 KB of further logging after it. With this change, the captured output is the assertion and nothing else:

```
ci_report_canary_test.go:51: Step 1/1 error: Check failed: Check 1/1 error:
  data.confluent_ip_group.test_ip_group_resource_label:
  Attribute 'group_name' expected "deliberately-wrong-value...", got "CorpNet"
```

No `sdk.helper_resource` lines, no `tf_provider_addr=`, no container teardown noise. Grepping that job's log for the debug patterns that saturate `master`'s logs returns zero matches, and `tflogs.tar.gz` was attached to the job at 14.5 KB.

An earlier revision of this branch used a relative `TF_LOG_PATH_MASK`, which is worth knowing about because the failure mode is severe and silent. `go test` runs each test binary from its own package directory, so a relative mask resolves under `internal/provider/` rather than where `mkdir` created it, and `helper/logging.SetOutput` calls `log.Fatal` when it cannot open the mask. The acceptance run recorded 1 test instead of 698. That is why the mask is now rooted at `$(CURDIR)`.
