### PR TITLE
INC-12907 - Allow credential-only updates on Flink materialized tables and statements

### DIFF
--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -772,7 +772,7 @@ func materializedTableImport(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func materializedTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChangesExcept(paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints, paramTableOptions) {
+	if d.HasChangesExcept(paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints, paramTableOptions, paramCredentials, paramRestEndpoint, paramOrganization, paramEnvironment) {
 		return diag.Errorf("error updating Flink Materialized Table %q: only %q, %q, %q, %q, %q, %q, %q, and %q attributes can be updated for Flink Materialized Table", d.Id(), paramQuery, paramStopped, paramComputePool, paramPrincipal, paramColumns, paramWatermark, paramConstraints, paramTableOptions)
 	}
 

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -435,6 +435,157 @@ func testAccCheckMaterializedTableExists(n string) resource.TestCheckFunc {
 		return nil
 	}
 }
+func TestAccFlinkMaterializedTableCredentialUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockTestServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	scenarioName := "confluent_flink_materialized_table Credential Rotation"
+	stateCreated := "Table created"
+	stateDeleted := "Table deleted"
+
+	createResponse, _ := os.ReadFile("../testdata/flink_materialized_table/create_materialized_table.json")
+	readResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_materialized_table.json")
+	readDeletedResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_deleted_materialized_table.json")
+
+	// Step 1: Create
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(stateCreated).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusOK))
+
+	// Step 2: Credential-only update — no-op PUT, server state unchanged
+	_ = wiremockClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(readFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	// Cleanup
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WillSetStateTo(stateDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateDeleted).
+		WillReturn(string(readDeletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	resourceLabel := "cred_rotation_test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_materialized_table.%s", resourceLabel)
+
+	rotatedApiKey := "rotated_test_key"
+	rotatedApiSecret := "rotated_test_secret"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckMaterializedTableDestroy(s, mockTestServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMaterializedTableWithCredentials(mockTestServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", kafkaApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", kafkaApiSecret),
+				),
+			},
+			{
+				Config: testAccCheckMaterializedTableWithCredentials(mockTestServerUrl, resourceLabel, rotatedApiKey, rotatedApiSecret),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", rotatedApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", rotatedApiSecret),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramQuery, "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMaterializedTableWithCredentials(mockServerUrl, resourceLabel, apiKey, apiSecret string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+    	endpoint = "%s"
+	}
+	resource "confluent_flink_materialized_table" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+      display_name  = "%s"
+	  kafka_cluster {
+	    id = "%s"
+	  }
+      stopped = false
+	  query = "SELECT user_id, product_id, price, quantity FROM orders WHERE price > 1000;"
+	  watermark {
+	    column     = "col123"
+	    expression = "exp123"
+	  }
+	  distribution {
+	    bucket_count = 10
+	    kind = "HASH"
+	    keys = [
+	      "keys",
+	      "passwords",
+	    ]
+	  }
+	  table_options = {
+	    "changelog_mode" = "upsert"
+	  }
+	  session_options = {
+	    "sql_local_time_zone" = "UTC"
+	  }
+	constraints {
+      name = "pk_orders"
+      type = "PRIMARY_KEY"
+      columns = ["user_id","product_id"]
+      enforced = false
+      }
+	columns {
+		columns_physical {
+			column_physical_name = "user_id"
+	        column_physical_kind = "Physical"
+	  		column_physical_comment = "string"
+			column_physical_type = "type1"
+		}
+	}
+}
+	`, mockServerUrl, resourceLabel, apiKey, apiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, flinkMaterializedTableDisplayName, flinkMaterializedTableDatabase)
+}
+
 func testAccCheckMaterializedTableDestroy(s *terraform.State, url string) error {
 	testClient := testAccProvider.Meta().(*Client)
 	c := testClient.flinkRestClientFactory.CreateFlinkRestClient(url, flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, flinkPrincipalIdTest, kafkaApiKey, kafkaApiSecret, false, testClient.oauthToken)

--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -332,7 +332,7 @@ func flinkStatementStop(ctx context.Context, d *schema.ResourceData, meta interf
 
 func flinkStatementResume(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Only the `stopped`, `principal.id` and 'compute_pool.id` fields can be updated for Flink statement resume
