### PR TITLE
[DEMO — do not merge] Read-error regression test fails on master (response body dropped)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,14 +124,19 @@ endif
 # assertion rather than whatever else was logging; semaphore.yml tars $(TF_LOG_DIR) as an artifact.
 # The mask must be absolute: go test runs each binary from its own package directory, and the SDK
 # log.Fatals on a mask it cannot open.
+# DEMO BRANCH ONLY (do not merge): testacc is scoped to the single regression test so CI runs
+# just it and goes red quickly and unambiguously on master's read-path bug. On `master` this
+# test FAILS (the surfaced error's "raw response body" is empty); with the one-line fix in the
+# companion PR it PASSES. On the real branches this target runs the whole acceptance suite.
+DEMO_RUN := -run 'TestAccServiceAccountReadErrorSurfacesResponseBody$$'
 .PHONY: testacc
 testacc:
 ifeq ($(CI),true)
 	@$(GOTESTSUM_INSTALL)
 	mkdir -p $(TF_LOG_DIR)
-	TF_LOG=debug TF_LOG_PATH_MASK='$(CURDIR)/$(TF_LOG_DIR)/%s.log' TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- $(TEST) $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
+	TF_LOG=debug TF_LOG_PATH_MASK='$(CURDIR)/$(TF_LOG_DIR)/%s.log' TF_ACC=1 $(GOENV) gotestsum --format testname --junitfile acceptance-report.xml -- ./internal/provider/ $(DEMO_RUN) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 else
-	TF_LOG=debug TF_ACC=1 $(GOCMD) test $(TEST) -v $(TESTARGS) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
+	TF_LOG=debug TF_ACC=1 $(GOCMD) test ./internal/provider/ -v $(DEMO_RUN) -coverprofile=coverage.txt -covermode=atomic -timeout 120m -failfast
 endif
 	@echo "finished testacc"
 

--- a/internal/provider/resource_service_account_readerror_test.go
+++ b/internal/provider/resource_service_account_readerror_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/walkerus/go-wiremock"
+)
+
+// TestAccServiceAccountReadErrorSurfacesResponseBody pins the behavior the regenerated read
+// path fixes.
+//
+// createDescriptiveError (utils.go) enriches an otherwise-opaque error by reading the HTTP
+// response body. The body is a one-shot stream the SDK hands back as a single re-readable
+// buffer. The previous generated read path called createDescriptiveError twice on the same
+// response, once to log and once to return, so the second call read an already-drained body
+// and the error surfaced to Terraform silently dropped the detail. The current code enriches
+// once and reuses it.
+//
+// Create succeeds, then the post-create read returns a 501 whose body cannot be parsed as a
+// structured API error, which is exactly the case that falls back to reading the raw body.
+// (501, like the ksql error test, because the provider's retryable client does not retry it,
+// so the read fails on a single deterministic response.) ExpectError requires that raw body
+// to reach the surfaced error, so this fails on the old read path (body comes back empty) and
+// passes on the current one.
+func TestAccServiceAccountReadErrorSurfacesResponseBody(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	const readErrorScenario = "ServiceAccountReadError"
+	const stateCreated = "sa-created"
+	const stateReadFailed = "sa-read-failed"
+	const readErrorMarker = "SA_READ_500_MARKER_quota_backend_unavailable"
+
+	// Create succeeds and sets the id (sa-1jjv26, from the fixture).
+	createSaResponse, _ := ioutil.ReadFile("../testdata/service_account/create_sa.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo("/iam/v2/service-accounts")).
+		InScenario(readErrorScenario).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(stateCreated).
+		WillReturn(string(createSaResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	// The post-create read returns an unparseable error carrying a distinctive marker. 501 is
+	// used (like the ksql error test) because it is not one of the statuses the provider's
+	// retryable HTTP client retries, so the read fails on a single deterministic response.
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/iam/v2/service-accounts/sa-1jjv26")).
+		InScenario(readErrorScenario).
+		WhenScenarioStateIs(stateCreated).
+		WillSetStateTo(stateReadFailed).
+		WillReturn(fmt.Sprintf(`{"unexpected":%q}`, readErrorMarker), contentTypeJSONHeader, http.StatusNotImplemented))
+
+	// The failed apply leaves a tainted resource; teardown deletes it.
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo("/iam/v2/service-accounts/sa-1jjv26")).
+		InScenario(readErrorScenario).
+		WhenScenarioStateIs(stateReadFailed).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckServiceAccountConfig(mockServerUrl, "sa_read_error", "test_sa_read_error", "desc"),
+				ExpectError: regexp.MustCompile(readErrorMarker),
+			},
+		},
+	})
+}


