### PR TITLE
INC-12684: Remove filter length validation from pool and group mapping resources

### DIFF
--- a/internal/provider/resource_certificate_pool.go
+++ b/internal/provider/resource_certificate_pool.go
@@ -59,10 +59,9 @@ func certificatePoolResource() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			paramFilter: {
-				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "A filter expression in Supported Common Expression Language (CEL) that specifies which identities can authenticate using your certificate pool.",
-				ValidateFunc: validation.StringLenBetween(1, 300),
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A filter expression in Supported Common Expression Language (CEL) that specifies which identities can authenticate using your certificate pool.",
 			},
 		},
 	}

--- a/internal/provider/resource_group_mapping.go
+++ b/internal/provider/resource_group_mapping.go
@@ -53,10 +53,9 @@ func groupMappingResource() *schema.Resource {
 				Description: "A description explaining the purpose and use of the group mapping.",
 			},
 			paramFilter: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 300),
-				Description:  "A single group identifier or a condition based on [supported CEL operators](https://docs.confluent.io/cloud/current/access-management/authenticate/sso/group-mapping/overview.html#supported-cel-operators-for-group-mapping) that defines which groups are included.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A single group identifier or a condition based on [supported CEL operators](https://docs.confluent.io/cloud/current/access-management/authenticate/sso/group-mapping/overview.html#supported-cel-operators-for-group-mapping) that defines which groups are included.",
 			},
 		},
 	}

--- a/internal/provider/resource_identity_pool.go
+++ b/internal/provider/resource_identity_pool.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	identityproviderv2 "github.com/confluentinc/ccloud-sdk-go-v2/identity-provider/v2"
 )
@@ -58,10 +57,9 @@ func identityPoolResource() *schema.Resource {
 				Description: "The JSON Web Token (JWT) claim to extract the authenticating identity to Confluent resources from (see [Registered Claim Names](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) for more details). This appears in the audit log records, showing, for example, that \"identity Z used identity pool X to access topic A\".",
 			},
 			paramFilter: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 300),
-				Description:  "A filter expression in [Supported Common Expression Language (CEL)](https://docs.confluent.io/cloud/current/access-management/authenticate/oauth/identity-pools.html#supported-common-expression-language-cel-filters) that specifies which identities can authenticate using your identity pool (see [Set identity pool filters](https://docs.confluent.io/cloud/current/access-management/authenticate/oauth/identity-pools.html#set-identity-pool-filters) for more details).",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A filter expression in [Supported Common Expression Language (CEL)](https://docs.confluent.io/cloud/current/access-management/authenticate/oauth/identity-pools.html#supported-common-expression-language-cel-filters) that specifies which identities can authenticate using your identity pool (see [Set identity pool filters](https://docs.confluent.io/cloud/current/access-management/authenticate/oauth/identity-pools.html#set-identity-pool-filters) for more details).",
 			},
 		},
 	}


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Removed the client-side 300-character limit on the `filter` attribute of `confluent_identity_pool`, `confluent_certificate_pool`, and `confluent_group_mapping`. Filter length is validated by the API, so the provider no longer rejects longer CEL filters at plan time.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. — No new resource or functionality; the existing acceptance tests for all three resources and their data sources were run and pass (output in `Test & Review`).
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality. — Live tests already cover all three and compile against this change; they run on `master` before a release. Listed in `Test & Review`.
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing. — https://confluent.slack.com/archives/C02TG07V058/p1786559836775009
- [x] I have included rate limit/load testing results. — N/A, no change to request volume or shape.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR. — N/A, none of the three resources' docs stated the limit.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in: — N/A, this removes a client-side check and gates nothing.
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

> Live suites run on `master` before a release; manual validation is linked under `Test & Review`.

What
----

`filter` on all three resources was validated with `validation.StringLenBetween(_, 300)`, derived from the OpenAPI spec's `maxLength: 300`. All three now declare no `ValidateFunc` on `filter`:

| Resource | Before | After |
|---|---|---|
| `confluent_identity_pool` | `StringLenBetween(0, 300)` | *(none)* |
| `confluent_certificate_pool` | `StringLenBetween(1, 300)` | *(none)* |
| `confluent_group_mapping` | `StringLenBetween(1, 300)` | *(none)* |

**That 300 does not apply universally.** It is not a bound the provider can assume holds for everyone, so enforcing it client-side rejects configurations the API would have accepted — at `plan` time, before any request is made, leaving no workaround. Filter length is the API's to validate, and the API is the only place it can be evaluated correctly.

