### PR TITLE
docs: document OAuth support for confluent_api_key

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -156,7 +156,6 @@ provider "confluent" {
 Complete examples (with Okta and Microsoft Azure Entra ID as identity provider) for using OAuth credentials with the Confluent Terraform Provider can be found [here](https://github.com/confluentinc/terraform-provider-confluent/tree/master/examples/configurations/authentication-using-oauth).
 
 -> **Note:** You still need `cloud_api_key` and `cloud_api_secret` to manage below Confluent Cloud resources/data-sources as they are not supported with OAuth credentials yet:
-* `confluent_api_key` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_api_key).
 * `confluent_catalog_integration` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_catalog_integration) and [data-source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_catalog_integration).
 * `confluent_custom_connector_plugin` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_custom_connector_plugin).
 * `confluent_flink_artifact` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_artifact).

--- a/docs/resources/confluent_api_key.md
+++ b/docs/resources/confluent_api_key.md
@@ -229,25 +229,33 @@ resource "azurerm_key_vault_secret" "connect-xyz-consumer-secret" {
 
 -> **Note:** You must set the `API_KEY_SECRET` (`secret`) environment variable before importing an API Key.
 
+-> **Note:** Importing an API Key relies on the provider's authentication. You can authenticate with either `cloud_api_key` / `cloud_api_secret` or [OAuth credentials](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#oauth-credentials). When authenticating with OAuth, configure the `oauth` block in your provider configuration instead of setting `CONFLUENT_CLOUD_API_KEY` / `CONFLUENT_CLOUD_API_SECRET`; you must still set `API_KEY_SECRET`.
+
 You can import a Cluster API Key by using the Environment ID and Cluster API Key ID in the format `<Environment ID>/<Cluster API Key ID>`, for example:
 
 ```shell
+# Option #1: Provider authenticated with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
+$ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
 
-# Option #1: Cluster API Key 
+# Option #2: Provider authenticated with OAuth (see the `oauth {}` block in the provider configuration)
+$ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
 ```
 
 You can import a Cloud or Tableflow API Key by using Cloud or Tableflow API Key ID, for example:
 
 ```shell
+# Option #1: Provider authenticated with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
+$ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
 
-# Option #2: Cloud or Tableflow API Key
+# Option #2: Provider authenticated with OAuth (see the `oauth {}` block in the provider configuration)
+$ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
 ```
 

--- a/docs/resources/confluent_api_key.md
+++ b/docs/resources/confluent_api_key.md
@@ -229,30 +229,40 @@ resource "azurerm_key_vault_secret" "connect-xyz-consumer-secret" {
 
 -> **Note:** You must set the `API_KEY_SECRET` (`secret`) environment variable before importing an API Key. This applies whether the provider is authenticated with a Cloud API key/secret or [OAuth credentials](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#oauth-credentials): the API Key Mgmt API does not return an API Key's secret after creation, so it cannot be read back on import.
 
+-> **Note:** When authenticating with OAuth, `CONFLUENT_CLOUD_API_KEY` and `CONFLUENT_CLOUD_API_SECRET` must not be set (they populate `cloud_api_key` / `cloud_api_secret`, which the provider rejects when an `oauth {}` block is present). Unset them in your shell or CI environment before importing.
+
 You can import a Cluster API Key by using the Environment ID and Cluster API Key ID in the format `<Environment ID>/<Cluster API Key ID>`, for example:
 
+When the provider is authenticated with a Cloud API key/secret:
+
 ```shell
-# Authenticate with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
+```
 
-# Authenticate with OAuth (configure the `oauth {}` block in the provider configuration)
+When the provider is authenticated with OAuth (configure the `oauth {}` block in the provider configuration):
+
+```shell
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
 ```
 
 You can import a Cloud or Tableflow API Key by using Cloud or Tableflow API Key ID, for example:
 
+When the provider is authenticated with a Cloud API key/secret:
+
 ```shell
-# Authenticate with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
+```
 
-# Authenticate with OAuth (configure the `oauth {}` block in the provider configuration)
+When the provider is authenticated with OAuth (configure the `oauth {}` block in the provider configuration):
+
+```shell
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
 ```

--- a/docs/resources/confluent_api_key.md
+++ b/docs/resources/confluent_api_key.md
@@ -227,20 +227,18 @@ resource "azurerm_key_vault_secret" "connect-xyz-consumer-secret" {
 
 ## Import
 
--> **Note:** You must set the `API_KEY_SECRET` (`secret`) environment variable before importing an API Key.
-
--> **Note:** Importing an API Key relies on the provider's authentication. You can authenticate with either `cloud_api_key` / `cloud_api_secret` or [OAuth credentials](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#oauth-credentials). When authenticating with OAuth, configure the `oauth` block in your provider configuration instead of setting `CONFLUENT_CLOUD_API_KEY` / `CONFLUENT_CLOUD_API_SECRET`; you must still set `API_KEY_SECRET`.
+-> **Note:** You must set the `API_KEY_SECRET` (`secret`) environment variable before importing an API Key. This applies whether the provider is authenticated with a Cloud API key/secret or [OAuth credentials](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs#oauth-credentials): the API Key Mgmt API does not return an API Key's secret after creation, so it cannot be read back on import.
 
 You can import a Cluster API Key by using the Environment ID and Cluster API Key ID in the format `<Environment ID>/<Cluster API Key ID>`, for example:
 
 ```shell
-# Option #1: Provider authenticated with a Cloud API key/secret
+# Authenticate with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
 
-# Option #2: Provider authenticated with OAuth (see the `oauth {}` block in the provider configuration)
+# Authenticate with OAuth (configure the `oauth {}` block in the provider configuration)
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX7FHD2GV"
 ```
@@ -248,13 +246,13 @@ $ terraform import confluent_api_key.example_kafka_api_key "env-abc123/UTT6WDRXX
 You can import a Cloud or Tableflow API Key by using Cloud or Tableflow API Key ID, for example:
 
 ```shell
-# Option #1: Provider authenticated with a Cloud API key/secret
+# Authenticate with a Cloud API key/secret
 $ export CONFLUENT_CLOUD_API_KEY="<cloud_api_key>"
 $ export CONFLUENT_CLOUD_API_SECRET="<cloud_api_secret>"
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
 
-# Option #2: Provider authenticated with OAuth (see the `oauth {}` block in the provider configuration)
+# Authenticate with OAuth (configure the `oauth {}` block in the provider configuration)
 $ export API_KEY_SECRET="<api_key_secret>"
 $ terraform import confluent_api_key.example_cloud_api_key "4UEXOMMWIBE5KZQG"
 ```


### PR DESCRIPTION
## Summary

`confluent_api_key` now works with OAuth credentials — the provider threads the STS/OAuth token in `apiKeysV2ApiContext` (`internal/provider/utils.go`), which serves create, read, and import. This PR updates the docs to reflect that.

## Changes

- **`docs/index.md`** — Remove `confluent_api_key` from the "not supported with OAuth credentials yet" list. (The other four entries are left untouched.)
- **`docs/resources/confluent_api_key.md`**
  - Add a note in the Import section clarifying that the provider can authenticate with either a Cloud API key/secret or OAuth credentials.
  - `API_KEY_SECRET` is still required in both cases: the API Key Mgmt API does not return an API Key's secret after creation, so it cannot be read back on import (`apiKeyImport` errors on an empty `API_KEY_SECRET`, and `setApiKeyAttributes` never populates `secret`).
  - Add an OAuth variant to both import shell examples (Cluster and Cloud/Tableflow) so Cloud key/secret is no longer presented as the only path.

## Notes

- Docs-only change; no code changes.
- Verified against current `master`: OAuth is wired for the API Key client, and the `API_KEY_SECRET` import requirement is still enforced in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)