### PR TITLE
chore: add R2 AI code review as a manual promotion

### DIFF
--- a/.semaphore/r2-code-review.yml
+++ b/.semaphore/r2-code-review.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: R2 Code Review
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-2
+
+# Match the sibling promotion pipelines (live-tests, smoke-tests): a manual run isn't auto-cancelled.
+auto_cancel:
+  running:
+    when: "false"
+
+blocks:
+  - name: R2 Code Review
+    task:
+      jobs:
+        - name: "R2 Code Review"
+          # Bound above r2's own --timeout=15m: `|| true` masks a non-zero exit but not a hard
+          # execution_time_limit kill, which would otherwise fail the promotion.
+          execution_time_limit:
+            minutes: 20
+          commands:
+            # Triggered manually from a review-ready PR, so no pull_request gate is needed here.
+            - checkout
+            # `|| true`: an AI-review failure is unrelated to the code under review and must not
+            # fail the promotion (report R2 issues to #r2).
+            - r2 code-review --verbose --timeout=15m || true

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,6 +49,27 @@ blocks:
             # --trim-output-to keeps the LAST N characters; the 1000 default drops the assertion.
             - test-results publish unit-report.xml acceptance-report.xml -N "build-test-release" --ignore-missing --trim-output-to 20000
 
+  - name: R2 Code Review
+    # Runs after build/test rather than in parallel, so a review only posts on a green build.
+    dependencies:
+      - "Build & Test & Release"
+    run:
+      # PRs only. The change_in guard is R2's documented form; inert here (no /.deployed-versions/
+      # dir) but kept for cross-repo/template consistency. Non-PR runs skip the block.
+      when: "pull_request =~ '.+' and change_in('/', {exclude: ['/.deployed-versions/']})"
+    task:
+      jobs:
+        - name: "R2 Code Review"
+          # Bound above r2's own --timeout=15m: `|| true` masks a non-zero exit but not a hard
+          # execution_time_limit kill, and the block would otherwise inherit the 2h pipeline default.
+          execution_time_limit:
+            minutes: 20
+          commands:
+            # `checkout` is inherited from global_job_config's prologue.
+            # `|| true`: an AI-review failure is unrelated to the code under review and must not
+            # block CI (report R2 issues to #r2).
+            - r2 code-review --verbose --timeout=15m || true
+
 after_pipeline:
   task:
     jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,27 +49,6 @@ blocks:
             # --trim-output-to keeps the LAST N characters; the 1000 default drops the assertion.
             - test-results publish unit-report.xml acceptance-report.xml -N "build-test-release" --ignore-missing --trim-output-to 20000
 
-  - name: R2 Code Review
-    # Runs after build/test rather than in parallel, so a review only posts on a green build.
-    dependencies:
-      - "Build & Test & Release"
-    run:
-      # PRs only. The change_in guard is R2's documented form; inert here (no /.deployed-versions/
-      # dir) but kept for cross-repo/template consistency. Non-PR runs skip the block.
-      when: "pull_request =~ '.+' and change_in('/', {exclude: ['/.deployed-versions/']})"
-    task:
-      jobs:
-        - name: "R2 Code Review"
-          # Bound above r2's own --timeout=15m: `|| true` masks a non-zero exit but not a hard
-          # execution_time_limit kill, and the block would otherwise inherit the 2h pipeline default.
-          execution_time_limit:
-            minutes: 20
-          commands:
-            # `checkout` is inherited from global_job_config's prologue.
-            # `|| true`: an AI-review failure is unrelated to the code under review and must not
-            # block CI (report R2 issues to #r2).
-            - r2 code-review --verbose --timeout=15m || true
-
 after_pipeline:
   task:
     jobs:
@@ -88,3 +67,6 @@ promotions:
     pipeline_file: goreleaser.yml
   - name: Run Live Integration Tests
     pipeline_file: live-tests.yml
+  # Manual (no auto_promote): AI review runs on demand when a PR is review-ready, not per push.
+  - name: R2 Code Review
+    pipeline_file: r2-code-review.yml


### PR DESCRIPTION
> Stacked on #1179. Review that one first.

Release Notes
---------
None. This is a CI-only change; there are no user-facing provider changes, so it will not appear in a release.

Checklist
---------
> [!NOTE]
> This PR adds only Semaphore CI config. It changes no provider code, resources, data sources, schema, docs, or examples, so the resource-focused checklist items (custom binary, real-Cloud verification, screenshots, acceptance/live tests, testing thread, rate-limit testing, docs, blast radius, feature enablement) are not applicable.

- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.

What
----
This adds Confluent's `r2 code-review` - an AI pull-request reviewer powered by Claude Code - as a **manual Semaphore promotion**. It runs only when someone triggers it on a review-ready PR, and it reads this repo's `.claude/` review rules (added in the base PR) so its feedback is repo-aware rather than generic.

Design choices:
- **Manual, not per-push.** Added as a `promotions:` entry with no `auto_promote`, alongside the existing manual `Draft a Release` and `Run Live Integration Tests` promotions. A pipeline *block* would run a full review on every commit pushed; a promotion runs on demand, when a PR is actually ready for review.
- **Isolated pipeline.** The promotion points at a new `.semaphore/r2-code-review.yml` that runs `checkout` then `r2 code-review --verbose --timeout=15m || true`. The `|| true` keeps an AI-review failure from failing the run, and a 20-minute job `execution_time_limit` bounds a hung run (headroom over r2's own 15m timeout, since `|| true` does not survive a hard timeout kill).
- **No Go toolchain.** R2 does a read-only review and does not invoke the build toolchain, so the pipeline needs only `checkout`, not the Go prologue the main pipeline uses.

Blast Radius
----
None for customers. This adds one manual, non-blocking CI promotion; the worst case is that a review is not triggered or a comment is not posted. It ships no provider behavior and cannot fail the main pipeline.

References
----------
- Stacked on #1179, which adds the `.claude/` review rules R2 consumes.
- Onboarding follows Confluent's internal R2 code-review documentation.

Test & Review
-------------
- **Pipeline reviewed** for `pipeline_file` resolution, manual-only semantics (no `auto_promote`, matching the two existing promotions), and the standalone pipeline's `checkout`/toolchain needs - no blockers.
- **YAML validated.** Both files parse; the new promotion resolves to `.semaphore/r2-code-review.yml`, and the job runs `checkout` before `r2 code-review`.
- **Not yet exercised against a live pipeline** - the first manual trigger on a PR will be the first execution.
