### PR TITLE
fix(CI): Publish live-test results on failed runs

### DIFF
--- a/.semaphore/live-tests.yml
+++ b/.semaphore/live-tests.yml
@@ -51,20 +51,20 @@ blocks:
               # RTCE live tests run separately because they require their own env flags
               # (e.g. TF_ACC_REGION pinned to a region where RTCE is enabled in prod). Only run when
               # live-test passed, matching the old set -e behavior; skip if the group filter excludes core.
-              if [ $rc -eq 0 ]; then
+              if [ "$rc" -eq 0 ]; then
                 case "$TF_LIVE_TEST_GROUPS" in
                   ""|*core*) make live-test-rtce || rc=$? ;;
                   *) echo "Skipping live-test-rtce (group filter excludes RTCE)" ;;
                 esac
               fi
 
-              if [ $rc -ne 0 ]; then
+              if [ "$rc" -ne 0 ]; then
                 echo "Live tests failed, sending Slack notification..."
                 curl -X POST -H "Content-type: application/json" --data "{}" "$SLACK_WEBHOOK_URL"
               fi
 
               # Fail the job without calling `exit`, so the epilogue's test-results publish still runs.
-              [ $rc -eq 0 ]
+              [ "$rc" -eq 0 ]
       epilogue:
         always:
           commands:

--- a/.semaphore/live-tests.yml
+++ b/.semaphore/live-tests.yml
@@ -33,21 +33,11 @@ blocks:
             - . vault-sem-get-secret v1/ci/kv/apif/terraform-provider-confluent/live-testing-data
             - . vault-sem-get-secret v1/ci/kv/apif/terraform-provider-confluent/slack-notifications-live-testing
 
-            # 2. The main script
+            # 2. The main script. No `set -e` and no trap that calls `exit`: calling `exit` from a
+            # job command tears down Semaphore's shell before the epilogue runs, which silently
+            # skips the test-results publish below (the whole reason it lives in `epilogue.always`).
+            # Fail the job with a final non-zero test instead, mirroring smoke-tests.yml.
             - |
-              set -e
-
-              trap '
-                RC=$?
-                if [ $RC -ne 0 ]; then
-                  echo "Live tests failed, sending Slack notification..."
-
-                  curl -X POST -H "Content-type: application/json" --data "{}" "$SLACK_WEBHOOK_URL"
-                fi
-                exit $RC
-              ' EXIT
-
-              # Your original test logic runs here
               case "$TF_LIVE_TEST_GROUPS" in
                 "essential") TF_LIVE_TEST_GROUPS="core,kafka" ;;
                 "all"|"") TF_LIVE_TEST_GROUPS="" ;;
@@ -55,15 +45,26 @@ blocks:
               esac
 
               echo "Running live tests for: ${TF_LIVE_TEST_GROUPS:-all groups}"
-              make live-test ${TF_LIVE_TEST_GROUPS:+TF_LIVE_TEST_GROUPS="$TF_LIVE_TEST_GROUPS"}
+              rc=0
+              make live-test ${TF_LIVE_TEST_GROUPS:+TF_LIVE_TEST_GROUPS="$TF_LIVE_TEST_GROUPS"} || rc=$?
 
               # RTCE live tests run separately because they require their own env flags
-              # (e.g. TF_ACC_REGION pinned to a region where RTCE is enabled in prod).
-              # Skip if the caller asked for a specific group that isn't "core" or "all".
-              case "$TF_LIVE_TEST_GROUPS" in
-                ""|*core*) make live-test-rtce ;;
-                *) echo "Skipping live-test-rtce (group filter excludes RTCE)" ;;
-              esac
+              # (e.g. TF_ACC_REGION pinned to a region where RTCE is enabled in prod). Only run when
+              # live-test passed, matching the old set -e behavior; skip if the group filter excludes core.
+              if [ $rc -eq 0 ]; then
+                case "$TF_LIVE_TEST_GROUPS" in
+                  ""|*core*) make live-test-rtce || rc=$? ;;
+                  *) echo "Skipping live-test-rtce (group filter excludes RTCE)" ;;
+                esac
+              fi
+
+              if [ $rc -ne 0 ]; then
+                echo "Live tests failed, sending Slack notification..."
+                curl -X POST -H "Content-type: application/json" --data "{}" "$SLACK_WEBHOOK_URL"
+              fi
+
+              # Fail the job without calling `exit`, so the epilogue's test-results publish still runs.
+              [ $rc -eq 0 ]
       epilogue:
         always:
           commands:


### PR DESCRIPTION
Release Notes
---------

No user-facing changes. This is CI configuration only.

Checklist
---------

Most items below concern provider behavior and don't apply: this PR changes only `.semaphore/live-tests.yml` pipeline YAML. No provider code ships.

- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----

#1119 turned on Semaphore's **Test Report** tab so a failing test is legible without scrolling the raw job log. But for the live integration tests it stays empty on exactly the runs you need it for: when a live test **fails**, no results are published. Passing runs publish fine, which hid the problem.

The `test-results publish` step lives in the job's `epilogue.always` block (code that runs regardless of pass/fail) precisely so it runs on failure. But the main command wraps the test run in `set -e` and a `trap` that calls `exit` on failure. Calling `exit` from a job command tears down Semaphore's shell before the epilogue runs, so the publish step never executes.

The fix drops `set -e` and the exit-calling trap. It captures the `make live-test` / `make live-test-rtce` exit codes, still sends the existing failure Slack alert, and fails the job with a final `[ $rc -eq 0 ]` test instead of `exit`, the same shell-safe pattern `smoke-tests.yml` already uses. The shell now survives into the epilogue; nothing else about the job changes.

Blast Radius
----

None for customers: no provider code or resource/data-source behavior changes.

CI-side, failed live-test runs now publish JUnit results to the Test Report tab (they published nothing before). Test execution, the failure-only Slack alert, and the job's pass/fail semantics are untouched.

References
----------

- Follow-up to #1119, which added the publish step this fix makes effective on failed runs.
- Uses the same job-failure pattern as `.semaphore/smoke-tests.yml`.
- The `set -e`/trap wrapper this removes was added in #824 to send a Slack alert on live-test failure.

Test & Review
-------------

Verified by comparing the publish step across three real jobs. A publish that actually runs takes ~2s and logs a transfer summary; the broken one finishes in 0s with no output.

- **Failed live-test run (the bug):** [`c4411a0e`](https://semaphore.ci.confluent.io/jobs/c4411a0e-5030-4d61-97c2-b5d7c5733e9a): `test-results publish` finished in 0s with no output and pushed nothing. Empty Test Report tab.
- **Passing live-test run:** [`b7cc11cf`](https://semaphore.ci.confluent.io/jobs/b7cc11cf-4781-4630-9358-80a3173549ec): same step ran for 2s and pushed 5 files (31.4 KB). Results appear.
- **Failed build pipeline (control):** [`d8bd7bde`](https://semaphore.ci.confluent.io/jobs/d8bd7bde-f9f2-4349-a1eb-6ec74315e34d): the identical publish epilogue, but with no `set -e`/trap wrapper, ran for 2s and pushed 5 files (394.5 KB) **even though the job failed**. That confirms the wrapper, not the failure, is what suppressed publishing.

Also reviewed the diff to confirm it prevents the shell teardown and preserves the job's pass/fail result, the failure-only Slack alert, and running RTCE only after a passing `live-test`, versus the previous `set -e` flow. Full end-to-end confirmation (a failed live-test run publishing results) will come from the next scheduled live-test failure once this merges.