### PR DESCRIPTION
> ⚠️ **This is a demonstration PR. Do not merge.** It contains **no fix** — only a new test (plus a one-line CI tweak), added on top of `master`. **CI is _expected_ to fail here.** That red build is the whole point: it proves the bug exists on `master` today. The actual fix is in #1136.
>
> CI (`make testacc`) is scoped on this branch to run **only** `TestAccServiceAccountReadErrorSurfacesResponseBody`, so the failure is fast and unambiguously about this one test.

## The clearest evidence: the CI log shows both halves of the bug

In the failing CI run you can see the same response body **present** in the debug log and **empty** in the error returned to the user — that gap is the bug:

```
[WARN]  Error reading service account "sa-1jjv26": 501 Not Implemented; could not
        parse error details; raw response body: "{\"unexpected\":\"SA_READ_500_MARKER_quota_backend_unavailable\"}"
        ^ the FIRST createDescriptiveError call (for the log) drained the body — it still has the detail

  Error: 501 Not Implemented; could not parse error details; raw response body: ""
        ^ the SECOND call (the error returned to Terraform) re-read the now-empty stream — detail gone

--- FAIL: TestAccServiceAccountReadErrorSurfacesResponseBody
```

## What this PR is for

To let you see, in CI, that `master` has the bug. This branch = `master` + one new test file, nothing else. When CI runs the test against `master`'s current code, the test **fails**. #1136 changes one line of `serviceAccountRead` and the same test **passes**.

## The bug, in plain terms

1. When the provider reads a resource and the API returns an error, it builds a human-readable error message. For errors it can't otherwise interpret, it does that by **reading the HTTP response body** and appending it to the message.
2. An HTTP response body is a **one-time stream** — you can read it **once**. After that, it's empty.
3. `master`'s read code reads it **twice**: once to write a debug log line, and once to build the error returned to you. The **first** read drains the stream, so the **second** read (the error you actually see) gets an **empty** body.
4. Net effect: on those errors, the detail shows up in the debug log but is **missing from the error Terraform prints**.

## What the test does

`TestAccServiceAccountReadErrorSurfacesResponseBody` (a WireMock-backed acceptance test, same style as `TestAccCreateKsqlClusterError`):

1. Stubs the API so **create succeeds**, then the **read** returns a `501 Not Implemented` whose body contains a marker string, `SA_READ_500_MARKER_quota_backend_unavailable`.
   - (`501` is used because it's the one 5xx the provider does **not** retry, so the read fails on a single clean response — see `factory_utils.go`.)
2. Asserts (via `ExpectError`) that the marker **appears in the error** Terraform surfaces.

## Expected vs actual

- **Expected (correct) behavior:** the raw response body — including the marker — reaches the error message, so the user can see what the API actually said.
- **Actual behavior on `master`:** the body was already drained by the first read, so the surfaced error contains an **empty** body and the marker is missing. The test fails with:

  ```
  expected an error with pattern, no match on:
  Error: 501 Not Implemented; could not parse error details; raw response body: ""
  --- FAIL: TestAccServiceAccountReadErrorSurfacesResponseBody
  ```

  Note the `raw response body: ""` — empty. That empty string **is** the bug.

## How to see the failure

- **In CI:** the `Build & Test & Release` block runs `make all`, which runs the acceptance suite with `TF_ACC=1`; this test fails there.
- **Locally:**

  ```bash
  TF_ACC=1 go test ./internal/provider/ \
    -run TestAccServiceAccountReadErrorSurfacesResponseBody -v
  ```

  (needs Docker for WireMock.) On this branch → **FAIL**. On #1136 → **PASS**.

## The fix

#1136 makes `serviceAccountRead` read/enrich the error **once** and reuse it for both the log and the returned error, so the body survives. Same one-line pattern exists in every generated resource's read path.
