### PR TITLE
[APIE-1555] Telemetry payload model, run ID, sequence, and timing capture (TFCA-B1)

### DIFF
--- a/internal/provider/telemetry/run.go
+++ b/internal/provider/telemetry/run.go
@@ -1,0 +1,64 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+)
+
+// A provider subprocess handles many concurrent CRUD/import calls over its life
+// but has a single identity throughout. These process-scoped primitives supply
+// that identity: one run ID and one monotonic sequence counter, shared by every
+// operation the process handles. Together they let downstream consumers
+// reconstruct the invocation order of Terraform's concurrent, independently
+// timed operations, which is not otherwise preserved.
+var (
+	runIDOnce sync.Once
+	runID     string
+	sequence  atomic.Int64
+)
+
+// RunID returns the process-scoped run identifier, generating it exactly once
+// on first use and returning that same value for the life of the process.
+//
+// The sync.Once — rather than minting the ID inside the single
+// ConfigureProvider call — is deliberate defense-in-depth. Terraform Core calls
+// ConfigureProvider exactly once per provider subprocess today, but that is an
+// implementation detail of Core, not a documented protocol guarantee, so RunID
+// does not rely on it.
+//
+// See Usage.RunID for the (non-)correlation semantics callers must respect.
+func RunID() string {
+	runIDOnce.Do(func() {
+		runID = uuid.New().String()
+	})
+	return runID
+}
+
+// NextSequence returns the next sequence number for this process, starting at 1
+// and increasing by one per call. It is safe for concurrent use by Terraform's
+// parallel graph walk.
+//
+// Call it at wrapper entry, not at report time, so the number reflects the
+// order operations were invoked in even when the matching report is later
+// dropped. Because reports can be dropped, the emitted stream of sequence
+// numbers within a run may contain gaps; consumers must not assume every value
+// arrived.
+func NextSequence() int64 {
+	return sequence.Add(1)
+}

