### PR TITLE
Add user_agent_suffix provider argument for run attribution

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -303,6 +303,11 @@ func New(version, userAgent string) func() *schema.Provider {
 					ValidateFunc: validation.IntAtLeast(4),
 					Description:  "Maximum number of retries of HTTP client. Defaults to 4.",
 				},
+				"append_user_agent": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Attributes Terraform runs to their source.",
+				},
 				"oauth": providerOAuthSchema(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
@@ -507,6 +512,19 @@ func gatewayDataSourceSchema() *schema.Schema {
 	}
 }
 
+// p.UserAgent already appends the TF_APPEND_USER_AGENT env var, so append_user_agent deliberately
+// has no env default — that would append the same marker twice.
+func buildUserAgent(p *schema.Provider, providerVersion, additionalUserAgent, appendUserAgent string) string {
+	userAgent := p.UserAgent(terraformProviderUserAgent, fmt.Sprintf("%s (https://confluent.cloud; support@confluent.io)", providerVersion))
+	if additionalUserAgent != "" {
+		userAgent = fmt.Sprintf("%s %s", additionalUserAgent, userAgent)
+	}
+	if appendUserAgent = strings.TrimSpace(appendUserAgent); appendUserAgent != "" {
+		userAgent = fmt.Sprintf("%s %s", userAgent, appendUserAgent)
+	}
+	return userAgent
+}
+
 func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Provider, providerVersion, additionalUserAgent string) (interface{}, diag.Diagnostics) {
 	tflog.Info(ctx, "Initializing Terraform Provider for Confluent Cloud")
 	endpoint := d.Get("endpoint").(string)
@@ -531,11 +549,9 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	tableflowApiKey := d.Get("tableflow_api_key").(string)
 	tableflowApiSecret := d.Get("tableflow_api_secret").(string)
 	maxRetries := d.Get("max_retries").(int)
+	appendUserAgent := d.Get("append_user_agent").(string)
 
-	userAgent := p.UserAgent(terraformProviderUserAgent, fmt.Sprintf("%s (https://confluent.cloud; support@confluent.io)", providerVersion))
-	if additionalUserAgent != "" {
-		userAgent = fmt.Sprintf("%s %s", additionalUserAgent, userAgent)
-	}
+	userAgent := buildUserAgent(p, providerVersion, additionalUserAgent, appendUserAgent)
 
 	acceptanceTestMode := false
 	if os.Getenv("TF_ACC") == "1" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -303,10 +303,10 @@ func New(version, userAgent string) func() *schema.Provider {
 					ValidateFunc: validation.IntAtLeast(4),
 					Description:  "Maximum number of retries of HTTP client. Defaults to 4.",
 				},
-				"append_user_agent": {
+				"user_agent_suffix": {
 					Type:        schema.TypeString,
 					Optional:    true,
-					Description: "Attributes Terraform runs to their source.",
+					Description: "Value appended to the User-Agent header, used to attribute Terraform runs to their source (e.g., a config exported from Confluent Cloud Console).",
 				},
 				"oauth": providerOAuthSchema(),
 			},
@@ -512,15 +512,15 @@ func gatewayDataSourceSchema() *schema.Schema {
 	}
 }
 
-// p.UserAgent already appends the TF_APPEND_USER_AGENT env var, so append_user_agent deliberately
+// p.UserAgent already appends the TF_APPEND_USER_AGENT env var, so user_agent_suffix deliberately
 // has no env default — that would append the same marker twice.