**Why not just raise the constant.** Any number hard-coded in the provider is a second source of truth, and no single value is right in every case, so a larger one would postpone this rather than fix it. Removing the check avoids the class of problem.

`Required` still rejects an *absent* `filter` — it fires when the key is missing (`helper/schema/schema.go`: `if !ok { if schema.Required {...} }`), independently of any `ValidateFunc`.

Blast Radius
----

Limited to the `filter` attribute of `confluent_identity_pool`, `confluent_certificate_pool`, and `confluent_group_mapping`, and to client-side validation only — no request, state, or import behavior changes.

It only widens what the provider accepts, so no existing configuration stops working. A `filter` the API rejects is now caught at `apply` instead of `plan`, with nothing created in that path. Empty filters are also no longer rejected client-side on `group_mapping` and `certificate_pool`, matching `confluent_identity_pool`.

Test & Review
-------------

### Manual validation

Applied against real Confluent Cloud and written up in the testing thread: https://confluent.slack.com/archives/C02TG07V058/p1786559836775009

### Acceptance tests — run, passing

Every existing WireMock acceptance test covering the three resources and their data sources, run on this branch with `TF_ACC=1`:

```
$ TF_ACC=1 go test ./internal/provider/ \
    -run 'TestAccGroupMapping$|TestAccIdentityPool$|TestAccCertificatePool$' -v

--- PASS: TestAccCertificatePool (6.32s)
--- PASS: TestAccGroupMapping    (4.80s)
--- PASS: TestAccIdentityPool    (4.43s)
ok      github.com/confluentinc/terraform-provider-confluent/internal/provider  16.125s

$ TF_ACC=1 go test ./internal/provider/ \
    -run 'TestAccDataSourceGroupMapping|TestAccDataSourceIdentityPool|TestAccDataSourceCertificatePool' -v

--- PASS: TestAccDataSourceCertificatePool (4.42s)
--- PASS: TestAccDataSourceGroupMapping    (4.26s)
--- PASS: TestAccDataSourceIdentityPool    (4.22s)
ok      github.com/confluentinc/terraform-provider-confluent/internal/provider  13.417s
```

No new acceptance test is added. The change removes a validator, and the meaningful assertion — that a filter longer than 300 characters is accepted — cannot be made against WireMock, which does not enforce a length limit and would pass whether or not the validator were still present. A test that appeared to cover this would be misleading; the real check is the live/manual apply below.

### Live tests — compile-verified, not executed

The three resources are covered by:

| Test | File | Build tag |
|---|---|---|
| `TestAccGroupMappingLive`, `TestAccGroupMappingUpdateLive` | `resource_group_mapping_live_test.go` | `live_test && (all \|\| rbac)` |
| `TestAccGroupMappingDataSourceLive` | `data_source_group_mapping_live_test.go` | `live_test && (all \|\| rbac)` |
| `TestAccIdentityPoolLive` | `resource_identity_pool_live_test.go` | `live_test && (all \|\| rbac)` |
| `TestAccDataSourceIdentityPoolLive` | `data_source_identity_pool_live_test.go` | `live_test && (all \|\| rbac)` |
| `TestAccIdentityPoolDriftDetection` | `resource_identity_pool_drift_test.go` | `live_test && (all \|\| rbac \|\| drift)` |
| `TestAccCertificatePoolLive` | `resource_certificate_pool_live_test.go` | `live_test && (all \|\| rbac)` |

These need real Confluent Cloud credentials, so they are **not run here** — the live suites run on `master` before a release, which is where this change gets exercised end to end. What this PR verifies is that they still compile against the changed schema, worth checking explicitly since the change removes an import:

```
$ go vet -tags "live_test all" ./internal/provider/    # clean
```

### Static checks

- `go build ./...` — clean.
- `go test ./internal/provider/ -run TestProvider` — passes. The only gate that runs the Terraform SDK's `InternalValidate` over every resource and data-source schema, so it is what confirms the schemas are still well-formed after the edit.
- `gofmt -l` on all three files — clean.
- `go vet ./internal/provider/` — clean. Relevant because `filter` held the only `validation.*` reference in `resource_identity_pool.go`, so removing it left that file's `helper/validation` import unused, which is a compile error; the import is dropped in the same change. The other two files keep the import for their remaining validators.
- Confirmed no test asserted the 300 bound (so nothing was silently weakened), and no `docs/resources/*.md` stated it (so no doc drift).

Diff is 9 insertions / 13 deletions across the three files — the validator lines, one now-unused import, and the `gofmt` re-alignment that removing the longest struct key causes in each block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
