### PR TITLE
INC-12957: Prevent Flink materialized table panic by preserving column types as JSON

### DIFF
--- a/internal/provider/resource_flink_materialized_table.go
+++ b/internal/provider/resource_flink_materialized_table.go
@@ -495,6 +495,40 @@ func setServerManagedOptionsMap(d *schema.ResourceData, key string, serverOption
 	return d.Set(key, managedOptions)
 }
 
+// flinkColumnTypeToString normalizes a column's SQL type, as returned by the Flink
+// Gateway API, into the plain string that the string-typed column_*_type schema
+// attributes require.
+//
+// The Gateway returns the type either as a plain SQL string (e.g. "INT") or, in
+// practice for every column we've observed, as a structured DataType object
+// (e.g. {"type":"VARCHAR","length":2147483647,"nullable":false}). The generated SDK
+// models the field as interface{} to accommodate both shapes, so assigning it directly
+// to a string-typed schema field panics inside the SDK's ResourceData.Set as soon as
+// the object shape appears (INC-12957).
+//
+// When the value is already a string we pass it through unchanged. Otherwise we
+// preserve the server's representation losslessly by JSON-encoding it, rather than
+// dropping information or guessing at SQL syntax for nested types (ARRAY/MAP/ROW, etc.).
+// encoding/json sorts object keys deterministically, so the stored value stays stable
+// across reads even if the server varies key ordering — this keeps Terraform from
+// reporting spurious drift on refresh.
+func flinkColumnTypeToString(rawType interface{}) string {
+	if rawType == nil {
+		return ""
+	}
+	if s, ok := rawType.(string); ok {
+		return s
+	}
+	encoded, err := json.Marshal(rawType)
+	if err != nil {
+		// json.Marshal only fails on unencodable values (channels, funcs), which the
+		// SDK's decoded JSON can never contain; fall back to Go's default rendering so
+		// we still never panic and never store an empty type.
+		return fmt.Sprintf("%v", rawType)
+	}
+	return string(encoded)
+}
+
 func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable flinkgatewayv1.SqlV1MaterializedTable, c *FlinkRestClient) (*schema.ResourceData, error) {
 	if err := d.Set(paramDisplayName, materializedTable.GetName()); err != nil {
 		return nil, err
@@ -588,7 +622,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnComputed] = []map[string]interface{}{
 					{
 						paramComputedName:       computedCol.Name,
-						paramComputedType:       computedCol.Type,
+						paramComputedType:       flinkColumnTypeToString(computedCol.Type),
 						paramComputedComment:    computedCol.Comment,
 						paramComputedKind:       computedCol.Kind,
 						paramComputedExpression: computedCol.Expression,
@@ -604,7 +638,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnPhysical] = []map[string]interface{}{
 					{
 						paramPhysicalName:    physicalCol.Name,
-						paramPhysicalType:    physicalCol.Type,
+						paramPhysicalType:    flinkColumnTypeToString(physicalCol.Type),
 						paramPhysicalComment: physicalCol.Comment,
 						paramPhysicalKind:    physicalCol.Kind,
 					},
@@ -623,7 +657,7 @@ func setMaterializedTableAttributes(d *schema.ResourceData, materializedTable fl
 				m[paramColumnMetadata] = []map[string]interface{}{
 					{
 						paramMetadataName:    metadataCol.Name,
-						paramMetadataType:    metadataCol.Type,
+						paramMetadataType:    flinkColumnTypeToString(metadataCol.Type),
 						paramMetadataComment: metadataCol.Comment,
 						paramMetadataKind:    metadataCol.Kind,
 						paramMetadataKey:     metadataCol.MetadataKey,

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -921,4 +922,74 @@ func testAccCheckMaterializedTableUnmanagedOptionsConfig(mockServerUrl, resource
 }
 	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
+}
+
+// TestFlinkColumnTypeToString covers INC-12957: the Flink Gateway API returns a
+// column's type as a structured DataType object rather than a plain string, which used
+// to be assigned directly to the string-typed column_*_type schema attributes and
+// panicked inside the SDK's ResourceData.Set.
+//
+// The raw JSON strings below are the exact payloads captured from a live create against
+// examples.marketplace.orders (the query the failing live tests use). Decoding them into
+// interface{} with encoding/json mirrors precisely what the generated SDK does before the
+// value reaches flinkColumnTypeToString: JSON objects become map[string]interface{} and
+// JSON numbers become float64.
+func TestFlinkColumnTypeToString(t *testing.T) {
+	decode := func(raw string) interface{} {
+		var v interface{}
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Fatalf("failed to decode test input %q: %s", raw, err)
+		}
+		return v
+	}
+
+	tests := []struct {
+		name     string
+		rawType  interface{}
+		expected string
+	}{
+		{
+			name:     "nil type",
+			rawType:  nil,
+			expected: "",
+		},
+		{
+			name:     "a plain string type passes through unchanged",
+			rawType:  "INT",
+			expected: "INT",
+		},
+		{
+			// The exact payload from the INC-12957 panic (the order_id column).
+			name:     "parameterized VARCHAR object from the live repro",
+			rawType:  decode(`{"type":"VARCHAR","length":2147483647,"nullable":false}`),
+			expected: `{"length":2147483647,"nullable":false,"type":"VARCHAR"}`,
+		},
+		{
+			// Simple, unparameterized types come back as objects too, not as bare strings.
+			name:     "unparameterized INTEGER object from the live repro",
+			rawType:  decode(`{"type":"INTEGER","nullable":false}`),
+			expected: `{"nullable":false,"type":"INTEGER"}`,
+		},
+		{
+			// Drift guard: the same type with keys in a different server-supplied order must
+			// serialize to an identical string, so a refresh never shows a spurious diff.
+			name:     "keys in a different server order still serialize identically",
+			rawType:  decode(`{"nullable":false,"length":2147483647,"type":"VARCHAR"}`),
+			expected: `{"length":2147483647,"nullable":false,"type":"VARCHAR"}`,
+		},
+		{
+			// Nested types are preserved losslessly rather than dropped or truncated.
+			name:     "nested ARRAY element type is preserved",
+			rawType:  decode(`{"type":"ARRAY","element_type":{"type":"VARCHAR","length":100,"nullable":true},"nullable":true}`),
+			expected: `{"element_type":{"length":100,"nullable":true,"type":"VARCHAR"},"nullable":true,"type":"ARRAY"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := flinkColumnTypeToString(tt.rawType); got != tt.expected {
+				t.Errorf("flinkColumnTypeToString(%#v) = %q, want %q", tt.rawType, got, tt.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Fixed a panic in the `confluent_flink_materialized_table` [resource](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_flink_materialized_table) and [data source](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_flink_materialized_table) that crashed the provider when the Flink Gateway API returned a column's type as a structured object.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Fixes INC-12957. This is a more surgical alternative to #1178 — same root cause, but it
preserves the server's type representation as-is instead of reconstructing SQL syntax.
We should merge one of the two, not both.

**Root cause:** the Flink Gateway API can return a column's type either as a plain string
or as a structured `DataType` object, e.g.
`{"type":"VARCHAR","length":2147483647,"nullable":false}`. The generated SDK models
`SqlV1PhysicalColumn.Type` / `SqlV1ComputedColumn.Type` / `SqlV1MetadataColumn.Type` as
`interface{}` to accommodate both shapes. `setMaterializedTableAttributes` assigned that
value straight into the string-typed `column_physical_type` / `column_computed_type` /
`column_metadata_type` schema attributes, and Terraform's SDKv2 **panics** inside
`ResourceData.Set` when it gets an object where it expects a string. Since the live tests
run in one in-process test binary, that single panic takes down every other live test
sharing the process (which is why an unrelated ~27 tests reported failures in the same
run).

**Confirmed with a live reproduction.** I ran the exact query the failing live tests use
(`SELECT order_id, customer_id, product_id, price FROM examples.marketplace.orders WHERE price > 100`)
against a real compute pool and captured the response:

```json
"columns": [
  {"kind":"Physical","name":"order_id",    "type":{"type":"VARCHAR","length":2147483647,"nullable":false}},
  {"kind":"Physical","name":"customer_id", "type":{"type":"INTEGER","nullable":false}},
  {"kind":"Physical","name":"product_id",  "type":{"type":"VARCHAR","length":2147483647,"nullable":false}},
  {"kind":"Physical","name":"price",       "type":{"type":"DOUBLE","nullable":false}}
]
```

Two takeaways: (1) `order_id` matches the panic payload exactly, and (2) **every** column
is an object — including simple unparameterized types like `INTEGER` and `DOUBLE` — not
just parameterized ones. So this isn't a VARCHAR/DECIMAL edge case; the `type` field is
always an object in the responses we see.

This was never caught by unit/acceptance tests because their JSON fixtures
(`internal/testdata/flink_materialized_table/*.json`) hand-author the type as a plain
string (`"type": "type1"`), so the object shape only ever surfaces against the real API.

**The fix** (`flinkColumnTypeToString`): if the value is already a string, pass it
through unchanged; otherwise JSON-encode it. This:
- never panics, and never silently stores an empty type;
- preserves the server's representation losslessly, including nested `ARRAY`/`MAP`/`ROW`
  types, rather than guessing at SQL syntax;
- is deterministic — `encoding/json` sorts object keys, so the stored string is stable
  across reads even if the server varies key ordering, avoiding spurious drift on refresh.

**Open question for reviewers:** what's the right *shape* to store here? This PR stores
the raw type object as canonical JSON (e.g.
`{"length":2147483647,"nullable":false,"type":"VARCHAR"}`); #1178 instead renders a SQL
summary string (e.g. `VARCHAR(2147483647) NOT NULL`, which matches the server's own
`status.creation_statement`). JSON is lossless and trivially correct for nested types;
the SQL summary is friendlier if a user ever hand-authors `columns` in HCL. It's also
worth asking whether these `column_*_type` attributes need full type-parameter fidelity
at all — in the scenario that triggered this, `columns` is entirely server-derived from a
`CREATE TABLE AS SELECT` query and never set by the user. Happy to go whichever way the
team prefers.

**Note for the backend team (separate from this fix):** this resource and its live tests
have been green and functionally unchanged since 2026-04-30, with no column-type handling
changes since 2026-07-30, yet only started failing on 2026-08-23. That timing suggests the
Gateway may have recently changed how `columns[].type` is serialized (to always be an
object). Filing that question with them separately; this provider-side fix is correct
regardless of the answer.

Blast Radius
----
Confluent Cloud customers using the `confluent_flink_materialized_table` resource or data
source currently hit a hard provider panic on create/read/refresh whenever the API returns
column types (i.e. essentially always, per the live repro above). This fix removes the
crash. Low regression risk: the change only affects how `column_*_type` is rendered into
state on read; it does not touch the create/update/delete request paths.

References
----------
- INC-12957
- Alternative approach: #1178

Test & Review
-------------
- `go build ./...` and `go vet ./internal/provider/...` pass; `gofmt` clean.
- Added `TestFlinkColumnTypeToString`, which decodes the **exact** JSON payloads captured
  from the live repro (via `encoding/json`, mirroring how the SDK decodes them) and
  asserts the rendered strings — including a determinism/drift-guard case that feeds the
  same object with keys in a different order and asserts identical output.
- Verified against real Confluent Cloud: created a materialized table with the live-test
  query, captured the object-shaped `columns[].type` response shown above, and confirmed
  it is what previously triggered the panic. Temporary service account / API key / table
  used for the repro were deleted afterward.
- Did not run the wiremock-based `TestAccFlinkMaterializedTable` (no Docker in this
  environment) or the full live suite locally; deferring those to CI.