--- a/internal/provider/telemetry/telemetry.go
+++ b/internal/provider/telemetry/telemetry.go
@@ -1,0 +1,168 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry holds the client-side analytics data model and the
+// process-scoped primitives used to correlate provider operations.
+//
+// It is intentionally self-contained: it owns only the payload struct
+// (Usage), the process run identifier and sequence counter (run.go), the
+// captured configuration snapshot (Config), and timing capture (Timer). The
+// central CRUD/import wrapping that populates a Usage, the opt-out wiring that
+// sets Config.Disabled, and the network transport that reports a Usage all
+// live outside this package and consume it. It does no network or filesystem
+// I/O, reads no environment variables, and does not reference the provider's
+// Client struct.
+package telemetry
+
+import "time"
+
+// Operation identifies which CRUD or import entry point produced a Usage event.
+// The set is closed and known at compile time; these are the only valid values.
+type Operation string
+
+const (
+	OperationCreate Operation = "create"
+	OperationRead   Operation = "read"
+	OperationUpdate Operation = "update"
+	OperationDelete Operation = "delete"
+	OperationImport Operation = "import"
+)
+
+// Usage is the metadata-only analytics payload emitted for a single resource
+// CRUD or import operation. Its field names mirror the TFCA-A1 `terraform/v1`
+// usage contract; the concrete wire client is generated separately (TFCA-A2),
+// and this struct is the provider-internal model that populates it.
+//
+// By construction Usage never carries attribute values or the keys of a
+// user-controlled map: ChangedAttributes holds schema-declared attribute names
+// only (enforced by the TFCA-B2 build-time allowlist), and StackFrames is
+// populated only on the panic path.
+type Usage struct {
+	// RunID is the process-scoped run identifier, stable for the life of one
+	// provider subprocess (see RunID).
+	//
+	// It is process-scoped — not plan-scoped and not config-scoped. Terraform
+	// Core launches a fresh provider subprocess for each phase and for each
+	// aliased provider block, so:
+	//   - A `plan` and its paired `apply` run as two separate processes and
+	//     therefore carry two different, non-joinable RunIDs. RunID does not
+	//     correlate a plan to its apply, even within a single `terraform apply`
+	//     invocation.
+	//   - Each aliased `provider "confluent"` instance runs in its own process
+	//     and produces its own RunID. RunID does not correlate one aliased
+	//     instance to another.
+	// Downstream consumers must not assume RunID joins any of these.
+	RunID string `json:"run_id"`
+
+	// Sequence is the monotonic, per-process invocation order of this
+	// operation, assigned at wrapper entry (see NextSequence). Because reports
+	// can be dropped, the sequence values that actually arrive within a run may
+	// contain gaps; consumers must not assume every value was emitted.
+	Sequence int64 `json:"sequence"`
+
+	// StartTime is when the operation began, captured at wrapper entry.
+	StartTime time.Time `json:"start_time"`
+
+	// Duration is the operation's elapsed time in milliseconds, measured with a
+	// monotonic clock from entry to just before the wrapped function returns.
+	Duration int64 `json:"duration"`
+
+	// OS is the reporting host's operating system (runtime.GOOS), e.g. "darwin".
+	OS string `json:"os"`
+
+	// Arch is the reporting host's architecture (runtime.GOARCH), e.g. "arm64".
+	Arch string `json:"arch"`
+
+	// ProviderVersion is the released provider version, constant for the life
+	// of the process.
+	ProviderVersion string `json:"provider_version"`
+
+	// TerraformVersion is the version of Terraform Core that launched the
+	// provider.
+	TerraformVersion string `json:"terraform_version"`
+
+	// ResourceType is the resource's Terraform type, e.g. "confluent_kafka_topic".
+	ResourceType string `json:"resource_type"`
+
+	// Operation is which CRUD or import entry point ran.
+	Operation Operation `json:"operation"`
+
+	// ChangedAttributes lists schema-declared attribute names only — never a
+	// map's keys and never any attribute value. Callers should supply a
+	// non-nil slice (empty when nothing changed) so it serializes as [] rather
+	// than null.
+	ChangedAttributes []string `json:"changed_attributes"`
+
+	// Error reports whether the operation returned an error or panicked.
+	Error bool `json:"error"`
+
+	// StackFrames is a trimmed stack trace, populated only on the panic path
+	// and omitted otherwise.
+	StackFrames []string `json:"stack_frames,omitempty"`
+}
+
+// Config is the process-scoped telemetry configuration captured once during
+// provider configuration and only read thereafter.
+//
+// It is a value type holding only immutable scalar fields, so copying it shares
+// no mutable state with the original — deliberately unlike the provider's
+// Client struct, parts of which are mutated after configuration without a lock
+// (so "the Client is safe to read concurrently" is not an assumption these
+// fields can rely on). Value semantics alone do not publish it safely: the
+// happens-before edge that lets the CRUD goroutines read it comes from writing
+// the one canonical Config during provider configuration, before those
+// goroutines start (a downstream, TFCA-B6/B3 concern).
+type Config struct {
+	// RunID is a snapshot of the process run identifier (see RunID).
+	RunID string
+
+	// Disabled reports whether telemetry reporting is turned off for this
+	// process (opt-out environment variable or non-default endpoint). It is
+	// populated by the opt-out wiring (TFCA-B6); the zero value leaves
+	// telemetry enabled.
+	Disabled bool
+}
+
+// NewConfig snapshots the process run identifier together with the opt-out
+// decision into an immutable Config.
+func NewConfig(disabled bool) Config {
+	return Config{
+		RunID:    RunID(),
+		Disabled: disabled,
+	}
+}
+
+// Timer captures the start of an operation so the wrapper can record the
+// Usage.StartTime and Usage.Duration, timed from wrapper entry to just before
+// the wrapped function returns.
+type Timer struct {
+	start time.Time
+}
+
+// StartTimer captures the current time as an operation's start. Call it at
+// wrapper entry.
+func StartTimer() Timer {
+	return Timer{start: time.Now()}
+}
+
+// StartTime returns the instant the timer was started.
+func (t Timer) StartTime() time.Time {
+	return t.start
+}
+
+// Elapsed returns the time elapsed since the timer was started. Call it just
+// before the wrapped function returns.
+func (t Timer) Elapsed() time.Duration {
+	return time.Since(t.start)
+}

