### PR TITLE
[INC-12957] Skip Flink Materialized Table live tests until the column type panic is fixed

### DIFF
--- a/internal/provider/data_source_flink_materialized_table_live_test.go
+++ b/internal/provider/data_source_flink_materialized_table_live_test.go
@@ -29,6 +29,11 @@ import (
 func TestAccDataSourceFlinkMaterializedTableLive(t *testing.T) {
 	t.Parallel()
 
+	// TODO(INC-12957): remove once confluentinc/terraform-provider-confluent#1178 or
+	// #1180 merges. See the identical guard in resource_flink_materialized_table_live_test.go
+	// for the full explanation.
+	t.Skip("Skipping due to INC-12957 (confluent_flink_materialized_table column type panic); re-enable once confluentinc/terraform-provider-confluent#1178 or #1180 merges")
+
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
 	}

--- a/internal/provider/data_source_flink_materialized_table_live_test.go
+++ b/internal/provider/data_source_flink_materialized_table_live_test.go
@@ -27,16 +27,18 @@ import (
 )
 
 func TestAccDataSourceFlinkMaterializedTableLive(t *testing.T) {
-	t.Parallel()
-
 	// TODO(INC-12957): remove once confluentinc/terraform-provider-confluent#1178 or
 	// #1180 merges. See the identical guard in resource_flink_materialized_table_live_test.go
-	// for the full explanation.
+	// for the full explanation. This (and the TF_ACC_PROD guard below) must run before
+	// t.Parallel(), which blocks until the parallel phase starts — skipping first avoids
+	// waiting on a parallel slot for a test that's going to skip anyway.
 	t.Skip("Skipping due to INC-12957 (confluent_flink_materialized_table column type panic); re-enable once confluentinc/terraform-provider-confluent#1178 or #1180 merges")
 
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
 	}
+
+	t.Parallel()
 
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")

--- a/internal/provider/resource_flink_materialized_table_live_test.go
+++ b/internal/provider/resource_flink_materialized_table_live_test.go
@@ -48,19 +48,23 @@ func extractAwsRegionFromKafkaRestEndpoint(endpoint string) (string, error) {
 }
 
 func TestAccFlinkMaterializedTableLive(t *testing.T) {
-	t.Parallel()
-
 	// TODO(INC-12957): remove once confluentinc/terraform-provider-confluent#1178 or
 	// #1180 merges. The Flink Gateway now returns columns[].type as a structured object
 	// instead of a plain string; setMaterializedTableAttributes hands that straight to
 	// d.Set on a string-typed field, which panics under TF_ACC=1. All live tests share
 	// one test binary (make live-test runs with -parallel 10), so that panic takes down
 	// every other in-flight live test, not just this one.
+	//
+	// This must run before t.Parallel(), which blocks until the parallel phase starts;
+	// skipping first avoids waiting on (and briefly holding) a parallel slot for a test
+	// that's going to skip anyway.
 	t.Skip("Skipping due to INC-12957 (confluent_flink_materialized_table column type panic); re-enable once confluentinc/terraform-provider-confluent#1178 or #1180 merges")
 
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
 	}
+
+	t.Parallel()
 
 	apiKey := os.Getenv("CONFLUENT_CLOUD_API_KEY")
 	apiSecret := os.Getenv("CONFLUENT_CLOUD_API_SECRET")

--- a/internal/provider/resource_flink_materialized_table_live_test.go
+++ b/internal/provider/resource_flink_materialized_table_live_test.go
@@ -50,6 +50,14 @@ func extractAwsRegionFromKafkaRestEndpoint(endpoint string) (string, error) {
 func TestAccFlinkMaterializedTableLive(t *testing.T) {
 	t.Parallel()
 
+	// TODO(INC-12957): remove once confluentinc/terraform-provider-confluent#1178 or
+	// #1180 merges. The Flink Gateway now returns columns[].type as a structured object
+	// instead of a plain string; setMaterializedTableAttributes hands that straight to
+	// d.Set on a string-typed field, which panics under TF_ACC=1. All live tests share
+	// one test binary (make live-test runs with -parallel 10), so that panic takes down
+	// every other in-flight live test, not just this one.
+	t.Skip("Skipping due to INC-12957 (confluent_flink_materialized_table column type panic); re-enable once confluentinc/terraform-provider-confluent#1178 or #1180 merges")
+
 	if os.Getenv("TF_ACC_PROD") == "" {
 		t.Skip("Skipping live test. Set TF_ACC_PROD=1 to run this test.")
 	}


### PR DESCRIPTION
Release Notes
---------
No user-facing changes — this only skips two live tests.

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — no provider code changed)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A)
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. (N/A — no new functionality; this removes live coverage temporarily, see Blast Radius)
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR. (N/A)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Stopgap for INC-12957. `confluent_flink_materialized_table` live tests panic and take
the shared test binary down with them, failing every other in-flight live test in the
same run. Root cause is tracked separately (#1178, #1180). Until one lands, skip the two
affected tests (`TestAccFlinkMaterializedTableLive`,
`TestAccDataSourceFlinkMaterializedTableLive`) so CI stops losing signal on unrelated
tests.

No production code touched — only the two `*_live_test.go` files.

Blast Radius
----
None for customers. This resource already fails open in production today — a known,
low-severity gap tracked separately, not something this PR introduces or changes.
Confirmed no `confluent_flink_materialized_table` code has changed since the v2.83.0 tag
other than an unrelated fix (#1174), so nothing here is masking a regression. Scope of
this PR is limited to CI: reduced live-test coverage for
`confluent_flink_materialized_table` until the skip is removed (#1178/#1180); unit and
acceptance tests are unaffected.
