### PR TITLE
INC-13010: Accept COMPLETED phase for Flink Materialized Table create/update

### DIFF
--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -675,11 +675,8 @@ func testAccCheckMaterializedTableServerDerivedDistributionConfig(mockServerUrl,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
 }
 
-// TestAccFlinkMaterializedTableCompletedPhase is a regression test for the bug where a Materialized
-// Table whose query is bounded reaches the terminal COMPLETED phase, which the provider treated as
-// "an unexpected state" and failed the create. COMPLETED is a valid success phase (confluent_flink_statement
-// already accepts it), so the create must succeed. Before the fix, this test fails with
-// `Flink Materialized Table "table_completed" is in an unexpected state "COMPLETED"`.
+// TestAccFlinkMaterializedTableCompletedPhase locks in that a bounded table reaching the terminal
+// COMPLETED phase is accepted as a successful create (COMPLETED is valid, like confluent_flink_statement).
 func TestAccFlinkMaterializedTableCompletedPhase(t *testing.T) {
 	ctx := context.Background()
 
@@ -736,8 +733,6 @@ func TestAccFlinkMaterializedTableCompletedPhase(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				// A bounded query drives the table to COMPLETED; the create must succeed rather than
-				// fail with "unexpected state".
 				Config: testAccCheckMaterializedTableCompletedPhaseConfig(mockTestServerUrl, resourceLabel, completedDisplayName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaterializedTableExists(fullResourceLabel),

--- a/internal/provider/resource_flink_materialized_table_test.go
+++ b/internal/provider/resource_flink_materialized_table_test.go
@@ -675,6 +675,115 @@ func testAccCheckMaterializedTableServerDerivedDistributionConfig(mockServerUrl,
 		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
 }
 
+// TestAccFlinkMaterializedTableCompletedPhase is a regression test for the bug where a Materialized
+// Table whose query is bounded reaches the terminal COMPLETED phase, which the provider treated as
+// "an unexpected state" and failed the create. COMPLETED is a valid success phase (confluent_flink_statement
+// already accepts it), so the create must succeed. Before the fix, this test fails with
+// `Flink Materialized Table "table_completed" is in an unexpected state "COMPLETED"`.
+func TestAccFlinkMaterializedTableCompletedPhase(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockTestServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockTestServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	const scenarioName = "confluent_flink_materialized_table Completed Phase"
+	const completedDisplayName = "table_completed"
+	readCompletedPath := fmt.Sprintf("/sql/v1/organizations/%s/environments/%s/databases/%s/materialized-tables/%s", flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkMaterializedTableDatabase, completedDisplayName)
+
+	createResponse, _ := os.ReadFile("../testdata/flink_materialized_table/create_completed_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Post(wiremock.URLPathEqualTo(createFlinkMaterializedTablePath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(createResponse), contentTypeJSONHeader, http.StatusCreated))
+
+	readResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_completed_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCompletedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillReturn(string(readResponse), contentTypeJSONHeader, http.StatusOK))
+
+	_ = wiremockClient.StubFor(wiremock.Delete(wiremock.URLPathEqualTo(readCompletedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenCreated).
+		WillSetStateTo(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent))
+
+	readDeletedResponse, _ := os.ReadFile("../testdata/flink_materialized_table/read_deleted_materialized_table.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo(readCompletedPath)).
+		InScenario(scenarioName).
+		WhenScenarioStateIs(scenarioStateMaterializedTableHasBeenDeleted).
+		WillReturn(string(readDeletedResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	resourceLabel := "test"
+	fullResourceLabel := fmt.Sprintf("confluent_flink_materialized_table.%s", resourceLabel)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckMaterializedTableDestroy(s, mockTestServerUrl)
+		},
+		Steps: []resource.TestStep{
+			{
+				// A bounded query drives the table to COMPLETED; the create must succeed rather than
+				// fail with "unexpected state".
+				Config: testAccCheckMaterializedTableCompletedPhaseConfig(mockTestServerUrl, resourceLabel, completedDisplayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMaterializedTableExists(fullResourceLabel),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramDisplayName, completedDisplayName),
+					resource.TestCheckResourceAttr(fullResourceLabel, paramStopped, "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMaterializedTableCompletedPhaseConfig(mockServerUrl, resourceLabel, displayName string) string {
+	return fmt.Sprintf(`
+	provider "confluent" {
+    	endpoint = "%s"
+	}
+
+	resource "confluent_flink_materialized_table" "%s" {
+      credentials {
+        key = "%s"
+        secret = "%s"
+      }
+      rest_endpoint = "%s"
+      principal {
+         id = "%s"
+      }
+      organization {
+         id = "%s"
+      }
+      environment {
+         id = "%s"
+      }
+      compute_pool {
+         id = "%s"
+      }
+      display_name  = "%s"
+	  kafka_cluster {
+	    id = "%s"
+	  }
+      stopped = false
+	  query = "SELECT customer_id, product_id FROM examples.marketplace.orders LIMIT 10;"
+}
+	`, mockServerUrl, resourceLabel, kafkaApiKey, kafkaApiSecret, mockServerUrl, flinkPrincipalIdTest,
+		flinkOrganizationIdTest, flinkEnvironmentIdTest, flinkComputePoolIdTest, displayName, flinkMaterializedTableDatabase)
+}
+
 // TestAccFlinkMaterializedTableManagedOptionsSuperset locks in the fix for
 // table_options/session_options drift. The config manages only a SUBSET of the
 // options while the API read returns the FULL effective option set. The provider must persist only the user-managed keys

--- a/internal/provider/utils_wait.go
+++ b/internal/provider/utils_wait.go
@@ -1229,17 +1229,17 @@ func flinkStatementUpdatingStatus(ctx context.Context, c *FlinkRestClient, state
 func waitForFlinkMaterializedTableToProvision(ctx context.Context, c *FlinkRestClient, orgId, environmentId, kafkaId, tableName string, wantStopped bool, isAcceptanceTestMode bool, timeout time.Duration) error {
 	delay, pollInterval := getDelayAndPollInterval(5*time.Second, 10*time.Second, isAcceptanceTestMode)
 	var pendingStates []string
-	var target string
+	var target []string
 	if wantStopped {
 		pendingStates = []string{stateCreating, statePending, stateRunning, stateStopping, stateAltering}
-		target = stateStopped
+		target = []string{stateStopped, stateCompleted}
 	} else {
 		pendingStates = []string{stateCreating, statePending, stateStopped, stateStopping, stateAltering}
-		target = stateRunning
+		target = []string{stateRunning, stateCompleted}
 	}
 	stateConf := &resource.StateChangeConf{
 		Pending:      pendingStates,
-		Target:       []string{target},
+		Target:       target,
 		Refresh:      flinkMaterializedTableProvisionStatus(c.apiContext(ctx), c, orgId, environmentId, kafkaId, tableName),
 		Timeout:      timeout,
 		Delay:        delay,
@@ -1260,11 +1260,11 @@ func waitForFlinkMaterializedTableToBeUpdated(ctx context.Context, c *FlinkRestC
 
 	if toStop {
 		pendingStates = []string{stateCreating, statePending, stateRunning, stateStopping, stateAltering}
-		targetStates = []string{stateStopped}
+		targetStates = []string{stateStopped, stateCompleted}
 		targetStatusMessage = stateStopped
 	} else {
 		pendingStates = []string{stateCreating, statePending, stateStopped, stateStopping, stateAltering}
-		targetStates = []string{stateRunning}
+		targetStates = []string{stateRunning, stateCompleted}
 		targetStatusMessage = stateRunning
 	}
 
@@ -1321,7 +1321,7 @@ func flinkMaterializedTableProvisionStatus(ctx context.Context, c *FlinkRestClie
 
 		phase := table.Status.GetPhase()
 		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Materialized Table %q provisioning status to become target: current status is %q", tableName, phase), map[string]interface{}{flinkMaterializedTableLoggingKey: tableName})
-		if isFlinkMaterializedTableTransitionalPhase(phase) || phase == stateRunning || phase == stateStopped {
+		if isFlinkMaterializedTableTransitionalPhase(phase) || phase == stateRunning || phase == stateStopped || phase == stateCompleted {
 			return table, phase, nil
 		} else if phase == stateFailed || phase == stateFailing {
 			return nil, stateFailed, fmt.Errorf("Flink Materialized Table %q provisioning status is %q: %s", tableName, phase, table.Status.GetDetail())
@@ -1341,7 +1341,7 @@ func flinkMaterializedTableUpdatingStatus(ctx context.Context, c *FlinkRestClien
 
 		phase := table.Status.GetPhase()
 		tflog.Debug(ctx, fmt.Sprintf("Waiting for Flink Materialized Table %q status to become %q: current status is %q", tableName, targetStatusMessage, phase), map[string]interface{}{flinkMaterializedTableLoggingKey: tableName})
-		if isFlinkMaterializedTableTransitionalPhase(phase) || phase == stateRunning || phase == stateStopped {
+		if isFlinkMaterializedTableTransitionalPhase(phase) || phase == stateRunning || phase == stateStopped || phase == stateCompleted {
 			return table, phase, nil
 		} else if phase == stateFailed || phase == stateFailing {
 			return nil, stateFailed, fmt.Errorf("Flink Materialized Table %q status is %q: %s", tableName, phase, table.Status.GetDetail())

--- a/internal/testdata/flink_materialized_table/create_completed_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/create_completed_materialized_table.json
@@ -1,0 +1,24 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_completed",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {},
+    "session_options": {},
+    "query": "SELECT customer_id, product_id FROM examples.marketplace.orders LIMIT 10;"
+  },
+  "status": {
+    "phase": "COMPLETED",
+    "detail": "Materialized table has completed.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_completed AS SELECT customer_id, product_id FROM examples.marketplace.orders LIMIT 10;",
+    "scaling_status": {},
+    "version": 1
+  }
+}

--- a/internal/testdata/flink_materialized_table/read_completed_materialized_table.json
+++ b/internal/testdata/flink_materialized_table/read_completed_materialized_table.json
@@ -1,0 +1,24 @@
+{
+  "api_version": "sql/v1",
+  "kind": "MaterializedTable",
+  "name": "table_completed",
+  "organization_id": "1111aaaa-11aa-11aa-11aa-111111aaaaaa",
+  "environment_id": "env-abc123",
+  "spec": {
+    "kafka_cluster_id": "lkc-01",
+    "compute_pool_id": "lfcp-x7rgx1",
+    "principal": "u-yo9j87",
+    "stopped": false,
+    "table_options": {},
+    "session_options": {},
+    "query": "SELECT customer_id, product_id FROM examples.marketplace.orders LIMIT 10;"
+  },
+  "status": {
+    "phase": "COMPLETED",
+    "detail": "Materialized table has completed.",
+    "warnings": [],
+    "creation_statement": "CREATE OR ALTER MATERIALIZED TABLE table_completed AS SELECT customer_id, product_id FROM examples.marketplace.orders LIMIT 10;",
+    "scaling_status": {},
+    "version": 1
+  }
+}


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- Fixed a bug where creating or updating the `confluent_flink_materialized_table` resource failed with `is in an unexpected state "COMPLETED"` when the table's query is bounded and reaches the terminal `COMPLETED` phase.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [x] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [x] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [x] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [x] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [x] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
A `confluent_flink_materialized_table` whose query is **bounded** finishes processing all of its input and transitions to the terminal `COMPLETED` phase instead of staying `RUNNING` indefinitely. While waiting for a create or update to settle, the provider only accepted `RUNNING` and `STOPPED` as valid target phases, so a table that completed failed the apply with:

```
Error: error creating Flink Materialized Table "env-.../lkc-.../<name>": Flink Materialized Table "<name>" is in an unexpected state "COMPLETED"
```

`COMPLETED` is a documented, valid phase in the API (`sql.v1.MaterializedTableStatus.phase`), and `confluent_flink_statement` already treats it as a success target. This PR mirrors that behavior for materialized tables:

- Add `COMPLETED` to the `Target` phase list in `waitForFlinkMaterializedTableToProvision` and `waitForFlinkMaterializedTableToBeUpdated` (terminal regardless of the requested run/stop intent).
- Accept `COMPLETED` in the corresponding `flinkMaterializedTableProvisionStatus` / `flinkMaterializedTableUpdatingStatus` refresh functions so it is no longer reported as an unexpected state.

### Consistency with `confluent_flink_statement`

The `COMPLETED` handling is copied straight from `confluent_flink_statement` — same `Target`-list addition, same status-refresh accept-set — so the two resources stay consistent.

Blast Radius
----
Customers using `confluent_flink_materialized_table` with a bounded query are currently unable to create or update the resource — the apply fails once the table reaches `COMPLETED`, even though the table was created successfully on the backend. This change unblocks them. It only widens the set of accepted terminal phases, so it is not a breaking change for existing (RUNNING/STOPPED) tables.

Test & Review
-------------
- Manual testing (main.tf, apply against real Confluent Cloud resources): https://confluent.slack.com/archives/C02TG07V058/p1787887537088969
- Added acceptance test `TestAccFlinkMaterializedTableCompletedPhase` (wiremock) that stubs a create returning the terminal `COMPLETED` phase. Before the fix the create fails with `is in an unexpected state "COMPLETED"`; after the fix it succeeds. New testdata: `create_completed_materialized_table.json`, `read_completed_materialized_table.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

