### PR TITLE
[INC-12957] Isolate Flink Materialized Table live tests from the main live-test run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,13 @@ endif
 # Usage: make live-test TF_LIVE_TEST_GROUPS="core,kafka" or make live-test (for all)
 # RTCE tests are excluded here because RTCE prod is only enabled in aws.us-east-1;
 # run them via the dedicated `live-test-rtce` target below.
+# Flink Materialized Table live tests are excluded here too, temporarily: the Flink
+# Gateway now returns columns[].type as a structured object instead of a plain string,
+# which panics inside d.Set under TF_ACC=1. All live tests share one test binary
+# (-parallel 10), so that panic takes every other in-flight live test down with it
+# (INC-12957). Run them deliberately via `live-test-flink-materialized-table` below;
+# remove this exclusion and that target once the provider-side fix
+# (confluentinc/terraform-provider-confluent#1178 or #1180) merges.
 # VERBOSE is empty under CI deliberately: -v breaks gotestsum's report, per the note above `test`.
 # A failed gotestsum install degrades to plain `go test` rather than aborting: smoke-tests wraps
 # this in a PASS/FAIL that pages, so a module-proxy blip must not look like a Confluent outage.
@@ -155,14 +162,14 @@ live-test:
 	fi; \
 	if [ -z "$(TF_LIVE_TEST_GROUPS)" ]; then \
 		echo "Running ALL live tests with parallel execution..."; \
-		$(GOENV) TF_ACC=1 TF_ACC_PROD=1 $$RUNNER ./internal/provider/ $$VERBOSE -run=".*Live$$|.*DriftDetection$$" -skip="Rtce" -tags="live_test,all" -timeout 1440m -parallel 10; \
+		$(GOENV) TF_ACC=1 TF_ACC_PROD=1 $$RUNNER ./internal/provider/ $$VERBOSE -run=".*Live$$|.*DriftDetection$$" -skip="Rtce|FlinkMaterializedTable" -tags="live_test,all" -timeout 1440m -parallel 10; \
 	else \
 		echo "Running live tests for groups: $(TF_LIVE_TEST_GROUPS) with parallel execution..."; \
 		TAGS="live_test"; \
 		for group in $$(echo "$(TF_LIVE_TEST_GROUPS)" | tr ',' ' '); do \
 			TAGS="$$TAGS,$$group"; \
 		done; \
-		$(GOENV) TF_ACC=1 TF_ACC_PROD=1 $$RUNNER ./internal/provider/ $$VERBOSE -run=".*Live$$|.*DriftDetection$$" -skip="Rtce" -tags="$$TAGS" -timeout 1440m -parallel 10; \
+		$(GOENV) TF_ACC=1 TF_ACC_PROD=1 $$RUNNER ./internal/provider/ $$VERBOSE -run=".*Live$$|.*DriftDetection$$" -skip="Rtce|FlinkMaterializedTable" -tags="$$TAGS" -timeout 1440m -parallel 10; \
 	fi
 	@echo "Finished running live integration tests against Confluent Cloud"
 
@@ -183,6 +190,27 @@ live-test-rtce:
 	fi; \
 	TF_ACC=1 TF_ACC_PROD=1 TF_ACC_REGION=us-east-1 $(GOENV) $$RUNNER ./internal/provider/ $$VERBOSE -run="Rtce.*Live$$" -tags="live_test,all" -timeout 1440m -parallel 10
 	@echo "Finished running RTCE live integration tests"