--- a/internal/provider/telemetry/telemetry.go
+++ b/internal/provider/telemetry/telemetry.go
@@ -29,20 +29,27 @@ import "time"
 
 // Operation identifies which CRUD or import entry point produced a Usage event.
 // The set is closed and known at compile time; these are the only valid values.
+//
+// The values are the uppercase verbs defined by the TFCA-A1 contract's
+// `operation` x-extensible-enum (pattern ^[A-Z][A-Z0-9_]*$), so a Usage
+// serializes to the exact contract value. The cc-cli-service backend records
+// this value verbatim as the terraform.operation span attribute and lowercases
+// it itself only when composing the <resource_type>.<operation> span name.
 type Operation string
 
 const (
-	OperationCreate Operation = "create"
-	OperationRead   Operation = "read"
-	OperationUpdate Operation = "update"
-	OperationDelete Operation = "delete"
-	OperationImport Operation = "import"
+	OperationCreate Operation = "CREATE"
+	OperationRead   Operation = "READ"
+	OperationUpdate Operation = "UPDATE"
+	OperationDelete Operation = "DELETE"
+	OperationImport Operation = "IMPORT"
 )
 
 // Usage is the metadata-only analytics payload emitted for a single resource
-// CRUD or import operation. Its field names mirror the TFCA-A1 `terraform/v1`
-// usage contract; the concrete wire client is generated separately (TFCA-A2),
-// and this struct is the provider-internal model that populates it.
+// CRUD or import operation. Its JSON field names mirror the TFCA-A1
+// `terraform-usage/v1` usage contract; the concrete wire client is generated
+// separately (TFCA-A2), and this struct is the provider-internal model that
+// populates it.
 //
 // By construction Usage never carries attribute values or the keys of a
 // user-controlled map: ChangedAttributes holds schema-declared attribute names
