### PR TITLE
APIE-1541: Document that provider-level flink_principal_id takes precedence over the principal block

### DIFF
--- a/docs/resources/confluent_flink_connection.md
+++ b/docs/resources/confluent_flink_connection.md
@@ -78,6 +78,8 @@ resource "confluent_flink_connection" "example" {
 }
 ```
 
+!> **Warning:** With Option #2, `flink_principal_id` in the `provider` block takes precedence over the `principal` block of the resource, which is silently ignored. To run resources under different principals, use Option #1, or declare one [aliased provider](https://developer.hashicorp.com/terraform/language/providers/configuration) per principal and select it with the `provider` meta-argument.
+
 The following arguments are supported:
 
 - `organization` (Optional Configuration Block) supports the following:

--- a/docs/resources/confluent_flink_materialized_table.md
+++ b/docs/resources/confluent_flink_materialized_table.md
@@ -81,6 +81,8 @@ resource "confluent_flink_materialized_table" "example" {
 }
 ```
 
+!> **Warning:** With Option #2, `flink_principal_id` in the `provider` block takes precedence over the `principal` block of the resource, which is silently ignored. To run resources under different principals, use Option #1, or declare one [aliased provider](https://developer.hashicorp.com/terraform/language/providers/configuration) per principal and select it with the `provider` meta-argument.
+
 ### Stopping and Resuming a Materialized Table
 
 A running Materialized Table can be paused and later resumed by toggling the `stopped` attribute. The default value is `false` (running). To stop the table, set `stopped = true` and run `terraform apply`; to resume it, set `stopped = false` (or remove the attribute) and apply again. The Materialized Table is preserved across stop/resume — only its execution is paused.

--- a/docs/resources/confluent_flink_statement.md
+++ b/docs/resources/confluent_flink_statement.md
@@ -83,6 +83,8 @@ resource "confluent_flink_statement" "example" {
 }
 ```
 
+!> **Warning:** With Option #2, `flink_principal_id` in the `provider` block takes precedence over the `principal` block of the resource, which is silently ignored. To run resources under different principals, use Option #1, or declare one [aliased provider](https://developer.hashicorp.com/terraform/language/providers/configuration) per principal and select it with the `provider` meta-argument.
+
 ### Example: Create a model using a Flink Connection
 
 Use a [`confluent_flink_connection`](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_connection) resource to


### PR DESCRIPTION
Release Notes
---------

Examples
- Documented that `flink_principal_id` set in the `provider` block takes precedence over the `principal` block of the `confluent_flink_statement`, `confluent_flink_materialized_table`, and `confluent_flink_connection` resources.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

Docs-only change: no provider code is touched, so the testing, live testing, and feature-enablement items do not apply.

What
----

When all Flink attributes are set in the `provider` block (Option #2), `extractFlinkPrincipalId` short-circuits on `client.isFlinkMetadataSet` and returns the provider-level value, so the resource's `principal` block is ignored rather than rejected:

https://github.com/confluentinc/terraform-provider-confluent/blob/master/internal/provider/resource_flink_statement.go#L697-L714

`setAttributes` also skips refreshing that block in this mode, so a `principal` block that disagrees with `flink_principal_id` never shows up as drift. The plan keeps displaying the configured service account while the statement actually runs as `flink_principal_id`, and users hit this as a `Table not found` or an authorization error for a statement that works via the Confluent CLI, with nothing in the plan to explain it. This is distinct from the OAuth identity-pool issue fixed in v2.67.0 (#979), which is why it still comes up in support.

This PR adds the same two-sentence warning to the `Option #2` section of the `confluent_flink_statement`, `confluent_flink_materialized_table`, and `confluent_flink_connection` docs. The wording is byte-identical in all three files, and it points at Option #1, or one aliased provider per principal, as the way to run resources under different principals.

Blast Radius
----
None. Documentation only; no resource, data source, or provider behavior changes.

References
----------
- Fixed the related OAuth case: #979 (v2.67.0)

Test & Review
-------------
Docs-only change. Rendered each modified page with the Terraform Registry doc preview tool (https://registry.terraform.io/tools/doc-preview):

<img width="677" height="637" alt="image" src="https://github.com/user-attachments/assets/70827d5b-774d-4ef3-9012-4c6b50141403" />