+
+# Flink Materialized Table live tests — temporarily excluded from the main `live-test`
+# target (see the comment there) because of INC-12957: the Flink Gateway now returns
+# columns[].type as a structured object instead of a plain string, which panics inside
+# d.Set under TF_ACC=1 and takes down every other live test sharing the test binary.
+# Run these deliberately here instead, e.g. to validate
+# confluentinc/terraform-provider-confluent#1178 or #1180 against real Confluent Cloud.
+# Remove this target and its exclusion from `live-test` once one of those merges.
+.PHONY: live-test-flink-materialized-table
+live-test-flink-materialized-table:
+	@echo "Running Flink Materialized Table live integration tests against Confluent Cloud..."
+	@if [ "$(CI)" != "true" ]; then \
+		RUNNER="go test"; VERBOSE="-v"; \
+	elif $(GOTESTSUM_INSTALL); then \
+		RUNNER="gotestsum --format testname --junitfile live-flink-materialized-table-report.xml --"; VERBOSE=""; \
+	else \
+		echo "gotestsum unavailable, running without a JUnit report"; \
+		RUNNER="go test"; VERBOSE="-v"; \
+	fi; \
+	$(GOENV) TF_ACC=1 TF_ACC_PROD=1 $$RUNNER ./internal/provider/ $$VERBOSE -run=".*FlinkMaterializedTable.*Live$$" -tags="live_test,all" -timeout 1440m -parallel 10
+	@echo "Finished running Flink Materialized Table live integration tests"
 
 # Helper targets for common group combinations
 .PHONY: live-test-core


### PR DESCRIPTION
Release Notes
---------
No user-facing changes — this only changes local/CI test tooling (Makefile).

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — no provider code changed)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A — Makefile-only change)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A)
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. (N/A — no new functionality)
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR. (N/A)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
Fixes the CI symptom of INC-12957 without touching provider code.

The Flink Gateway API now returns `columns[].type` as a structured object instead of a
plain string. `setMaterializedTableAttributes` (resource_flink_materialized_table.go)
hands that straight to `d.Set` on the string-typed `column_physical_type` /
`column_computed_type` / `column_metadata_type` fields. Under `TF_ACC=1`,
`ResourceData.Set` panics instead of just logging the rejected write — and because
`make live-test` runs every live test in one process with `-parallel 10`, that single
panic crashes the whole binary and reports ~27 unrelated live tests as failed alongside
it.

Two provider-side fixes for the actual root cause are already open (#1178, #1180); this
PR is a companion stopgap to #1186 so CI stops losing signal on every other live test
while the team picks one. It excludes only the two Flink Materialized Table live tests
(`TestAccFlinkMaterializedTableLive`, `TestAccDataSourceFlinkMaterializedTableLive`) from
`make live-test`, the same way `TestAccRtce*Live` tests are already isolated via
`-skip="Rtce"` (see #1020). A new `make live-test-flink-materialized-table` target keeps
them runnable on demand — e.g. to validate #1178 or #1180 against real Confluent Cloud
before merging either one.

No Go source (production or test) was changed — this is a Makefile-only change to test
invocation. #1186 is the preferred alternative (a source-level `t.Skip`, so the tests are
skipped regardless of how they're invoked, not just under `make live-test`) — merge
whichever the team prefers, not both.

Blast Radius
----
None for customers — this only changes which live tests Semaphore runs in CI; it does
not touch any resource/data-source code path. The tradeoff is reduced CI coverage: the
two excluded live tests won't run automatically until this exclusion is reverted (see
below), so a real regression in `confluent_flink_materialized_table` between now and
then wouldn't be caught by live tests (unit/acceptance tests are unaffected and still
run).

References
----------
- INC-12957
- Alternative root-cause fixes: #1178, #1180
- Precedent for this pattern: #1020 (isolating RTCE live tests the same way)
- Preferred alternative: #1186 (skips these same two tests at the test-source level via
  `t.Skip`, so they're skipped regardless of invocation — not just under `make live-test`)

Test & Review
-------------
- Verified locally (bypassing an unrelated local vendoring inconsistency with
  `-mod=mod`) that:
  - `go test ./internal/provider/ -tags="live_test,all" -run=".*Live$|.*DriftDetection$"
    -skip="Rtce|FlinkMaterializedTable" -v` no longer selects
    `TestAccFlinkMaterializedTableLive` or `TestAccDataSourceFlinkMaterializedTableLive`,
    while other live tests (e.g. `TestAccApiKeyLive`, `TestAccEnvironmentLive`) are still
    selected.
  - `go test ./internal/provider/ -tags="live_test,all"
    -run=".*FlinkMaterializedTable.*Live$" -v` selects exactly those two tests.
  - `gmake -n live-test` / `gmake -n live-test-flink-materialized-table` (GNU Make 4.4.1)
    show the expected shell commands with no syntax errors.
- Did not run the live suite against Confluent Cloud (no credentials in this
  environment) — this change only affects which tests get selected, not their internals.