@@ -71,12 +78,12 @@ type Usage struct {
 	// contain gaps; consumers must not assume every value was emitted.
 	Sequence int64 `json:"sequence"`
 
-	// StartTime is when the operation began, captured at wrapper entry.
-	StartTime time.Time `json:"start_time"`
+	// StartedAt is when the operation began, captured at wrapper entry.
+	StartedAt time.Time `json:"started_at"`
 
-	// Duration is the operation's elapsed time in milliseconds, measured with a
+	// DurationMs is the operation's elapsed time in milliseconds, measured with a
 	// monotonic clock from entry to just before the wrapped function returns.
-	Duration int64 `json:"duration"`
+	DurationMs int64 `json:"duration_ms"`
 
 	// OS is the reporting host's operating system (runtime.GOOS), e.g. "darwin".
 	OS string `json:"os"`

--- a/internal/provider/telemetry/telemetry_test.go
+++ b/internal/provider/telemetry/telemetry_test.go
@@ -1,0 +1,292 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Acceptance criterion: a single run ID is shared across every resource
+// operation in one provider process. RunID() must return the same, valid,
+// non-empty value on every call.
+func TestRunID_StableAndValid(t *testing.T) {
+	first := RunID()
+	if first == "" {
+		t.Fatal("RunID() returned an empty string")
+	}
+	if _, err := uuid.Parse(first); err != nil {
+		t.Fatalf("RunID() = %q is not a valid UUID: %v", first, err)
+	}
+	for i := 0; i < 1000; i++ {
+		if got := RunID(); got != first {
+			t.Fatalf("RunID() not stable across calls: first=%q got=%q", first, got)
+		}
+	}
+}
+
+// Under Terraform's parallel graph walk many goroutines read the run ID
+// concurrently. Every one must observe the same value, and -race must stay
+// clean.
+func TestRunID_ConcurrentStable(t *testing.T) {
+	const goroutines = 64
+	results := make([]string, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = RunID()
+		}(i)
+	}
+	wg.Wait()
+
+	want := RunID()
+	for i, got := range results {
+		if got != want {
+			t.Fatalf("goroutine %d observed RunID %q, want %q", i, got, want)
+		}
+	}
+}
+
+// Acceptance criterion: sequence numbers are monotonic. Consecutive calls from
+// a single goroutine must increase by exactly one. This holds regardless of the
+// counter's absolute starting point (other tests in the package also advance
+// it), because the assertion is relative to the first value observed here.
+//
+// This and the concurrent test below share the process-global counter and must
+// not call t.Parallel(): they rely on no other test advancing it during their
+// run.
+func TestNextSequence_MonotonicSequential(t *testing.T) {
+	first := NextSequence()
+	for i := int64(1); i <= 1000; i++ {
+		got := NextSequence()
+		if got != first+i {
+			t.Fatalf("NextSequence() = %d, want %d", got, first+i)
+		}
+	}
+}
+
+// Acceptance criterion: sequence numbers are race-free under a parallel graph
+// walk (run with -race). Every value allocated across all goroutines must be
+// unique, and the full set must be gap-free — proving each increment was
+// atomic. The uniqueness and count assertions are order-independent; the
+// gap-free (contiguity) assertion additionally assumes no other goroutine
+// advances the counter during this test, which holds only while the sequence
+// tests stay serial (see the note on the sequential test above — no
+// t.Parallel()).
+func TestNextSequence_ConcurrentUniqueAndContiguous(t *testing.T) {
+	const goroutines = 16
+	const perGoroutine = 500
+	const total = goroutines * perGoroutine
+
+	out := make(chan int64, total)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				out <- NextSequence()
+			}
+		}()
+	}
+	wg.Wait()
+	close(out)
+
+	seen := make(map[int64]struct{}, total)
+	var min, max int64
+	first := true
+	for v := range out {
+		if _, dup := seen[v]; dup {
+			t.Fatalf("duplicate sequence number %d — increment was not atomic", v)
+		}
+		seen[v] = struct{}{}
+		if first {
+			min, max, first = v, v, false
+			continue
+		}
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+
+	if len(seen) != total {
+		t.Fatalf("got %d unique sequence numbers, want %d", len(seen), total)
+	}
+	if max-min+1 != int64(total) {
+		t.Fatalf("sequence numbers not contiguous: min=%d max=%d span=%d, want span %d",
+			min, max, max-min+1, total)
+	}
+}
+
+func TestTimer(t *testing.T) {
+	before := time.Now()
+	tm := StartTimer()
+	after := time.Now()
+
+	if tm.StartTime().Before(before) || tm.StartTime().After(after) {
+		t.Fatalf("StartTime %v not within [%v, %v]", tm.StartTime(), before, after)
+	}
+
+	// Lower bound only: time.Sleep guarantees at least `sleep` elapses, so this
+	// rejects a constant or clock-ignoring Elapsed() while staying non-flaky
+	// under CI load (no upper bound, which would be load-sensitive).
+	const sleep = 5 * time.Millisecond
+	time.Sleep(sleep)
+	if e := tm.Elapsed(); e < sleep {
+		t.Fatalf("Elapsed() = %v, want >= %v", e, sleep)
+	}
+}
+
+func TestNewConfig(t *testing.T) {
+	enabled := NewConfig(false)
+	if enabled.Disabled {
+		t.Error("NewConfig(false).Disabled = true, want false")
+	}
+	if enabled.RunID != RunID() {
+		t.Errorf("NewConfig(false).RunID = %q, want the process RunID %q", enabled.RunID, RunID())
+	}
+
+	disabled := NewConfig(true)
+	if !disabled.Disabled {
+		t.Error("NewConfig(true).Disabled = false, want true")
+	}
+	if disabled.RunID != enabled.RunID {
+		t.Errorf("Config.RunID differs across NewConfig calls: %q vs %q — run ID must be process-scoped",
+			disabled.RunID, enabled.RunID)
+	}
+}
+
+// topLevelJSONKeys marshals v and returns its top-level object as a key->raw map.
+func topLevelJSONKeys(t *testing.T, v any) map[string]json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(%T) error: %v", v, err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("json.Unmarshal error: %v", err)
+	}
+	return fields
+}
+
+var requiredUsageFields = []string{
+	"run_id", "sequence", "start_time", "duration", "os", "arch",
+	"provider_version", "terraform_version", "resource_type", "operation",
+	"changed_attributes", "error",
+}
+
+// Every required contract field must appear on the wire for BOTH a fully
+// populated event and a zero-value / read-shaped event. The zero-value case is
+// the load-bearing one: duration, sequence, and changed_attributes are exactly
+// the fields that are legitimately zero/empty on a common read, so this guards
+// against a future ",omitempty" (or a switch to pointer fields) silently
+// dropping them from the payload for the most common events — a regression a
+// fully-populated fixture cannot catch.
+func TestUsage_RequiredFieldsAlwaysPresent(t *testing.T) {
+	cases := map[string]Usage{
+		"populated": {
+			RunID:             "run-1",
+			Sequence:          3,
+			StartTime:         time.Unix(0, 0).UTC(),
+			Duration:          42,
+			OS:                "darwin",
+			Arch:              "arm64",
+			ProviderVersion:   "2.0.0",
+			TerraformVersion:  "1.9.0",
+			ResourceType:      "confluent_kafka_topic",
+			Operation:         OperationCreate,
+			ChangedAttributes: []string{"config"},
+			Error:             false,
+		},
+		// Everything left at its zero value except operation: duration 0,
+		// sequence 0, error false, nil changed attributes, empty strings.
+		"zero-value read": {
+			Operation: OperationRead,
+		},
+	}
+
+	for name, u := range cases {
+		fields := topLevelJSONKeys(t, u)
+		for _, key := range requiredUsageFields {
+			if _, ok := fields[key]; !ok {
+				t.Errorf("[%s] Usage JSON is missing required field %q", name, key)
+			}
+		}
+		if _, ok := fields["stack_frames"]; ok {
+			t.Errorf("[%s] stack_frames must be omitted when empty", name)
+		}
+	}
+}
+
+// stack_frames is optional (panic path only): omitted when empty, present when
+// populated.
+func TestUsage_StackFramesOptional(t *testing.T) {
+	empty := topLevelJSONKeys(t, Usage{Operation: OperationDelete})
+	if _, ok := empty["stack_frames"]; ok {
+		t.Error("stack_frames must be omitted when empty")
+	}
+
+	populated := topLevelJSONKeys(t, Usage{
+		Operation:   OperationDelete,
+		StackFrames: []string{"runtime/panic.go:884"},
+	})
+	if _, ok := populated["stack_frames"]; !ok {
+		t.Error("stack_frames must be present when populated")
+	}
+}
+
+// changed_attributes is a required, non-omitempty array. A nil slice serializes
+// as JSON null and a non-nil slice as [] — pinned here so downstream callers
+// (B3) know to pass a non-nil (possibly empty) slice for read events that
+// change nothing, rather than emitting null.
+func TestUsage_ChangedAttributesSerialization(t *testing.T) {
+	nilFields := topLevelJSONKeys(t, Usage{Operation: OperationRead})
+	if got := string(nilFields["changed_attributes"]); got != "null" {
+		t.Errorf("nil ChangedAttributes serialized as %s, want null", got)
+	}
+
+	emptyFields := topLevelJSONKeys(t, Usage{Operation: OperationRead, ChangedAttributes: []string{}})
+	if got := string(emptyFields["changed_attributes"]); got != "[]" {
+		t.Errorf("empty ChangedAttributes serialized as %s, want []", got)
+	}
+}
+
+// operation is a fixed, compile-time-known set; the wire values must be exactly
+// these lowercase verbs so downstream span names (<resource_type>.<operation>)
+// stay stable.
+func TestOperationConstants(t *testing.T) {
+	want := map[Operation]string{
+		OperationCreate: "create",
+		OperationRead:   "read",
+		OperationUpdate: "update",
+		OperationDelete: "delete",
+		OperationImport: "import",
+	}
+	for op, s := range want {
+		if string(op) != s {
+			t.Errorf("operation constant = %q, want %q", string(op), s)
+		}
+	}
+}