-func buildUserAgent(p *schema.Provider, providerVersion, additionalUserAgent, appendUserAgent string) string {
+func buildUserAgent(p *schema.Provider, providerVersion, additionalUserAgent, userAgentSuffix string) string {
 	userAgent := p.UserAgent(terraformProviderUserAgent, fmt.Sprintf("%s (https://confluent.cloud; support@confluent.io)", providerVersion))
 	if additionalUserAgent != "" {
 		userAgent = fmt.Sprintf("%s %s", additionalUserAgent, userAgent)
 	}
-	if appendUserAgent = strings.TrimSpace(appendUserAgent); appendUserAgent != "" {
-		userAgent = fmt.Sprintf("%s %s", userAgent, appendUserAgent)
+	if userAgentSuffix = strings.TrimSpace(userAgentSuffix); userAgentSuffix != "" {
+		userAgent = fmt.Sprintf("%s %s", userAgent, userAgentSuffix)
 	}
 	return userAgent
 }
@@ -549,9 +549,9 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	tableflowApiKey := d.Get("tableflow_api_key").(string)
 	tableflowApiSecret := d.Get("tableflow_api_secret").(string)
 	maxRetries := d.Get("max_retries").(int)
-	appendUserAgent := d.Get("append_user_agent").(string)
+	userAgentSuffix := d.Get("user_agent_suffix").(string)
 
-	userAgent := buildUserAgent(p, providerVersion, additionalUserAgent, appendUserAgent)
+	userAgent := buildUserAgent(p, providerVersion, additionalUserAgent, userAgentSuffix)
 
 	acceptanceTestMode := false
 	if os.Getenv("TF_ACC") == "1" {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -58,6 +58,61 @@ func TestProvider_InternalValidate(t *testing.T) {
 	}
 }
 
+func TestBuildUserAgent(t *testing.T) {
+	// p.UserAgent appends the TF_APPEND_USER_AGENT env var if set, which would leak into the
+	// assertions below, so make sure it is unset for this test.
+	t.Setenv("TF_APPEND_USER_AGENT", "")
+
+	p := New(testVersion, "")()
+
+	base := buildUserAgent(p, testVersion, "", "")
+	if !strings.Contains(base, terraformProviderUserAgent) {
+		t.Fatalf("expected base user agent to contain %q, got %q", terraformProviderUserAgent, base)
+	}
+
+	tests := []struct {
+		name                string
+		additionalUserAgent string
+		appendUserAgent     string
+		wantPrefix          string
+		wantSuffix          string
+	}{
+		{
+			name:            "append_user_agent is added as the last token",
+			appendUserAgent: "confluent_cloud_export",
+			wantSuffix:      "confluent_cloud_export",
+		},
+		{
+			name:            "append_user_agent is trimmed",
+			appendUserAgent: "  confluent_cloud_export  ",
+			wantSuffix:      "confluent_cloud_export",
+		},
+		{
+			name:            "blank append_user_agent leaves the user agent unchanged",
+			appendUserAgent: "   ",
+			wantSuffix:      base,
+		},
+		{
+			name:                "additional user agent is prepended",
+			additionalUserAgent: "confluent-cli/1.2.3",
+			appendUserAgent:     "confluent_cloud_export",
+			wantPrefix:          "confluent-cli/1.2.3",
+			wantSuffix:          "confluent_cloud_export",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUserAgent(p, testVersion, tc.additionalUserAgent, tc.appendUserAgent)
+			if tc.wantPrefix != "" && !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("expected user agent %q to start with %q", got, tc.wantPrefix)
+			}
+			if tc.wantSuffix != "" && !strings.HasSuffix(got, tc.wantSuffix) {
+				t.Errorf("expected user agent %q to end with %q", got, tc.wantSuffix)
+			}
+		})
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	ccApiKey := getEnv("CONFLUENT_CLOUD_API_KEY", "")
 	ccApiSecret := getEnv("CONFLUENT_CLOUD_API_SECRET", "")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -73,36 +73,36 @@ func TestBuildUserAgent(t *testing.T) {
 	tests := []struct {
 		name                string
 		additionalUserAgent string
-		appendUserAgent     string
+		userAgentSuffix     string
 		wantPrefix          string
 		wantSuffix          string
 	}{
 		{
-			name:            "append_user_agent is added as the last token",
-			appendUserAgent: "confluent_cloud_export",
+			name:            "user_agent_suffix is added as the last token",
+			userAgentSuffix: "confluent_cloud_export",
 			wantSuffix:      "confluent_cloud_export",
 		},
 		{
-			name:            "append_user_agent is trimmed",
-			appendUserAgent: "  confluent_cloud_export  ",
+			name:            "user_agent_suffix is trimmed",
+			userAgentSuffix: "  confluent_cloud_export  ",
 			wantSuffix:      "confluent_cloud_export",
 		},
 		{
-			name:            "blank append_user_agent leaves the user agent unchanged",
-			appendUserAgent: "   ",
+			name:            "blank user_agent_suffix leaves the user agent unchanged",
+			userAgentSuffix: "   ",
 			wantSuffix:      base,
 		},
 		{
 			name:                "additional user agent is prepended",
 			additionalUserAgent: "confluent-cli/1.2.3",
-			appendUserAgent:     "confluent_cloud_export",
+			userAgentSuffix:     "confluent_cloud_export",
 			wantPrefix:          "confluent-cli/1.2.3",
 			wantSuffix:          "confluent_cloud_export",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildUserAgent(p, testVersion, tc.additionalUserAgent, tc.appendUserAgent)
+			got := buildUserAgent(p, testVersion, tc.additionalUserAgent, tc.userAgentSuffix)
 			if tc.wantPrefix != "" && !strings.HasPrefix(got, tc.wantPrefix) {
 				t.Errorf("expected user agent %q to start with %q", got, tc.wantPrefix)
 			}


### PR DESCRIPTION
Release Notes
---------

_No user-facing release note — `user_agent_suffix` is an internal attribution mechanism and is intentionally left undocumented._

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [x] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [x] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [x] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

Adds a new optional `user_agent_suffix` provider argument. Its value is appended (last) to the `User-Agent` header of every Confluent Cloud API request, so Terraform runs can be attributed to their source — for example, runs launched from a configuration bundle exported by the Confluent Cloud Console.

- Implemented in `internal/provider/provider.go`: a `TypeString`, `Optional` schema attribute, read in `providerConfigure` and appended to the User-Agent via a new `buildUserAgent` helper.
- **No env default on the attribute**: the terraform-plugin-sdk's `p.UserAgent()` already appends the `TF_APPEND_USER_AGENT` environment variable, so giving the attribute an env default would append the same marker twice.
- **Intentionally undocumented**: this is an internal attribution mechanism, not a user-facing feature, so no `docs/` changes are included.

Blast Radius
----

Low. The argument is optional and defaults to empty — when unset, the `User-Agent` is byte-for-byte unchanged, so existing configurations are unaffected. It only adds a token to the `User-Agent` when explicitly set (and the existing `TF_APPEND_USER_AGENT` environment-variable behavior is unchanged). No resource or data-source behavior changes; no breaking changes or backward-compatibility concerns.

References
----------

- https://confluentinc.atlassian.net/browse/EXP-26599

Test & Review
-------------

Automated (in this PR):
- Unit test `TestBuildUserAgent` covering append-as-last-token, whitespace trimming, blank-input no-op, and that the build-time user agent is still prepended. Run: `go test ./internal/provider/ -run 'TestBuildUserAgent|TestProvider_InternalValidate' -v`.
- `go build ./...` and `go vet ./internal/provider/` pass.

Manual provider-binary verification: build a local provider binary, configure `user_agent_suffix`, and confirm via an HTTP proxy that the marker appears at the end of the outgoing `User-Agent` header on Confluent Cloud API requests.

<img width="1070" height="139" alt="Screenshot 2026-08-20 at 1 06 25 PM" src="https://github.com/user-attachments/assets/d5febb05-c17e-49ab-a934-e6d499e032d7" />
