### PR TITLE
[DEMO — do not merge] 403 invalid-key error drops the response body (fails on master)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,18 @@ build: clean ## Build binary for current OS/ARCH
 # stray stderr parses as framing and invents test cases. --format testname keeps the per-test
 # progress the default pkgname format drops, while still discarding passing tests' output.
 # Unlike live-test*, a failed install fails the build here, since nothing pages on semaphore.yml.
+# DEMO BRANCH ONLY (do not merge): scoped to the single regression test so CI runs just it and
+# goes red quickly and unambiguously on master's 403 body-consumption bug. On `master` this test
+# FAILS (the classifier drains resp.Body and does not restore it); the one-line fix in the
+# companion PR makes it PASS. On the real branches this target runs the whole `./...` suite.
+DEMO_RUN := -run 'TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody$$'
 .PHONY: test
 test:
 ifeq ($(CI),true)
 	@$(GOTESTSUM_INSTALL)
-	$(GOENV) gotestsum --format testname --junitfile unit-report.xml -- ./...
+	$(GOENV) gotestsum --format testname --junitfile unit-report.xml -- ./internal/provider/ $(DEMO_RUN)
 else
-	$(GOCMD) test ./...
+	$(GOCMD) test ./internal/provider/ $(DEMO_RUN)
 endif
 
 # TF_LOG_PATH_MASK gives each test its own debug log, so a failure's captured output is the

--- a/internal/provider/utils_forbidden_apikey_body_test.go
+++ b/internal/provider/utils_forbidden_apikey_body_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody pins that the 403 classifier
+// does not swallow the response body.
+//
+// ResponseHasStatusForbiddenDueToInvalidAPIKey reads resp.Body to look for the invalid-key
+// marker. An http.Response body is a one-shot stream, so if the classifier does not restore it,
+// the next reader on the same response (createDescriptiveError, when building the error returned
+// to Terraform) gets an empty body and the raw API detail is silently dropped.
+//
+// This fails against the old helper (the body is drained after the call) and passes once the
+// helper restores it.
+func TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody(t *testing.T) {
+	const body = `{"errors":[{"detail":"403 forbidden: invalid API key for this operation"}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// The classifier must still detect the invalid-key 403...
+	require.True(t, ResponseHasStatusForbiddenDueToInvalidAPIKey(resp),
+		"a 403 whose body contains the invalid-key marker must be classified as such")
+
+	// ...and must leave resp.Body readable for the next consumer, rather than draining it.
+	remaining, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(remaining),
+		"ResponseHasStatusForbiddenDueToInvalidAPIKey must restore resp.Body after reading it; "+
+			"otherwise the later createDescriptiveError call sees an empty body and the surfaced error loses the raw detail")
+}


### PR DESCRIPTION
> ⚠️ **Demonstration PR. Do not merge.** It contains **no fix** — only a new test (plus a one-line CI scope), added on top of `master`. **CI is _expected_ to fail here.** That red build proves the bug exists on `master` today. The fix is in #1138.
>
> CI (`make test`) is scoped on this branch to run **only** `TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody`, so the failure is fast and unambiguously about this one test. (It's a plain unit test, so no Docker or `TF_ACC` is involved.)

## The bug, in plain terms

1. When a read is rejected with a `403`, the provider checks whether it's due to an invalid API key by **reading the HTTP response body** and searching it for `"invalid API key"` (`ResponseHasStatusForbiddenDueToInvalidAPIKey` in `utils.go`).
2. An HTTP response body is a **one-time stream** — once you read it, it's empty.
3. That check reads the body but **never puts it back**. So the **next** reader on the same response — `createDescriptiveError`, which builds the error message returned to you — gets an **empty** body, and the raw API detail is dropped.

## What the test does

`TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody` (a plain unit test):

1. Builds a `403` response whose body contains the invalid-key marker.
2. Calls the classifier, and asserts it **both** (a) correctly detects the invalid key **and** (b) leaves the body **still readable** afterwards.

## Expected vs actual

- **Expected (correct) behavior:** after the classifier reads the body, the body is still readable, so the later error message can include it.
- **Actual behavior on `master`:** the body is drained and never restored, so reading it again returns `""`. The test fails with:

  ```
  Error Trace: utils_forbidden_apikey_body_test.go:50
      expected: "{\"errors\":[{\"detail\":\"403 forbidden: invalid API key for this operation\"}]}"
      actual  : ""
  Messages: ResponseHasStatusForbiddenDueToInvalidAPIKey must restore resp.Body after reading it; ...
  --- FAIL: TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody
  ```

  That `actual: ""` — the empty body after the call — **is** the bug.

## How to see the failure

- **In CI:** the `Build & Test & Release` block runs `make all` → `make test`; this test fails there.
- **Locally:**

  ```bash
  go test ./internal/provider/ \
    -run TestResponseHasStatusForbiddenDueToInvalidAPIKeyPreservesBody -v
  ```

  On this branch → **FAIL**. On #1138 → **PASS**.

## The fix

#1138 makes the classifier re-buffer the body after reading it (`response.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))`), so later readers still see it. It's a shared helper, so that one line fixes it for every resource.