--- a/internal/provider/telemetry/telemetry_test.go
+++ b/internal/provider/telemetry/telemetry_test.go
@@ -192,15 +192,15 @@ func topLevelJSONKeys(t *testing.T, v any) map[string]json.RawMessage {
 }
 
 var requiredUsageFields = []string{
-	"run_id", "sequence", "start_time", "duration", "os", "arch",
+	"run_id", "sequence", "started_at", "duration_ms", "os", "arch",
 	"provider_version", "terraform_version", "resource_type", "operation",
 	"changed_attributes", "error",
 }
 
 // Every required contract field must appear on the wire for BOTH a fully
 // populated event and a zero-value / read-shaped event. The zero-value case is
-// the load-bearing one: duration, sequence, and changed_attributes are exactly
-// the fields that are legitimately zero/empty on a common read, so this guards
+// the load-bearing one: duration_ms, sequence, and changed_attributes are
+// exactly the fields that are legitimately zero/empty on a common read, so this guards
 // against a future ",omitempty" (or a switch to pointer fields) silently
 // dropping them from the payload for the most common events — a regression a
 // fully-populated fixture cannot catch.
@@ -209,8 +209,8 @@ func TestUsage_RequiredFieldsAlwaysPresent(t *testing.T) {
 		"populated": {
 			RunID:             "run-1",
 			Sequence:          3,
-			StartTime:         time.Unix(0, 0).UTC(),
-			Duration:          42,
+			StartedAt:         time.Unix(0, 0).UTC(),
+			DurationMs:        42,
 			OS:                "darwin",
 			Arch:              "arm64",
 			ProviderVersion:   "2.0.0",
@@ -220,7 +220,7 @@ func TestUsage_RequiredFieldsAlwaysPresent(t *testing.T) {
 			ChangedAttributes: []string{"config"},
 			Error:             false,
 		},
-		// Everything left at its zero value except operation: duration 0,
+		// Everything left at its zero value except operation: duration_ms 0,
 		// sequence 0, error false, nil changed attributes, empty strings.
 		"zero-value read": {
 			Operation: OperationRead,
@@ -274,15 +274,18 @@ func TestUsage_ChangedAttributesSerialization(t *testing.T) {
 }
 
 // operation is a fixed, compile-time-known set; the wire values must be exactly
-// these lowercase verbs so downstream span names (<resource_type>.<operation>)
-// stay stable.
+// these uppercase verbs, matching the TFCA-A1 contract's `operation`
+// x-extensible-enum (pattern ^[A-Z][A-Z0-9_]*$). The cc-cli-service backend
+// stores this value verbatim as the terraform.operation attribute and lowercases
+// it itself when composing the <resource_type>.<operation> span name, so the
+// span name stays stable regardless of what the provider sends.
 func TestOperationConstants(t *testing.T) {
 	want := map[Operation]string{
-		OperationCreate: "create",
-		OperationRead:   "read",
-		OperationUpdate: "update",
-		OperationDelete: "delete",
-		OperationImport: "import",
+		OperationCreate: "CREATE",
+		OperationRead:   "READ",
+		OperationUpdate: "UPDATE",
+		OperationDelete: "DELETE",
+		OperationImport: "IMPORT",
 	}
 	for op, s := range want {
 		if string(op) != s {


### PR DESCRIPTION
Release Notes
---------
No user-facing changes, this change is additive only.

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — no provider code changed)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A)
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. 
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR. (N/A)
- [ ] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only


## What & why

First provider-side ticket of the **TF Provider Client Analytics** initiative ([INIT-17732](https://confluentinc.atlassian.net/browse/INIT-17732)) — this is **TFCA-B1: Telemetry payload model, run ID, sequence number, and timing capture** ([APIE-1555](https://confluentinc.atlassian.net/browse/APIE-1555)).

It adds a new, **self-contained** `internal/provider/telemetry/` package: the data model plus the process-scoped primitives that the later tickets consume. **No existing files are touched and nothing imports the package yet**, so it cannot affect the built provider until the downstream work lands. Fully backward-compatible.

## Scope (exactly TFCA-B1)

- **`Usage`** — metadata-only payload struct mirroring the TFCA-A1 `terraform/v1` contract: `run_id`, `sequence`, `start_time`, `duration`, `os`, `arch`, `provider_version`, `terraform_version`, `resource_type`, `operation`, `changed_attributes` (names only), `error`, and optional panic-only `stack_frames`. Its doc comment states `run_id` is **process-scoped**: a `plan` and its paired `apply` get different, non-joinable run IDs, and each aliased provider instance gets its own.
- **`RunID()`** — process-scoped run identifier generated once under `sync.Once` (defense-in-depth: Core calls `ConfigureProvider` once per subprocess today, but that's an impl detail, not a protocol guarantee).
- **`NextSequence()`** — monotonic, race-free sequence via `atomic.Int64`, incremented at wrapper entry so ordering survives dropped reports.
- **`Config`** — immutable value-type snapshot holding the run ID + opt-out flag, deliberately kept **off** the `Client` struct (parts of which are mutated post-configure without a lock).
- **`Timer`** — monotonic start/duration capture.

**Deliberately out of scope** (later tickets): the central CRUD/import wrapper in `provider.go` (B3), the bounded-worker transport (B5), reading `CONFLUENT_DISABLE_PROVIDER_ANALYTICS` / non-default-endpoint disable (B6), and the build-time attribute-allowlist generator (B2). This package does no network/filesystem I/O, reads no env vars, and references no SDK clients.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
This is internal and additive change only to lay the telemetry data model, it does not update the provider's actual runtime path hence not impact the provider's behavior. 

## Testing

`gofmt`, `go vet`, and `go build ./...` clean. 10 tests pass under `go test -race` (×5, no flakiness) using the repo-pinned Go 1.25.12. Coverage: run-ID stability + UUID validity (incl. 64-goroutine concurrent read), race-free monotonic sequences under a concurrent graph walk, the JSON contract with **required fields present even for zero-value/read-shaped events** (guards against a future `,omitempty` silently dropping `duration`/`sequence`/`changed_attributes`), `changed_attributes` null-vs-`[]` serialization, optional `stack_frames`, and the closed operation enum.

## Coordination notes for later tickets (not defects here)

- `duration` unit is documented as **milliseconds** — confirm TFCA-A1's `terraform/minispec.yaml` declares the same when it lands.
- `start_time` is a `time.Time` (RFC3339); the Timer keeps its monotonic reading (so `Elapsed()` stays correct) and does not force UTC — settle the wire timezone/`format` with A1/A2.
- `changed_attributes` is required and non-omitempty; **B3 should pass a non-nil (possibly empty) slice** so read events emit `[]` not `null` (pinned by a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INIT-17732]: https://confluentinc.atlassian.net/browse/INIT-17732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIE-1555]: https://confluentinc.atlassian.net/browse/APIE-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