### PR TITLE
Preserve the response body when classifying invalid-API-key 403s

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -950,6 +950,9 @@ func ResponseHasStatusForbiddenDueToInvalidAPIKey(response *http.Response) bool 
 		if err != nil {
 			return false
 		}
+		// An http.Response body is a one-shot stream; restore it after reading so a later
+		// reader (e.g. createDescriptiveError) still sees the raw body instead of an empty one.
+		response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		bodyString := string(bodyBytes)
 		// Search for a specific error message that indicates the invalid Cloud API Key has been used
 		return strings.Contains(bodyString, "invalid API key")

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -947,12 +947,14 @@ func createDescriptiveError(err error, resp ...*http.Response) error {
 func ResponseHasStatusForbiddenDueToInvalidAPIKey(response *http.Response) bool {
 	if ResponseHasExpectedStatusCode(response, http.StatusForbidden) {
 		bodyBytes, err := io.ReadAll(response.Body)
+		// An http.Response body is a one-shot stream: close the original to release it, then
+		// hand later readers (e.g. createDescriptiveError) a fresh reader over the bytes we
+		// consumed, so the raw body is preserved even if the read above returned an error.
+		_ = response.Body.Close()
+		response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		if err != nil {
 			return false
 		}
-		// An http.Response body is a one-shot stream; restore it after reading so a later
-		// reader (e.g. createDescriptiveError) still sees the raw body instead of an empty one.
-		response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		bodyString := string(bodyBytes)
 		// Search for a specific error message that indicates the invalid Cloud API Key has been used
 		return strings.Contains(bodyString, "invalid API key")

--- a/internal/provider/utils_forbidden_apikey_body_test.go
+++ b/internal/provider/utils_forbidden_apikey_body_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody pins that the 403 classifier
+// does not swallow the response body.
+//
+// ResponseHasStatusForbiddenDueToInvalidAPIKey reads resp.Body to look for the invalid-key
+// marker. An http.Response body is a one-shot stream, so if the classifier does not restore it,
+// the next reader on the same response (createDescriptiveError, when building the error returned
+// to Terraform) gets an empty body and the raw API detail is silently dropped.
+//
+// This fails against the old helper (the body is drained after the call) and passes once the
+// helper restores it.
+func TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody(t *testing.T) {
+	const body = `{"errors":[{"detail":"403 forbidden: invalid API key for this operation"}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// The classifier must still detect the invalid-key 403...
+	require.True(t, ResponseHasStatusForbiddenDueToInvalidAPIKey(resp),
+		"a 403 whose body contains the invalid-key marker must be classified as such")
+
+	// ...and must leave resp.Body readable for the next consumer, rather than draining it.
+	remaining, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(remaining),
+		"ResponseHasStatusForbiddenDueToInvalidAPIKey must restore resp.Body after reading it; "+
+			"otherwise the later createDescriptiveError call sees an empty body and the surfaced error loses the raw detail")
+}


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- When a read is rejected with a `403` whose body carries extra detail, that detail is now preserved in the error surfaced to Terraform instead of being dropped.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

**Unchecked items, explained**

| Item | Reason |
|---|---|
| Real Confluent Cloud / manual results / testing thread | The behavior can't be triggered on demand against real Cloud (you can't make the API return an invalid-key 403 with an unparseable body at will); the unit test below covers it deterministically. |
| Live testing | No lifecycle to live-test; this is an error-formatting helper. |
| Rate limit / load testing | No API call is added or altered. |
| Documentation | Internal error-handling helper; no user-facing docs. |

What
----

`ResponseHasStatusForbiddenDueToInvalidAPIKey` (`utils.go`) reads `resp.Body` to look for the invalid-key marker, but never restored it. An `http.Response` body is a one-shot stream, so the next reader on the same response, `createDescriptiveError` building the error returned to Terraform, got an empty body and the raw API detail was silently dropped.

Fix is one line: re-buffer the body after reading it, so later readers still see it.

```go
response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
```

This is a **shared hand-written helper**, so the fix lands once and covers every resource, generated or not. It was surfaced by a Copilot comment on #1136, where the regenerated read path calls the classifier before `createDescriptiveError`; this fixes the root cause rather than reordering (reordering alone would just move the empty body from the error to the classifier).

Blast Radius
----

If this is wrong, error messages for invalid-key `403`s could look different. No resource lifecycle or schema is affected.

Test & Review
-------------

**Unit test**: `TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody` (new). Calls the classifier on a `403` and asserts it both detects the invalid key **and** leaves `resp.Body` readable. It fails against the old helper (`resp.Body` comes back empty) and passes once the body is restored, so it pins the fix. A do-not-merge draft, opened separately, adds only this test on top of `master` to show it failing in CI.