-	if d.HasChangesExcept(paramStopped, paramPrincipal, paramComputePool) {
+	if d.HasChangesExcept(paramStopped, paramPrincipal, paramComputePool, paramCredentials, paramRestEndpoint, paramOrganization, paramEnvironment) {
 		return diag.Errorf(`error resuming Flink Statement %q: only %q, %q, and %q attributes can be updated for Flink Statement`, d.Id(), paramStopped, paramPrincipal, paramComputePool)
 	}
 

--- a/internal/provider/resource_flink_statement.go
+++ b/internal/provider/resource_flink_statement.go
@@ -242,7 +242,7 @@ func flinkStatementUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Make sure we must have a paramStopped update, or a paramPropertiesSensitive update for version change
 	// stopped: false -> true to trigger flink statement stopping
 	// stopped: true -> false to trigger flink statement resuming
-	if d.HasChangesExcept(paramStopped, paramPropertiesSensitive, paramPrincipal, paramComputePool) {
+	if d.HasChangesExcept(paramStopped, paramPropertiesSensitive, paramPrincipal, paramComputePool, paramCredentials, paramRestEndpoint, paramOrganization, paramEnvironment) {
 		return diag.Errorf(`error updating Flink Statement %q: %q or %q attribute must be updated for Flink Statement, "true" -> "false" to trigger resuming, "false" -> "true" to trigger stopping`, d.Id(), paramStopped, paramPropertiesSensitive)
 	}
 	if d.HasChanges(paramStopped, paramPrincipal, paramComputePool) {
@@ -265,7 +265,7 @@ func flinkStatementUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func flinkStatementStop(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Only the `stopped` field can be updated for Flink statement stop
-	if d.HasChangesExcept(paramStopped, paramPropertiesSensitive) {
+	if d.HasChangesExcept(paramStopped, paramPropertiesSensitive, paramCredentials, paramRestEndpoint, paramOrganization, paramEnvironment) {
 		return diag.Errorf(`error stopping Flink Statement %q: only %q or %q attribute can be updated for Flink Statement`, d.Id(), paramStopped, paramPropertiesSensitive)
 	}
 

--- a/internal/provider/resource_flink_statement_test.go
+++ b/internal/provider/resource_flink_statement_test.go
@@ -470,6 +470,7 @@ func TestAccFlinkStatementCredentialUpdate(t *testing.T) {
 	statePending := "Statement pending"
 	stateCreated := "Statement created"
 	stateStopped := "Statement stopped"
+	stateResumed := "Statement resumed"
 	stateDeleting := "Statement deleting"
 	stateDeleted := "Statement deleted"
 
@@ -507,6 +508,17 @@ func TestAccFlinkStatementCredentialUpdate(t *testing.T) {
 		InScenario(scenarioName).
 		WhenScenarioStateIs(stateStopped).
 		WillReturn(string(stoppedResponse), contentTypeJSONHeader, http.StatusOK))
+
+	// Step 4: Resume with rotated credentials (triggers resume PUT)
+	_ = wiremockClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateStopped).
+		WillSetStateTo(stateResumed).
+		WillReturn(string(runningResponse), contentTypeJSONHeader, http.StatusOK))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateResumed).
+		WillReturn(string(runningResponse), contentTypeJSONHeader, http.StatusOK))
 
 	// Cleanup
 	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readFlinkStatementPath)).
@@ -560,6 +572,15 @@ func TestAccFlinkStatementCredentialUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", rotatedApiKey),
 					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", rotatedApiSecret),
 					resource.TestCheckResourceAttr(fullResourceLabel, "stopped", "true"),
+				),
+			},
+			{
+				Config: testAccCheckFlinkStatementWithCredentials("", mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlinkStatementExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", kafkaApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", kafkaApiSecret),
+					resource.TestCheckResourceAttr(fullResourceLabel, "stopped", "false"),
 				),
 			},
 		},

--- a/internal/provider/resource_flink_statement_test.go
+++ b/internal/provider/resource_flink_statement_test.go
@@ -450,6 +450,164 @@ func testAccCheckFlinkStatementStopped(confluentCloudBaseUrl, mockServerUrl stri
 		flinkStatementNameTest, flinkStatementTest, flinkFirstPropertyKeyTest, flinkFirstPropertyValueTest)
 }
 
+func TestAccFlinkStatementCredentialUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	scenarioName := "confluent_flink_statement Credential Rotation"
+	statePending := "Statement pending"
+	stateCreated := "Statement created"
+	stateStopped := "Statement stopped"
+	stateDeleting := "Statement deleting"
+	stateDeleted := "Statement deleted"
+
+	createResponse, _ := ioutil.ReadFile("../testdata/flink_statement/create_flink_statement.json")
+	pendingResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_pending_flink_statement.json")
+	runningResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_running_flink_statement.json")
+	stoppedResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_stopped_flink_statement.json")
+	deletedResponse, _ := ioutil.ReadFile("../testdata/flink_statement/read_deleted_flink_statement.json")
+
+	// Step 1: Create
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(statePending).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(statePending).
+		WillSetStateTo(stateCreated).
+		WillReturn(string(pendingResponse), contentTypeJSONHeader, http.StatusOK))
+
+	// Steps 1+2: Read in created/running state (credential-only update only reads, no PUT)
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateCreated).
+		WillReturn(string(runningResponse), contentTypeJSONHeader, http.StatusOK))
+
+	// Step 3: Credentials + stopped change (triggers stop PUT)
+	_ = wiremockClient.StubFor(wiremock.Put(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateCreated).
+		WillSetStateTo(stateStopped).
+		WillReturn(string(stoppedResponse), contentTypeJSONHeader, http.StatusOK))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateStopped).
+		WillReturn(string(stoppedResponse), contentTypeJSONHeader, http.StatusOK))
+
+	// Cleanup
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WillSetStateTo(stateDeleting).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateDeleting).
+		WillSetStateTo(stateDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readFlinkStatementPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(stateDeleted).
+		WillReturn(string(deletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	rotatedApiKey := "rotated_test_key"
+	rotatedApiSecret := "rotated_test_secret"
+
+	resourceLabel := "cred_rotation_test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_statement.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckFlinkStatementDestroy(s, mockServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckFlinkStatementWithCredentials("", mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlinkStatementExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", kafkaApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", kafkaApiSecret),
+				),
+			},
+			{
+				Config: testAccCheckFlinkStatementWithCredentials("", mockServerUrl, resourceLabel, rotatedApiKey, rotatedApiSecret, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlinkStatementExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", rotatedApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", rotatedApiSecret),
+					resource.TestCheckResourceAttr(fullResourceLabel, "statement", flinkStatementTest),
+				),
+			},
+			{
+				Config: testAccCheckFlinkStatementWithCredentials("", mockServerUrl, resourceLabel, rotatedApiKey, rotatedApiSecret, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlinkStatementExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.key", rotatedApiKey),
+					resource.TestCheckResourceAttr(fullResourceLabel, "credentials.0.secret", rotatedApiSecret),
+					resource.TestCheckResourceAttr(fullResourceLabel, "stopped", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFlinkStatementWithCredentials(confluentCloudBaseUrl, mockServerUrl, resourceLabel, apiKey, apiSecret string, stopped bool) string {
+	stoppedStr := "false"
+	if stopped {
+		stoppedStr = "true"
+	}
+	return fmt.Sprintf(`
+	provider "confluent" {
+      endpoint = "%s"
+    }
+	resource "confluent_flink_statement" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+
+	  statement_name = "%s"
+	  statement = "%s"
+	  stopped = %s
+
+	  properties = {
+		"%s" = "%s"
+	  }
+	}
+	`, confluentCloudBaseUrl, resourceLabel, apiKey, apiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest,
+		flinkStatementNameTest, flinkStatementTest, stoppedStr, flinkFirstPropertyKeyTest, flinkFirstPropertyValueTest)
+}
+
 func testAccCheckFlinkStatementResumed(confluentCloudBaseUrl, mockServerUrl string) string {
 	return fmt.Sprintf(`
 	provider "confluent" {


### PR DESCRIPTION
## Summary

- The `confluent_flink_materialized_table` and `confluent_flink_statement` resources reject credential-only updates (e.g. after API key rotation) with an "unsupported attribute" error, blocking CI/CD pipelines.
- The `HasChangesExcept` guards in `materializedTableUpdate`, `flinkStatementUpdate`, and `flinkStatementStop` were missing `credentials`, `rest_endpoint`, `organization`, and `environment` from their exception lists.
- Added these four provider-local params to all three guards, matching the pattern already used by `kafka_acl`, `schema_registry_cluster_config`, and other resources in this provider.

## Test plan

- [x] New `TestAccFlinkMaterializedTableCredentialUpdate`: creates a materialized table, rotates credentials only, verifies the update succeeds without error
- [x] New `TestAccFlinkStatementCredentialUpdate`: creates a statement, rotates credentials only, then rotates credentials + stops the statement simultaneously -- verifies both cases succeed
- [x] Existing `TestAccFlinkMaterializedTable` and `TestAccFlinkStatement2` pass (no regressions)

Co-Authored-By: Claude <noreply@anthropic.com>