### PR TITLE
INC-12957: Fix panic when a Flink Gateway API column type is a parameterized SQL type

### DIFF
--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -495,6 +496,72 @@ func setServerManagedOptionsMap(d *schema.ResourceData, key string, serverOption
 	return d.Set(key, managedOptions)
 }
 
+// flinkSqlTypeToString normalizes a column's SQL type as returned by the Flink Gateway
+// API into the plain string the column_*_type schema attributes expect. The Gateway
+// represents parameter-less types (e.g. INT) as a JSON string, but represents
+// parameterized types (e.g. VARCHAR, DECIMAL) as a JSON object describing the type's
+// shape, e.g. {"type":"VARCHAR","length":2147483647,"nullable":false}. The SDK models
+// the field as `interface{}` to accommodate both shapes, so setting it directly on a
+// string-typed schema field panics inside the SDK's ResourceData.Set (INC-12957).
+func flinkSqlTypeToString(rawType interface{}) string {
+	switch v := rawType.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case map[string]interface{}:
+		return formatFlinkLogicalType(v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// formatFlinkLogicalType renders a Flink logical type descriptor, e.g.
+// {"type":"VARCHAR","length":2147483647,"nullable":false}, as its summary string, e.g.
+// "VARCHAR(2147483647) NOT NULL".
+func formatFlinkLogicalType(logicalType map[string]interface{}) string {
+	baseType, ok := logicalType["type"].(string)
+	if !ok || baseType == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(baseType)
+	if params := flinkLogicalTypeParams(logicalType); params != "" {
+		fmt.Fprintf(&b, "(%s)", params)
+	}
+	if nullable, ok := logicalType["nullable"].(bool); ok && !nullable {
+		b.WriteString(" NOT NULL")
+	}
+	return b.String()
+}
+
+// flinkLogicalTypeParams renders the parenthesized parameters of a parameterized SQL
+// type, e.g. the "2147483647" in VARCHAR(2147483647) or the "10, 2" in DECIMAL(10, 2).
+func flinkLogicalTypeParams(logicalType map[string]interface{}) string {
+	numericField := func(key string) (string, bool) {
+		v, ok := logicalType[key].(float64)
+		if !ok {
+			return "", false
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	}
+
+	if length, ok := numericField("length"); ok {
+		return length
+	}
+	precision, hasPrecision := numericField("precision")
+	scale, hasScale := numericField("scale")
+	switch {
+	case hasPrecision && hasScale:
+		return precision + ", " + scale
+	case hasPrecision:
+		return precision
+	default:
+		return ""
+	}
+}
+
 func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable flinkgatewayv1.SqlV1MaterializedTable, c *FlinkRestClient) (*schema.ResourceData, error) {
 	if err := d.Set(paramDisplayName, materializedTable.GetName()); err != nil {
 		return nil, err
@@ -588,7 +655,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnComputed] = []map[string]interface{}{
 					{
 						paramComputedName:       computedCol.Name,
-						paramComputedType:       computedCol.Type,
+						paramComputedType:       flinkSqlTypeToString(computedCol.Type),
 						paramComputedComment:    computedCol.Comment,
 						paramComputedKind:       computedCol.Kind,
 						paramComputedExpression: computedCol.Expression,
@@ -604,7 +671,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnPhysical] = []map[string]interface{}{
 					{
 						paramPhysicalName:    physicalCol.Name,
-						paramPhysicalType:    physicalCol.Type,
+						paramPhysicalType:    flinkSqlTypeToString(physicalCol.Type),
 						paramPhysicalComment: physicalCol.Comment,
 						paramPhysicalKind:    physicalCol.Kind,
 					},
@@ -623,7 +690,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnMetadata] = []map[string]interface{}{
 					{
 						paramMetadataName:    metadataCol.Name,
-						paramMetadataType:    metadataCol.Type,
+						paramMetadataType:    flinkSqlTypeToString(metadataCol.Type),
 						paramMetadataComment: metadataCol.Comment,
 						paramMetadataKind:    metadataCol.Kind,
 						paramMetadataKey:     metadataCol.MetadataKey,

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -922,3 +922,70 @@ func testAccCheckMaterializedTableUnmanagedOptionsConfig(mockServerUrl, resource
 	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
 }
+
+// TestFlinkSqlTypeToString covers INC-12957: the Flink Gateway API represents
+// parameterized column types (e.g. VARCHAR, DECIMAL) as a JSON object rather than a
+// plain string, which used to be set directly on the string-typed column_*_type
+// schema attributes and panicked inside the SDK's ResourceData.Set.
+func TestFlinkSqlTypeToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawType  interface{}
+		expected string
+	}{
+		{
+			name:     "plain string type",
+			rawType:  "INT",
+			expected: "INT",
+		},
+		{
+			name:     "nil type",
+			rawType:  nil,
+			expected: "",
+		},
+		{
+			name:     "the exact payload from the INC-12957 panic",
+			rawType:  map[string]interface{}{"type": "VARCHAR", "length": 2147483647.0, "nullable": false},
+			expected: "VARCHAR(2147483647) NOT NULL",
+		},
+		{
+			name:     "nullable parameterized type omits the NOT NULL suffix",
+			rawType:  map[string]interface{}{"type": "VARCHAR", "length": 200.0, "nullable": true},
+			expected: "VARCHAR(200)",
+		},
+		{
+			name:     "precision and scale",
+			rawType:  map[string]interface{}{"type": "DECIMAL", "precision": 10.0, "scale": 2.0, "nullable": true},
+			expected: "DECIMAL(10, 2)",
+		},
+		{
+			name:     "precision only",
+			rawType:  map[string]interface{}{"type": "TIMESTAMP", "precision": 3.0, "nullable": true},
+			expected: "TIMESTAMP(3)",
+		},
+		{
+			name:     "no parameters",
+			rawType:  map[string]interface{}{"type": "INT", "nullable": true},
+			expected: "INT",
+		},
+		{
+			name:     "no parameters, not null",
+			rawType:  map[string]interface{}{"type": "BOOLEAN", "nullable": false},
+			expected: "BOOLEAN NOT NULL",
+		},
+		{
+			name:     "missing type key falls back to empty string instead of panicking",
+			rawType:  map[string]interface{}{"length": 200.0, "nullable": true},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := flinkSqlTypeToString(tt.rawType)
+			if actual != tt.expected {
+				t.Errorf("flinkSqlTypeToString(%#v) = %q, expected %q", tt.rawType, actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Fixed a panic in the `confluent_flink_materialized_table` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_materialized_table) and [data source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_flink_materialized_table) that crashed the entire provider process when a column's SQL type was a parameterized type (e.g. `VARCHAR`, `DECIMAL`).

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Fixes INC-12957.

**Root cause:** the Flink Gateway API can return a column's type either as a plain
string (e.g. `"INT"`) or, for parameterized types, as a structured object like
`{"type":"VARCHAR","length":2147483647,"nullable":false}`. The generated SDK models
`SqlV1PhysicalColumn.Type` / `SqlV1ComputedColumn.Type` / `SqlV1MetadataColumn.Type` as
`interface{}` to accommodate both shapes (this looks like an openapi-generator
limitation with the `allOf`+`discriminator` composition used for `ColumnDetails` —
even `Name`, a plain `string` in the spec, comes out as `interface{}` in the generated
`_all_of.go` structs, so the SDK didn't preserve the fully-typed `DataType` object the
OpenAPI spec actually defines).

`setMaterializedTableAttributes` assigned that value straight into the string-typed
`column_physical_type` / `column_computed_type` / `column_metadata_type` schema
attributes. Terraform's SDKv2 panics inside `ResourceData.Set` when it hits the object
shape instead of returning an error, which crashes the whole (in-process) test binary —
that's why the live test run showed ~27 unrelated tests failing, not just the one
touching materialized tables.

This wasn't caught by the existing unit/acceptance tests because their JSON fixtures
(`internal/testdata/flink_materialized_table/*.json`) are hand-authored with plain
string type values like `"type1"`, never the object shape a real VARCHAR/DECIMAL
column returns. Only the live test hitting the actual Confluent Cloud Flink Gateway
surfaced it.

**The fix:** `flinkSqlTypeToString` normalizes either shape into a plain string before
it reaches `d.Set` — passing strings through as-is, and rendering the object shape as
its SQL summary string (e.g. `VARCHAR(2147483647) NOT NULL`).

**Open question / would appreciate input:** I'm not fully confident the
"summary string" rendering is the right shape for these attributes long-term, and I'm
not sure how deep to go (nested types like `ARRAY`/`MAP`/`ROW` aren't handled beyond
falling back to the bare type name — I didn't want to guess at their JSON shape without
a real sample). In the live test that hit this, `columns` isn't set by the user at all —
it's entirely server-derived from a `CREATE TABLE AS SELECT` query — so it's also fair
to ask whether `column_physical_type`/`column_computed_type`/`column_metadata_type` need
to carry full type-parameter fidelity at all, or whether something simpler (e.g. just the
base type name) would serve users better and be less risky to keep correct. Flagging
this for discussion rather than assuming my fix is the final shape.

Blast Radius
----
Confluent Cloud customers using the `confluent_flink_materialized_table` resource or
data source with a source table/query that has a parameterized column type (`VARCHAR`,
`CHAR`, `DECIMAL`, `TIMESTAMP`, etc.) currently get a hard provider panic on
create/read/refresh — this fix prevents the crash. Low risk of regression: the change
only affects how the `column_*_type` attributes are rendered into state; it doesn't
touch the create/update/delete request paths.

References
----------
- INC-12957

Test & Review
-------------
- `go build ./...` and `go vet ./internal/provider/...` pass.
- Added `TestFlinkSqlTypeToString`, a unit test covering the exact payload from the
  panic plus other parameterized/non-parameterized/nullable shapes.
- Did not run the existing wiremock-based `TestAccFlinkMaterializedTable` locally (no
  Docker in this environment) or the live test (no Confluent Cloud credentials in this
  environment) — deferring to CI for those. Would appreciate a run of
  `TestAccFlinkMaterializedTableLive` / `TestAccDataSourceFlinkMaterializedTableLive`
  against a source table with a `VARCHAR`/`DECIMAL` column to confirm this resolves the
  original panic end-to-end.
