### PR TITLE
[APIE-1566] Central CRUD + import telemetry wrapper (TFCA-B3)

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -445,10 +445,9 @@ func New(version, userAgent string) func() *schema.Provider {
 			},
 		}
 
-		// Wrap every managed resource's CRUD/import entry points with telemetry
-		// (TFCA-B3), once ResourcesMap is complete. The no-op sink keeps this
-		// transparent until TFCA-B5/B6 supply the real reporter; terraformVersion
-		// is read lazily because Core sets it during ConfigureProvider, later.
+		// Wrap every managed resource's CRUD and import entry points with
+		// telemetry, once ResourcesMap is complete. terraformVersion is read
+		// lazily because Core sets it during ConfigureProvider, after this point.
 		wrapResourcesMapForTelemetry(provider.ResourcesMap, telemetryWrapConfig{
 			reporter:         noopTelemetryReporter{},
 			providerVersion:  version,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -445,6 +445,20 @@ func New(version, userAgent string) func() *schema.Provider {
 			},
 		}
 
+		// Wrap every managed resource's CRUD and import entry points with
+		// client-analytics telemetry (TFCA-B3). This runs once, after
+		// ResourcesMap is fully constructed and before the provider is served.
+		// Reports currently go to a no-op sink; the network transport (TFCA-B5)
+		// and opt-out wiring (TFCA-B6) replace it downstream, so today this is
+		// behaviorally transparent. terraformVersion is read lazily because
+		// Terraform Core sets provider.TerraformVersion during ConfigureProvider,
+		// after this point but before any CRUD/import call runs.
+		wrapResourcesMapForTelemetry(provider.ResourcesMap, telemetryWrapConfig{
+			reporter:         noopTelemetryReporter{},
+			providerVersion:  version,
+			terraformVersion: func() string { return provider.TerraformVersion },
+		})
+
 		provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			return providerConfigure(ctx, d, provider, version, userAgent)
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -445,14 +445,10 @@ func New(version, userAgent string) func() *schema.Provider {
 			},
 		}
 
-		// Wrap every managed resource's CRUD and import entry points with
-		// client-analytics telemetry (TFCA-B3). This runs once, after
-		// ResourcesMap is fully constructed and before the provider is served.
-		// Reports currently go to a no-op sink; the network transport (TFCA-B5)
-		// and opt-out wiring (TFCA-B6) replace it downstream, so today this is
-		// behaviorally transparent. terraformVersion is read lazily because
-		// Terraform Core sets provider.TerraformVersion during ConfigureProvider,
-		// after this point but before any CRUD/import call runs.
+		// Wrap every managed resource's CRUD/import entry points with telemetry
+		// (TFCA-B3), once ResourcesMap is complete. The no-op sink keeps this
+		// transparent until TFCA-B5/B6 supply the real reporter; terraformVersion
+		// is read lazily because Core sets it during ConfigureProvider, later.
 		wrapResourcesMapForTelemetry(provider.ResourcesMap, telemetryWrapConfig{
 			reporter:         noopTelemetryReporter{},
 			providerVersion:  version,

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Confluent Inc. All Rights Reserved.
+// Copyright 2026 Confluent Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -1,0 +1,259 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"runtime"
+	"sort"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
+)
+
+// This file is the central client-analytics wrapping mechanism (TFCA-B3). It
+// replaces every managed resource's CRUD and import entry points, once, with
+// wrappers that build a telemetry.Usage and hand it to a reporter. It is the
+// single place this happens: no individual resource_*.go file is touched.
+//
+// Scope boundaries with the rest of Epic B, so this file stays reviewable in
+// isolation:
+//   - The payload/timing/run-ID model it populates lives in the telemetry
+//     package (TFCA-B1).
+//   - Reporting here goes to a no-op sink. The bounded-worker network transport
+//     (TFCA-B5) supplies the real reporter, and the opt-out wiring (TFCA-B6)
+//     decides when reporting is enabled. Until then this wrapper does no I/O and
+//     cannot fail, slow, or otherwise change the behavior of an operation.
+//   - Panic recovery is deliberately NOT added here (TFCA-B4). If a wrapped
+//     function panics, the panic propagates exactly as it does today and no
+//     Usage is reported for that call.
+
+// telemetryReporter receives a fully-populated Usage for one resource
+// operation. Report must not block the calling CRUD/import goroutine for long:
+// the no-op shipped here returns immediately, and the TFCA-B5 transport that
+// replaces it hands off to a bounded worker pool.
+type telemetryReporter interface {
+	Report(telemetry.Usage)
+}
+
+// noopTelemetryReporter drops every Usage. It is the reporter used until the
+// TFCA-B5 transport replaces it, which is what makes the wrapping mechanism
+// introduced here behaviorally transparent.
+type noopTelemetryReporter struct{}
+
+func (noopTelemetryReporter) Report(telemetry.Usage) {}
+
+// telemetryWrapConfig carries the process-scoped inputs the wrapper needs to
+// populate a Usage.
+type telemetryWrapConfig struct {
+	// reporter receives each Usage. A nil reporter is treated as a no-op.
+	reporter telemetryReporter
+
+	// providerVersion is the released provider version, constant for the life of
+	// the process (the value threaded through New).
+	providerVersion string
+
+	// terraformVersion returns the version of Terraform Core that launched the
+	// provider. It is a function, not a value, because Terraform Core populates
+	// schema.Provider.TerraformVersion during ConfigureProvider — after New
+	// returns but before any CRUD/import call runs. A nil function yields "".
+	terraformVersion func() string
+}
+
+func (c telemetryWrapConfig) report(u telemetry.Usage) {
+	r := c.reporter
+	if r == nil {
+		r = noopTelemetryReporter{}
+	}
+	r.Report(u)
+}
+
+func (c telemetryWrapConfig) tfVersion() string {
+	if c.terraformVersion == nil {
+		return ""
+	}
+	return c.terraformVersion()
+}
+
+// wrappedResources records which *schema.Resource values have already had their
+// entry points wrapped. Composing the wrap pass more than once over the same map
+// would double-emit events and, once TFCA-B4 lands, stack recover layers; this
+// guard makes a second pass a no-op. It is enforced in code rather than by a
+// "wrap only once" comment so it survives a future refactor that reorders or
+// repeats the call. Resource pointers are unique per constructed provider (each
+// xResource() constructor returns a fresh *schema.Resource), so resources from
+// different providers never collide here and one provider's wrapping never
+// suppresses another's.
+var wrappedResources sync.Map // map[*schema.Resource]struct{}
+
+// wrapResourcesMapForTelemetry wraps the CRUD and import entry points of every
+// resource in the map. It must run after ResourcesMap is fully constructed and
+// before the provider is served. It is safe to call more than once; each
+// resource is wrapped at most once.
+func wrapResourcesMapForTelemetry(resources map[string]*schema.Resource, cfg telemetryWrapConfig) {
+	if cfg.reporter == nil {
+		cfg.reporter = noopTelemetryReporter{}
+	}
+	for resourceType, r := range resources {
+		if r == nil {
+			continue
+		}
+		if _, alreadyWrapped := wrappedResources.LoadOrStore(r, struct{}{}); alreadyWrapped {
+			continue
+		}
+		wrapResourceForTelemetry(resourceType, r, cfg)
+	}
+}
+
+// resourceWrapped reports whether r has been through wrapResourcesMapForTelemetry.
+// It exists for tests that assert coverage of the wrap pass.
+func resourceWrapped(r *schema.Resource) bool {
+	_, ok := wrappedResources.Load(r)
+	return ok
+}
+
+// wrapResourceForTelemetry wraps each entry point of a single resource
+// independently, and only when that entry point is already non-nil.
+//
+// The non-nil guard matters: 8 of the managed resources have no UpdateContext.
+// The SDK decides at runtime whether an update is legal by checking whether an
+// update function is set (helper/schema/resource.go), so replacing a nil
+// UpdateContext with a non-nil wrapper closure would both nil-panic when that
+// closure invoked the (nil) inner function and silently make those resources
+// report as updatable. The same reasoning applies to any resource that happens
+// to leave a CRUD entry point unset.
+func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telemetryWrapConfig) {
+	if r.CreateContext != nil {
+		r.CreateContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationCreate, r.CreateContext, cfg)
+	}
+	if r.ReadContext != nil {
+		r.ReadContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationRead, r.ReadContext, cfg)
+	}
+	if r.UpdateContext != nil {
+		r.UpdateContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationUpdate, r.UpdateContext, cfg)
+	}
+	if r.DeleteContext != nil {
+		r.DeleteContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationDelete, r.DeleteContext, cfg)
+	}
+	if r.Importer != nil && r.Importer.StateContext != nil {
+		r.Importer.StateContext = wrapImportFunc(resourceType, r.Schema, r.Importer.StateContext, cfg)
+	}
+}
+
+// wrapContextFunc wraps a Create/Read/Update/DeleteContext function. The return
+// type is the bare function type rather than a named schema.*ContextFunc so the
+// one wrapper is assignable to all four fields (they share this underlying
+// signature).
+//
+// The sequence number and timer are taken at entry, before inner runs, so the
+// recorded order reflects invocation order even for operations whose report is
+// later dropped, and the duration brackets exactly the inner call. The Usage is
+// built and reported synchronously after inner returns and before the wrapper
+// returns, because the SDK reads the *schema.ResourceData immediately after the
+// CRUD function returns — nothing here may defer to a background goroutine that
+// touches d.
+func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Schema, op telemetry.Operation, inner func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		seq := telemetry.NextSequence()
+		timer := telemetry.StartTimer()
+
+		diags := inner(ctx, d, meta)
+
+		cfg.report(telemetry.Usage{
+			RunID:             telemetry.RunID(),
+			Sequence:          seq,
+			StartedAt:         timer.StartTime(),
+			DurationMs:        timer.Elapsed().Milliseconds(),
+			OS:                runtime.GOOS,
+			Arch:              runtime.GOARCH,
+			ProviderVersion:   cfg.providerVersion,
+			TerraformVersion:  cfg.tfVersion(),
+			ResourceType:      resourceType,
+			Operation:         op,
+			ChangedAttributes: changedAttributeNames(d, resourceSchema, op),
+			Error:             diags.HasError(),
+		})
+		return diags
+	}
+}
+
+// wrapImportFunc wraps an Importer.StateContext function. Import has a different
+// signature (it returns the imported resource data and an error, not
+// diagnostics), so it is wrapped separately from the CRUD entry points. Import
+// carries no attribute-level diff, so ChangedAttributes is always the empty
+// (non-nil) slice.
+func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schema, inner schema.StateContextFunc, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) ([]*schema.ResourceData, error) {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+		seq := telemetry.NextSequence()
+		timer := telemetry.StartTimer()
+
+		imported, err := inner(ctx, d, meta)
+
+		cfg.report(telemetry.Usage{
+			RunID:             telemetry.RunID(),
+			Sequence:          seq,
+			StartedAt:         timer.StartTime(),
+			DurationMs:        timer.Elapsed().Milliseconds(),
+			OS:                runtime.GOOS,
+			Arch:              runtime.GOARCH,
+			ProviderVersion:   cfg.providerVersion,
+			TerraformVersion:  cfg.tfVersion(),
+			ResourceType:      resourceType,
+			Operation:         telemetry.OperationImport,
+			ChangedAttributes: []string{},
+			Error:             err != nil,
+		})
+		return imported, err
+	}
+}
+
+// changedAttributeNames returns the schema-declared, top-level attribute names
+// that changed in this operation. It returns a non-nil slice (empty when nothing
+// changed) so the field serializes as [] rather than null.
+//
+// It iterates the resource's own schema keys and reports only those names — it
+// can never emit a map attribute's dynamic keys or any attribute value, because
+// the only strings it ever appends are the static schema keys themselves. A
+// schema.TypeMap attribute therefore contributes only its own name (e.g.
+// "config"), never the keys of the map a user set.
+//
+// Only Create and Update carry a meaningful attribute diff; Read, Delete, and
+// Import report the empty slice.
+func changedAttributeNames(d *schema.ResourceData, resourceSchema map[string]*schema.Schema, op telemetry.Operation) []string {
+	if d == nil || (op != telemetry.OperationCreate && op != telemetry.OperationUpdate) {
+		return []string{}
+	}
+	return collectChangedNames(resourceSchema, d.HasChange)
+}
+
+// collectChangedNames is the leak-proof core of changedAttributeNames, split out
+// so it can be tested deterministically without constructing a diff-bearing
+// *schema.ResourceData. The only strings it can ever return are keys of
+// resourceSchema — the statically declared attribute names — so no attribute
+// value and no user-controlled map key can escape into a Usage, regardless of
+// what hasChange reports.
+func collectChangedNames(resourceSchema map[string]*schema.Schema, hasChange func(string) bool) []string {
+	names := make([]string, 0)
+	for name := range resourceSchema {
+		if hasChange(name) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -27,52 +27,36 @@ import (
 	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
 )
 
-// This file is the central client-analytics wrapping mechanism (TFCA-B3). It
-// replaces every managed resource's CRUD and import entry points, once, with
-// wrappers that build a telemetry.Usage and hand it to a reporter. It is the
-// single place this happens: no individual resource_*.go file is touched.
-//
-// Scope boundaries with the rest of Epic B, so this file stays reviewable in
-// isolation:
-//   - The payload/timing/run-ID model it populates lives in the telemetry
-//     package (TFCA-B1).
-//   - Reporting here goes to a no-op sink. The bounded-worker network transport
-//     (TFCA-B5) supplies the real reporter, and the opt-out wiring (TFCA-B6)
-//     decides when reporting is enabled. Until then this wrapper does no I/O and
-//     cannot fail, slow, or otherwise change the behavior of an operation.
-//   - Panic recovery is deliberately NOT added here (TFCA-B4). If a wrapped
-//     function panics, the panic propagates exactly as it does today and no
-//     Usage is reported for that call.
+// Central client-analytics wrapping (TFCA-B3): replaces every managed resource's
+// CRUD and import entry points, once, with wrappers that build a telemetry.Usage
+// and hand it to a reporter — no resource_*.go file is touched. Reporting goes to
+// a no-op sink until the TFCA-B5 transport and TFCA-B6 opt-out supply the real
+// reporter, so today the wrapper does no I/O and changes no behavior. Panic
+// recovery is deferred to TFCA-B4; a panic here propagates unchanged.
 
-// telemetryReporter receives a fully-populated Usage for one resource
-// operation. Report must not block the calling CRUD/import goroutine for long:
-// the no-op shipped here returns immediately, and the TFCA-B5 transport that
-// replaces it hands off to a bounded worker pool.
+// telemetryReporter receives a fully-populated Usage. Report must not block the
+// calling goroutine for long (the TFCA-B5 transport hands off to a worker pool).
 type telemetryReporter interface {
 	Report(telemetry.Usage)
 }
 
-// noopTelemetryReporter drops every Usage. It is the reporter used until the
-// TFCA-B5 transport replaces it, which is what makes the wrapping mechanism
-// introduced here behaviorally transparent.
+// noopTelemetryReporter drops every Usage; it keeps this mechanism transparent
+// until the TFCA-B5 transport replaces it.
 type noopTelemetryReporter struct{}
 
 func (noopTelemetryReporter) Report(telemetry.Usage) {}
 
-// telemetryWrapConfig carries the process-scoped inputs the wrapper needs to
-// populate a Usage.
+// telemetryWrapConfig carries the process-scoped inputs used to populate a Usage.
 type telemetryWrapConfig struct {
-	// reporter receives each Usage. A nil reporter is treated as a no-op.
+	// reporter receives each Usage; a nil reporter is treated as a no-op.
 	reporter telemetryReporter
 
-	// providerVersion is the released provider version, constant for the life of
-	// the process (the value threaded through New).
+	// providerVersion is the released provider version.
 	providerVersion string
 
-	// terraformVersion returns the version of Terraform Core that launched the
-	// provider. It is a function, not a value, because Terraform Core populates
+	// terraformVersion is a func, not a value, because Core populates
 	// schema.Provider.TerraformVersion during ConfigureProvider — after New
-	// returns but before any CRUD/import call runs. A nil function yields "".
+	// returns but before any CRUD/import call. A nil func yields "".
 	terraformVersion func() string
 }
 
@@ -91,28 +75,16 @@ func (c telemetryWrapConfig) tfVersion() string {
 	return c.terraformVersion()
 }
 
-// wrappedResources records which *schema.Resource values have already had their
-// entry points wrapped. Composing the wrap pass more than once over the same map
-// would double-emit events and, once TFCA-B4 lands, stack recover layers; this
-// guard makes a second pass a no-op. It is enforced in code rather than by a
-// "wrap only once" comment so it survives a future refactor that reorders or
-// repeats the call. Resource pointers are unique per constructed provider (each
-// xResource() constructor returns a fresh *schema.Resource), so resources from
-// different providers never collide here and one provider's wrapping never
-// suppresses another's.
-//
-// Keys are weak.Pointers so an entry here does not keep the resource — nor the
-// whole provider graph its wrapper closures transitively capture (via the
-// terraformVersion closure) — alive for the life of the process. Each resource
-// registers a cleanup that removes its now-dead stub once it is collected, so the
-// map does not grow without bound when New() is called repeatedly (e.g.
-// confluent_tf_importer builds a fresh provider on every apply).
+// wrappedResources makes wrapping idempotent: a resource wrapped once is skipped
+// on any later pass, so composing the wrap twice never double-emits. Keys are
+// weak.Pointers so an entry does not keep the resource — or the provider graph
+// its closures capture — alive; each resource registers a cleanup that drops its
+// dead stub once collected, so repeated New() calls (e.g. confluent_tf_importer,
+// one per apply) don't leak.
 var wrappedResources sync.Map // map[weak.Pointer[schema.Resource]]struct{}
 
-// wrapResourcesMapForTelemetry wraps the CRUD and import entry points of every
-// resource in the map. It must run after ResourcesMap is fully constructed and
-// before the provider is served. It is safe to call more than once; each
-// resource is wrapped at most once.
+// wrapResourcesMapForTelemetry wraps every resource's CRUD and import entry
+// points. Run it after ResourcesMap is built; it is safe to call more than once.
 func wrapResourcesMapForTelemetry(resources map[string]*schema.Resource, cfg telemetryWrapConfig) {
 	if cfg.reporter == nil {
 		cfg.reporter = noopTelemetryReporter{}
@@ -125,31 +97,23 @@ func wrapResourcesMapForTelemetry(resources map[string]*schema.Resource, cfg tel
 		if _, alreadyWrapped := wrappedResources.LoadOrStore(key, struct{}{}); alreadyWrapped {
 			continue
 		}
-		// Reap the weak stub once the resource is collected, so repeated New()
-		// calls don't accumulate dead entries. The cleanup captures only the weak
-		// key (never r), so it cannot keep r alive.
+		// Drop the weak stub once the resource is collected. The cleanup
+		// captures only the weak key, never r, so it cannot keep r alive.
 		runtime.AddCleanup(r, wrappedResources.Delete, any(key))
 		wrapResourceForTelemetry(resourceType, r, cfg)
 	}
 }
 
-// resourceWrapped reports whether r has been through wrapResourcesMapForTelemetry.
-// It exists for tests that assert coverage of the wrap pass.
+// resourceWrapped reports whether r has been wrapped (used by tests).
 func resourceWrapped(r *schema.Resource) bool {
 	_, ok := wrappedResources.Load(weak.Make(r))
 	return ok
 }
 
-// wrapResourceForTelemetry wraps each entry point of a single resource
-// independently, and only when that entry point is already non-nil.
-//
-// The non-nil guard matters: 8 of the managed resources have no UpdateContext.
-// The SDK decides at runtime whether an update is legal by checking whether an
-// update function is set (helper/schema/resource.go), so replacing a nil
-// UpdateContext with a non-nil wrapper closure would both nil-panic when that
-// closure invoked the (nil) inner function and silently make those resources
-// report as updatable. The same reasoning applies to any resource that happens
-// to leave a CRUD entry point unset.
+// wrapResourceForTelemetry wraps each entry point only when it is already
+// non-nil. This matters: 8 managed resources have a nil UpdateContext, and the
+// SDK treats a set update func as "updates allowed" — turning nil into a wrapper
+// closure would nil-panic and falsely advertise those resources as updatable.
 func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telemetryWrapConfig) {
 	if r.CreateContext != nil {
 		r.CreateContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationCreate, r.CreateContext, cfg)
@@ -168,18 +132,11 @@ func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telem
 	}
 }
 
-// wrapContextFunc wraps a Create/Read/Update/DeleteContext function. The return
-// type is the bare function type rather than a named schema.*ContextFunc so the
-// one wrapper is assignable to all four fields (they share this underlying
-// signature).
-//
-// The sequence number and timer are taken at entry, before inner runs, so the
-// recorded order reflects invocation order even for operations whose report is
-// later dropped, and the duration brackets exactly the inner call. The Usage is
-// built and reported synchronously after inner returns and before the wrapper
-// returns, because the SDK reads the *schema.ResourceData immediately after the
-// CRUD function returns — nothing here may defer to a background goroutine that
-// touches d.
+// wrapContextFunc wraps a Create/Read/Update/DeleteContext function. Sequence and
+// timer are taken at entry (so order/duration are correct even if the report is
+// dropped), and the Usage is built and reported synchronously after inner returns
+// — the SDK reads ResourceData right after CRUD returns, so nothing may defer to
+// a goroutine that touches d.
 func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Schema, op telemetry.Operation, inner func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		seq := telemetry.NextSequence()
@@ -205,11 +162,8 @@ func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Sche
 	}
 }
 
-// wrapImportFunc wraps an Importer.StateContext function. Import has a different
-// signature (it returns the imported resource data and an error, not
-// diagnostics), so it is wrapped separately from the CRUD entry points. Import
-// carries no attribute-level diff, so ChangedAttributes is always the empty
-// (non-nil) slice.
+// wrapImportFunc wraps Importer.StateContext, which has a different signature and
+// carries no attribute diff, so ChangedAttributes is always the empty slice.
 func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schema, inner schema.StateContextFunc, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) ([]*schema.ResourceData, error) {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 		seq := telemetry.NextSequence()
@@ -235,18 +189,10 @@ func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schem
 	}
 }
 
-// changedAttributeNames returns the schema-declared, top-level attribute names
-// that changed in this operation. It returns a non-nil slice (empty when nothing
-// changed) so the field serializes as [] rather than null.
-//
-// It iterates the resource's own schema keys and reports only those names — it
-// can never emit a map attribute's dynamic keys or any attribute value, because
-// the only strings it ever appends are the static schema keys themselves. A
-// schema.TypeMap attribute therefore contributes only its own name (e.g.
-// "config"), never the keys of the map a user set.
-//
-// Only Create and Update carry a meaningful attribute diff; Read, Delete, and
-// Import report the empty slice.
+// changedAttributeNames returns the top-level schema attribute names that
+// changed, as a non-nil slice (so it serializes as [] not null). It appends only
+// static schema keys, so no attribute value or user-controlled map key can leak.
+// Only Create and Update carry a diff; other operations report the empty slice.
 func changedAttributeNames(d *schema.ResourceData, resourceSchema map[string]*schema.Schema, op telemetry.Operation) []string {
 	if d == nil || (op != telemetry.OperationCreate && op != telemetry.OperationUpdate) {
 		return []string{}
@@ -254,12 +200,8 @@ func changedAttributeNames(d *schema.ResourceData, resourceSchema map[string]*sc
 	return collectChangedNames(resourceSchema, d.HasChange)
 }
 
-// collectChangedNames is the leak-proof core of changedAttributeNames, split out
-// so it can be tested deterministically without constructing a diff-bearing
-// *schema.ResourceData. The only strings it can ever return are keys of
-// resourceSchema — the statically declared attribute names — so no attribute
-// value and no user-controlled map key can escape into a Usage, regardless of
-// what hasChange reports.
+// collectChangedNames is the core of changedAttributeNames, split out for
+// deterministic testing. It can only ever return keys of resourceSchema.
 func collectChangedNames(resourceSchema map[string]*schema.Schema, hasChange func(string) bool) []string {
 	names := make([]string, 0)
 	for name := range resourceSchema {

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -27,21 +27,16 @@ import (
 	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
 )
 
-// Central client-analytics wrapping (TFCA-B3): replaces every managed resource's
-// CRUD and import entry points, once, with wrappers that build a telemetry.Usage
-// and hand it to a reporter — no resource_*.go file is touched. Reporting goes to
-// a no-op sink until the TFCA-B5 transport and TFCA-B6 opt-out supply the real
-// reporter, so today the wrapper does no I/O and changes no behavior. Panic
-// recovery is deferred to TFCA-B4; a panic here propagates unchanged.
+// Central client-analytics wrapping. Replaces every managed resource's CRUD and
+// import entry points, once, with wrappers that build a telemetry.Usage and hand
+// it to a reporter.
 
-// telemetryReporter receives a fully-populated Usage. Report must not block the
-// calling goroutine for long (the TFCA-B5 transport hands off to a worker pool).
+// telemetryReporter receives a populated Usage; Report should not block the caller.
 type telemetryReporter interface {
 	Report(telemetry.Usage)
 }
 
-// noopTelemetryReporter drops every Usage; it keeps this mechanism transparent
-// until the TFCA-B5 transport replaces it.
+// noopTelemetryReporter drops every Usage.
 type noopTelemetryReporter struct{}
 
 func (noopTelemetryReporter) Report(telemetry.Usage) {}
@@ -54,9 +49,8 @@ type telemetryWrapConfig struct {
 	// providerVersion is the released provider version.
 	providerVersion string
 
-	// terraformVersion is a func, not a value, because Core populates
-	// schema.Provider.TerraformVersion during ConfigureProvider — after New
-	// returns but before any CRUD/import call. A nil func yields "".
+	// terraformVersion returns Terraform Core's version. It is a func because Core
+	// sets it during ConfigureProvider, after New returns; a nil func yields "".
 	terraformVersion func() string
 }
 
@@ -76,11 +70,8 @@ func (c telemetryWrapConfig) tfVersion() string {
 }
 
 // wrappedResources makes wrapping idempotent: a resource wrapped once is skipped
-// on any later pass, so composing the wrap twice never double-emits. Keys are
-// weak.Pointers so an entry does not keep the resource — or the provider graph
-// its closures capture — alive; each resource registers a cleanup that drops its
-// dead stub once collected, so repeated New() calls (e.g. confluent_tf_importer,
-// one per apply) don't leak.
+// on later passes. Keys are weak.Pointers with a cleanup, so an entry never keeps
+// the resource (or the provider graph its closures capture) alive.
 var wrappedResources sync.Map // map[weak.Pointer[schema.Resource]]struct{}
 
 // wrapResourcesMapForTelemetry wraps every resource's CRUD and import entry
@@ -110,10 +101,9 @@ func resourceWrapped(r *schema.Resource) bool {
 	return ok
 }
 
-// wrapResourceForTelemetry wraps each entry point only when it is already
-// non-nil. This matters: 8 managed resources have a nil UpdateContext, and the
-// SDK treats a set update func as "updates allowed" — turning nil into a wrapper
-// closure would nil-panic and falsely advertise those resources as updatable.
+// wrapResourceForTelemetry wraps each entry point only when it is already non-nil.
+// A nil UpdateContext means the resource has no update; wrapping it would nil-panic
+// and make the SDK treat the resource as updatable.
 func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telemetryWrapConfig) {
 	if r.CreateContext != nil {
 		r.CreateContext = wrapContextFunc(resourceType, r.Schema, telemetry.OperationCreate, r.CreateContext, cfg)
@@ -132,11 +122,9 @@ func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telem
 	}
 }
 
-// wrapContextFunc wraps a Create/Read/Update/DeleteContext function. Sequence and
-// timer are taken at entry (so order/duration are correct even if the report is
-// dropped), and the Usage is built and reported synchronously after inner returns
-// — the SDK reads ResourceData right after CRUD returns, so nothing may defer to
-// a goroutine that touches d.
+// wrapContextFunc wraps a Create/Read/Update/DeleteContext function: it times the
+// inner call and reports a Usage after it returns. Reporting is synchronous because
+// the SDK reads ResourceData as soon as the CRUD call returns.
 func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Schema, op telemetry.Operation, inner func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
 	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		seq := telemetry.NextSequence()
@@ -189,10 +177,9 @@ func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schem
 	}
 }
 
-// changedAttributeNames returns the top-level schema attribute names that
-// changed, as a non-nil slice (so it serializes as [] not null). It appends only
-// static schema keys, so no attribute value or user-controlled map key can leak.
-// Only Create and Update carry a diff; other operations report the empty slice.
+// changedAttributeNames returns the top-level schema attribute names that changed,
+// as a non-nil slice. It appends only static schema keys, so no attribute value or
+// map key can leak. Only Create and Update carry a diff; others return empty.
 func changedAttributeNames(d *schema.ResourceData, resourceSchema map[string]*schema.Schema, op telemetry.Operation) []string {
 	if d == nil || (op != telemetry.OperationCreate && op != telemetry.OperationUpdate) {
 		return []string{}

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"weak"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -99,7 +100,14 @@ func (c telemetryWrapConfig) tfVersion() string {
 // xResource() constructor returns a fresh *schema.Resource), so resources from
 // different providers never collide here and one provider's wrapping never
 // suppresses another's.
-var wrappedResources sync.Map // map[*schema.Resource]struct{}
+//
+// Keys are weak.Pointers so an entry here does not keep the resource — nor the
+// whole provider graph its wrapper closures transitively capture (via the
+// terraformVersion closure) — alive for the life of the process. Each resource
+// registers a cleanup that removes its now-dead stub once it is collected, so the
+// map does not grow without bound when New() is called repeatedly (e.g.
+// confluent_tf_importer builds a fresh provider on every apply).
+var wrappedResources sync.Map // map[weak.Pointer[schema.Resource]]struct{}
 
 // wrapResourcesMapForTelemetry wraps the CRUD and import entry points of every
 // resource in the map. It must run after ResourcesMap is fully constructed and
@@ -113,9 +121,14 @@ func wrapResourcesMapForTelemetry(resources map[string]*schema.Resource, cfg tel
 		if r == nil {
 			continue
 		}
-		if _, alreadyWrapped := wrappedResources.LoadOrStore(r, struct{}{}); alreadyWrapped {
+		key := weak.Make(r)
+		if _, alreadyWrapped := wrappedResources.LoadOrStore(key, struct{}{}); alreadyWrapped {
 			continue
 		}
+		// Reap the weak stub once the resource is collected, so repeated New()
+		// calls don't accumulate dead entries. The cleanup captures only the weak
+		// key (never r), so it cannot keep r alive.
+		runtime.AddCleanup(r, wrappedResources.Delete, any(key))
 		wrapResourceForTelemetry(resourceType, r, cfg)
 	}
 }
@@ -123,7 +136,7 @@ func wrapResourcesMapForTelemetry(resources map[string]*schema.Resource, cfg tel
 // resourceWrapped reports whether r has been through wrapResourcesMapForTelemetry.
 // It exists for tests that assert coverage of the wrap pass.
 func resourceWrapped(r *schema.Resource) bool {
-	_, ok := wrappedResources.Load(r)
+	_, ok := wrappedResources.Load(weak.Make(r))
 	return ok
 }
 

--- a/internal/provider/telemetry_wrapper_test.go
+++ b/internal/provider/telemetry_wrapper_test.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -152,7 +154,7 @@ func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
 }
 
 // Guards that every managed resource uses only *Context entry points; a deprecated
-// or WithoutTimeout variant would escape telemetry and fails the build here.
+// or WithoutTimeout variant would escape telemetry, so this test fails here.
 func TestWrapResourcesMap_OnlyContextEntryPointsAreUsed(t *testing.T) {
 	p := New(testVersion, "")()
 	for name, r := range p.ResourcesMap {
@@ -179,7 +181,9 @@ func TestWrapper_TransparentOnHappyPath(t *testing.T) {
 
 	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
 
+	before := time.Now()
 	got := r.CreateContext(context.Background(), nil, nil)
+	after := time.Now()
 	if len(got) != 1 || got[0].Summary != "hello" {
 		t.Fatalf("wrapper did not pass inner diagnostics through unchanged: %+v", got)
 	}
@@ -204,6 +208,18 @@ func TestWrapper_TransparentOnHappyPath(t *testing.T) {
 	}
 	if u.ChangedAttributes == nil {
 		t.Errorf("ChangedAttributes must be non-nil so it serializes as [] not null")
+	}
+	if u.OS != runtime.GOOS {
+		t.Errorf("OS = %q, want %q", u.OS, runtime.GOOS)
+	}
+	if u.Arch != runtime.GOARCH {
+		t.Errorf("Arch = %q, want %q", u.Arch, runtime.GOARCH)
+	}
+	if u.StartedAt.Before(before) || u.StartedAt.After(after) {
+		t.Errorf("StartedAt %v not within the call window [%v, %v]", u.StartedAt, before, after)
+	}
+	if u.DurationMs < 0 {
+		t.Errorf("DurationMs = %d, want >= 0", u.DurationMs)
 	}
 }
 

--- a/internal/provider/telemetry_wrapper_test.go
+++ b/internal/provider/telemetry_wrapper_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Confluent Inc. All Rights Reserved.
+// Copyright 2026 Confluent Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/provider/telemetry_wrapper_test.go
+++ b/internal/provider/telemetry_wrapper_test.go
@@ -28,8 +28,7 @@ import (
 	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
 )
 
-// recordingReporter is a concurrency-safe telemetryReporter that keeps every
-// Usage it is handed, for assertions.
+// recordingReporter is a concurrency-safe telemetryReporter that records every Usage.
 type recordingReporter struct {
 	mu    sync.Mutex
 	usage []telemetry.Usage
@@ -55,9 +54,7 @@ func (r *recordingReporter) count() int {
 	return len(r.usage)
 }
 
-// newTestResource builds a minimal managed resource whose CRUD and import entry
-// points are transparent no-ops, so the only observable effect of invoking them
-// is whatever the telemetry wrapper adds.
+// newTestResource builds a minimal managed resource with no-op CRUD/import entry points.
 func newTestResource() *schema.Resource {
 	okDiag := func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics { return nil }
 	return &schema.Resource{
@@ -84,16 +81,11 @@ func testWrapConfig(reporter telemetryReporter) telemetryWrapConfig {
 	}
 }
 
-// TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources asserts
-// the central pass wraps every managed resource (v1 scope) and leaves every data
-// source untouched, with no per-resource file edits.
+// Asserts the central pass wraps every managed resource and leaves data sources untouched.
 func TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources(t *testing.T) {
 	p := New(testVersion, "")()
 
-	// v1 scope is the 64 managed resources; the 63 data sources are excluded.
-	// This count is pinned deliberately: adding a managed resource should be a
-	// conscious decision to extend telemetry coverage, so bump it here when the
-	// ResourcesMap grows.
+	// v1 scope is the 64 managed resources; bump this pin when ResourcesMap changes.
 	const wantManagedResources = 64
 	if got := len(p.ResourcesMap); got != wantManagedResources {
 		t.Errorf("ResourcesMap has %d resources, want %d (update this pin if resources were intentionally added/removed)", got, wantManagedResources)
@@ -111,13 +103,9 @@ func TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources(t *tes
 	}
 }
 
-// TestWrapResourcesMap_PreservesNilUpdateContext asserts a resource with no
-// UpdateContext still has a nil UpdateContext after wrapping — never a non-nil
-// no-op closure that would nil-panic and change the SDK's update-legality check.
+// Asserts a nil UpdateContext stays nil after wrapping (never a non-nil no-op closure).
 func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
-	// The real provider's known nil-update resources, at the time of writing.
-	// Used only as a readable cross-check; the load-bearing assertion below is
-	// the count, which needs no name maintenance.
+	// The real provider's known nil-update resources; the load-bearing check is the count.
 	knownNilUpdate := map[string]bool{
 		"confluent_byok_key":                        true,
 		"confluent_connect_artifact":                true,
@@ -141,8 +129,7 @@ func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
 		}
 	}
 
-	// If wrapping had turned any nil UpdateContext into a non-nil no-op closure,
-	// this count would drop below the known set.
+	// A nil→non-nil substitution would drop this count below the known set.
 	if len(gotNilUpdate) != len(knownNilUpdate) {
 		t.Errorf("found %d resources with nil UpdateContext (%v), want %d", len(gotNilUpdate), gotNilUpdate, len(knownNilUpdate))
 	}
@@ -152,8 +139,7 @@ func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
 		}
 	}
 
-	// Also assert at the mechanism level, independent of the resource catalog: a
-	// synthetic resource with a nil UpdateContext stays nil.
+	// Mechanism-level check, independent of the resource catalog.
 	r := newTestResource()
 	r.UpdateContext = nil
 	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"x": r}, testWrapConfig(&recordingReporter{}))
@@ -165,11 +151,8 @@ func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
 	}
 }
 
-// TestWrapResourcesMap_OnlyContextEntryPointsAreUsed guards the assumption the
-// wrapper relies on: every managed resource uses only the *Context entry points.
-// If a future resource uses a deprecated (Create) or WithoutTimeout variant, it
-// would silently escape telemetry; this fails the build so the wrapper is
-// extended deliberately.
+// Guards that every managed resource uses only *Context entry points; a deprecated
+// or WithoutTimeout variant would escape telemetry and fails the build here.
 func TestWrapResourcesMap_OnlyContextEntryPointsAreUsed(t *testing.T) {
 	p := New(testVersion, "")()
 	for name, r := range p.ResourcesMap {
@@ -179,17 +162,14 @@ func TestWrapResourcesMap_OnlyContextEntryPointsAreUsed(t *testing.T) {
 		if r.CreateWithoutTimeout != nil || r.ReadWithoutTimeout != nil || r.UpdateWithoutTimeout != nil || r.DeleteWithoutTimeout != nil {
 			t.Errorf("resource %q uses a *WithoutTimeout CRUD func; extend the telemetry wrapper", name)
 		}
-		// The import wrapper only wraps Importer.StateContext; a resource using
-		// the deprecated Importer.State would silently escape import telemetry.
 		if r.Importer != nil && r.Importer.State != nil {
 			t.Errorf("resource %q uses the deprecated Importer.State; extend the telemetry wrapper to wrap it", name)
 		}
 	}
 }
 
-// TestWrapper_TransparentOnHappyPath asserts wrapped CRUD is behaviorally
-// transparent: the inner return value passes through unchanged, and exactly one
-// event is emitted per call carrying the right operation, run ID, and metadata.
+// Asserts wrapped CRUD is transparent: the inner return passes through and exactly
+// one event is emitted with the right operation, run ID, and metadata.
 func TestWrapper_TransparentOnHappyPath(t *testing.T) {
 	rec := &recordingReporter{}
 	r := newTestResource()
@@ -246,8 +226,7 @@ func TestWrapper_ErrorFlag(t *testing.T) {
 	}
 }
 
-// TestWrapper_ImportWrappedSeparately asserts the import path is wrapped with the
-// correct signature and reports an IMPORT event while passing results through.
+// Asserts import is wrapped with the correct signature, emits IMPORT, and passes results through.
 func TestWrapper_ImportWrappedSeparately(t *testing.T) {
 	rec := &recordingReporter{}
 	r := newTestResource()
@@ -272,9 +251,7 @@ func TestWrapper_ImportWrappedSeparately(t *testing.T) {
 	}
 }
 
-// TestWrapper_DoubleWrapEmitsOneEventPerCall asserts running the wrap pass twice
-// over the same map does not compose wrappers: each CRUD call still emits exactly
-// one event.
+// Asserts wrapping the same map twice does not compose wrappers: one event per call.
 func TestWrapper_DoubleWrapEmitsOneEventPerCall(t *testing.T) {
 	rec := &recordingReporter{}
 	r := newTestResource()
@@ -289,10 +266,8 @@ func TestWrapper_DoubleWrapEmitsOneEventPerCall(t *testing.T) {
 	}
 }
 
-// TestWrapper_ConcurrentRunIDsAndSequences drives ~20 independent resources'
-// entry points concurrently — modeling Terraform's parallel graph walk — and
-// asserts the run ID is stable and every sequence number is unique. Run with
-// -race to catch data races in the process-scoped run ID and sequence counter.
+// Drives ~20 resources' entry points concurrently (run with -race): the run ID is
+// stable and every sequence number is unique.
 func TestWrapper_ConcurrentRunIDsAndSequences(t *testing.T) {
 	rec := &recordingReporter{}
 	const numResources = 20
@@ -303,7 +278,7 @@ func TestWrapper_ConcurrentRunIDsAndSequences(t *testing.T) {
 	}
 	wrapResourcesMapForTelemetry(m, testWrapConfig(rec))
 
-	// Collect every entry point to invoke; ~20 resources x 4 CRUD + 1 import.
+	// ~20 resources x 4 CRUD + 1 import.
 	type call func()
 	var calls []call
 	for _, r := range m {
@@ -351,11 +326,8 @@ func TestWrapper_ConcurrentRunIDsAndSequences(t *testing.T) {
 	}
 }
 
-// TestCollectChangedNames_NamesOnlyNeverMapKeys asserts the changed-attribute
-// computation can only ever emit statically declared attribute names — never a
-// user-controlled map key or value — even when the change detector claims a
-// nested map key changed. This is the provider-side guarantee that pairs with
-// the TFCA-B2 build-time allowlist.
+// Asserts changed-attribute computation emits only declared schema names — never a
+// user-controlled map key or value — even when the detector reports everything.
 func TestCollectChangedNames_NamesOnlyNeverMapKeys(t *testing.T) {
 	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus scalars.
 	resourceSchema := map[string]*schema.Schema{
@@ -365,9 +337,7 @@ func TestCollectChangedNames_NamesOnlyNeverMapKeys(t *testing.T) {
 		"never_touched": {Type: schema.TypeString, Optional: true},
 	}
 
-	// A detector that reports EVERYTHING as changed, including a runtime map key
-	// that must never leak. The map key is never queried (the function only
-	// iterates schema keys), so it cannot appear in the output.
+	// A detector that reports everything changed; a runtime map key must never leak.
 	hasChange := func(name string) bool { return true }
 
 	got := collectChangedNames(resourceSchema, hasChange)
@@ -380,14 +350,13 @@ func TestCollectChangedNames_NamesOnlyNeverMapKeys(t *testing.T) {
 		if !want[name] {
 			t.Errorf("emitted %q which is not a declared schema attribute name", name)
 		}
-		// Defense-in-depth: a leaked map key would contain a '.' address like
-		// "config.cleanup.policy". None of the declared names do.
+		// A leaked map key would contain a '.' address; none of the declared names do.
 		if name == "config.cleanup.policy" || name == "cleanup.policy" {
 			t.Errorf("emitted a runtime map key %q — map contents must never leak", name)
 		}
 	}
 
-	// And when nothing changed, the result is an empty, non-nil slice.
+	// When nothing changed, the result is an empty, non-nil slice.
 	none := collectChangedNames(resourceSchema, func(string) bool { return false })
 	if none == nil {
 		t.Errorf("collectChangedNames must return non-nil even when nothing changed")
@@ -397,12 +366,8 @@ func TestCollectChangedNames_NamesOnlyNeverMapKeys(t *testing.T) {
 	}
 }
 
-// TestWrapper_ChangedAttributesFromRealResourceData exercises the full
-// changed-attributes path end to end with a genuine diff-bearing
-// *schema.ResourceData rather than a stubbed detector, proving that a
-// user-controlled map attribute contributes only its declared name to a Usage —
-// never its runtime keys. This is the empirical counterpart to the structural
-// TestCollectChangedNames_NamesOnlyNeverMapKeys.
+// Exercises the changed-attributes path end to end with a real diff-bearing
+// ResourceData: a map attribute contributes only its declared name, never its keys.
 func TestWrapper_ChangedAttributesFromRealResourceData(t *testing.T) {
 	rec := &recordingReporter{}
 	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus a scalar.
@@ -415,8 +380,7 @@ func TestWrapper_ChangedAttributesFromRealResourceData(t *testing.T) {
 	}
 	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_kafka_topic": r}, testWrapConfig(rec))
 
-	// A create-style ResourceData whose config map carries a user key
-	// ("cleanup.policy") that must never leak into telemetry.
+	// config carries a user key ("cleanup.policy") that must never leak into telemetry.
 	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
 		"config":     map[string]interface{}{"cleanup.policy": "compact"},
 		"topic_name": "orders",
@@ -436,9 +400,7 @@ func TestWrapper_ChangedAttributesFromRealResourceData(t *testing.T) {
 	}
 }
 
-// TestChangedAttributeNames_NonCreateUpdateAreEmpty asserts read/delete/import
-// report an empty (non-nil) changed-attributes slice and never dereference a nil
-// ResourceData.
+// Asserts read/delete/import report an empty non-nil slice and never deref a nil ResourceData.
 func TestChangedAttributeNames_NonCreateUpdateAreEmpty(t *testing.T) {
 	resourceSchema := map[string]*schema.Schema{"name": {Type: schema.TypeString}}
 	for _, op := range []telemetry.Operation{telemetry.OperationRead, telemetry.OperationDelete, telemetry.OperationImport} {

--- a/internal/provider/telemetry_wrapper_test.go
+++ b/internal/provider/telemetry_wrapper_test.go
@@ -87,7 +87,7 @@ func testWrapConfig(reporter telemetryReporter) telemetryWrapConfig {
 func TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources(t *testing.T) {
 	p := New(testVersion, "")()
 
-	// v1 scope is the 64 managed resources; bump this pin when ResourcesMap changes.
+	// There are 64 managed resources; bump this pin when ResourcesMap changes.
 	const wantManagedResources = 64
 	if got := len(p.ResourcesMap); got != wantManagedResources {
 		t.Errorf("ResourcesMap has %d resources, want %d (update this pin if resources were intentionally added/removed)", got, wantManagedResources)

--- a/internal/provider/telemetry_wrapper_test.go
+++ b/internal/provider/telemetry_wrapper_test.go
@@ -1,0 +1,457 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
+)
+
+// recordingReporter is a concurrency-safe telemetryReporter that keeps every
+// Usage it is handed, for assertions.
+type recordingReporter struct {
+	mu    sync.Mutex
+	usage []telemetry.Usage
+}
+
+func (r *recordingReporter) Report(u telemetry.Usage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.usage = append(r.usage, u)
+}
+
+func (r *recordingReporter) snapshot() []telemetry.Usage {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]telemetry.Usage, len(r.usage))
+	copy(out, r.usage)
+	return out
+}
+
+func (r *recordingReporter) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.usage)
+}
+
+// newTestResource builds a minimal managed resource whose CRUD and import entry
+// points are transparent no-ops, so the only observable effect of invoking them
+// is whatever the telemetry wrapper adds.
+func newTestResource() *schema.Resource {
+	okDiag := func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics { return nil }
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {Type: schema.TypeString, Optional: true},
+		},
+		CreateContext: okDiag,
+		ReadContext:   okDiag,
+		UpdateContext: okDiag,
+		DeleteContext: okDiag,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+	}
+}
+
+func testWrapConfig(reporter telemetryReporter) telemetryWrapConfig {
+	return telemetryWrapConfig{
+		reporter:         reporter,
+		providerVersion:  "9.9.9-test",
+		terraformVersion: func() string { return "1.7.0-test" },
+	}
+}
+
+// TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources asserts
+// the central pass wraps every managed resource (v1 scope) and leaves every data
+// source untouched, with no per-resource file edits.
+func TestWrapResourcesMap_CoversAllManagedResourcesAndExcludesDataSources(t *testing.T) {
+	p := New(testVersion, "")()
+
+	// v1 scope is the 64 managed resources; the 63 data sources are excluded.
+	// This count is pinned deliberately: adding a managed resource should be a
+	// conscious decision to extend telemetry coverage, so bump it here when the
+	// ResourcesMap grows.
+	const wantManagedResources = 64
+	if got := len(p.ResourcesMap); got != wantManagedResources {
+		t.Errorf("ResourcesMap has %d resources, want %d (update this pin if resources were intentionally added/removed)", got, wantManagedResources)
+	}
+
+	for name, r := range p.ResourcesMap {
+		if !resourceWrapped(r) {
+			t.Errorf("managed resource %q was not wrapped for telemetry", name)
+		}
+	}
+	for name, ds := range p.DataSourcesMap {
+		if resourceWrapped(ds) {
+			t.Errorf("data source %q was wrapped for telemetry but data sources are excluded in v1", name)
+		}
+	}
+}
+
+// TestWrapResourcesMap_PreservesNilUpdateContext asserts a resource with no
+// UpdateContext still has a nil UpdateContext after wrapping — never a non-nil
+// no-op closure that would nil-panic and change the SDK's update-legality check.
+func TestWrapResourcesMap_PreservesNilUpdateContext(t *testing.T) {
+	// The real provider's known nil-update resources, at the time of writing.
+	// Used only as a readable cross-check; the load-bearing assertion below is
+	// the count, which needs no name maintenance.
+	knownNilUpdate := map[string]bool{
+		"confluent_byok_key":                        true,
+		"confluent_connect_artifact":                true,
+		"confluent_custom_connector_plugin_version": true,
+		"confluent_flink_artifact":                  true,
+		"confluent_ksql_cluster":                    true,
+		"confluent_provider_integration":            true,
+		"confluent_provider_integration_setup":      true,
+		"confluent_tf_importer":                     true,
+	}
+
+	p := New(testVersion, "")()
+	var gotNilUpdate []string
+	for name, r := range p.ResourcesMap {
+		if r.UpdateContext == nil {
+			gotNilUpdate = append(gotNilUpdate, name)
+			// A nil-update resource must still have its other entry points intact.
+			if r.CreateContext == nil || r.ReadContext == nil || r.DeleteContext == nil {
+				t.Errorf("resource %q: a non-update entry point became nil after wrapping", name)
+			}
+		}
+	}
+
+	// If wrapping had turned any nil UpdateContext into a non-nil no-op closure,
+	// this count would drop below the known set.
+	if len(gotNilUpdate) != len(knownNilUpdate) {
+		t.Errorf("found %d resources with nil UpdateContext (%v), want %d", len(gotNilUpdate), gotNilUpdate, len(knownNilUpdate))
+	}
+	for _, name := range gotNilUpdate {
+		if !knownNilUpdate[name] {
+			t.Errorf("resource %q has nil UpdateContext but is not in the known set — update the cross-check", name)
+		}
+	}
+
+	// Also assert at the mechanism level, independent of the resource catalog: a
+	// synthetic resource with a nil UpdateContext stays nil.
+	r := newTestResource()
+	r.UpdateContext = nil
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"x": r}, testWrapConfig(&recordingReporter{}))
+	if r.UpdateContext != nil {
+		t.Errorf("synthetic resource: nil UpdateContext became non-nil after wrapping")
+	}
+	if r.CreateContext == nil {
+		t.Errorf("synthetic resource: CreateContext became nil after wrapping")
+	}
+}
+
+// TestWrapResourcesMap_OnlyContextEntryPointsAreUsed guards the assumption the
+// wrapper relies on: every managed resource uses only the *Context entry points.
+// If a future resource uses a deprecated (Create) or WithoutTimeout variant, it
+// would silently escape telemetry; this fails the build so the wrapper is
+// extended deliberately.
+func TestWrapResourcesMap_OnlyContextEntryPointsAreUsed(t *testing.T) {
+	p := New(testVersion, "")()
+	for name, r := range p.ResourcesMap {
+		if r.Create != nil || r.Read != nil || r.Update != nil || r.Delete != nil {
+			t.Errorf("resource %q uses a deprecated non-context CRUD func; extend the telemetry wrapper", name)
+		}
+		if r.CreateWithoutTimeout != nil || r.ReadWithoutTimeout != nil || r.UpdateWithoutTimeout != nil || r.DeleteWithoutTimeout != nil {
+			t.Errorf("resource %q uses a *WithoutTimeout CRUD func; extend the telemetry wrapper", name)
+		}
+		// The import wrapper only wraps Importer.StateContext; a resource using
+		// the deprecated Importer.State would silently escape import telemetry.
+		if r.Importer != nil && r.Importer.State != nil {
+			t.Errorf("resource %q uses the deprecated Importer.State; extend the telemetry wrapper to wrap it", name)
+		}
+	}
+}
+
+// TestWrapper_TransparentOnHappyPath asserts wrapped CRUD is behaviorally
+// transparent: the inner return value passes through unchanged, and exactly one
+// event is emitted per call carrying the right operation, run ID, and metadata.
+func TestWrapper_TransparentOnHappyPath(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+
+	sentinel := diag.Diagnostics{{Severity: diag.Warning, Summary: "hello"}}
+	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics { return sentinel }
+
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+	got := r.CreateContext(context.Background(), nil, nil)
+	if len(got) != 1 || got[0].Summary != "hello" {
+		t.Fatalf("wrapper did not pass inner diagnostics through unchanged: %+v", got)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("expected exactly 1 telemetry event, got %d", rec.count())
+	}
+	u := rec.snapshot()[0]
+	if u.ResourceType != "confluent_thing" {
+		t.Errorf("ResourceType = %q, want confluent_thing", u.ResourceType)
+	}
+	if u.Operation != telemetry.OperationCreate {
+		t.Errorf("Operation = %q, want CREATE", u.Operation)
+	}
+	if u.RunID != telemetry.RunID() {
+		t.Errorf("RunID = %q, want process run ID %q", u.RunID, telemetry.RunID())
+	}
+	if u.ProviderVersion != "9.9.9-test" || u.TerraformVersion != "1.7.0-test" {
+		t.Errorf("version metadata not populated: provider=%q terraform=%q", u.ProviderVersion, u.TerraformVersion)
+	}
+	if u.Error {
+		t.Errorf("Error should be false for a warning-only result")
+	}
+	if u.ChangedAttributes == nil {
+		t.Errorf("ChangedAttributes must be non-nil so it serializes as [] not null")
+	}
+}
+
+// TestWrapper_ErrorFlag asserts the Error flag reflects an error-severity result.
+func TestWrapper_ErrorFlag(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	r.DeleteContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+		return diag.Errorf("boom")
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+	_ = r.DeleteContext(context.Background(), nil, nil)
+	u := rec.snapshot()[0]
+	if !u.Error {
+		t.Errorf("Error flag should be true when the operation returns error diagnostics")
+	}
+	if u.Operation != telemetry.OperationDelete {
+		t.Errorf("Operation = %q, want DELETE", u.Operation)
+	}
+}
+
+// TestWrapper_ImportWrappedSeparately asserts the import path is wrapped with the
+// correct signature and reports an IMPORT event while passing results through.
+func TestWrapper_ImportWrappedSeparately(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+	out, err := r.Importer.StateContext(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("import returned unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("import passthrough returned %d results, want 1", len(out))
+	}
+	if rec.count() != 1 {
+		t.Fatalf("import emitted %d events, want exactly 1", rec.count())
+	}
+	u := rec.snapshot()[0]
+	if u.Operation != telemetry.OperationImport {
+		t.Errorf("Operation = %q, want IMPORT", u.Operation)
+	}
+	if u.ChangedAttributes == nil || len(u.ChangedAttributes) != 0 {
+		t.Errorf("import ChangedAttributes should be empty non-nil, got %#v", u.ChangedAttributes)
+	}
+}
+
+// TestWrapper_DoubleWrapEmitsOneEventPerCall asserts running the wrap pass twice
+// over the same map does not compose wrappers: each CRUD call still emits exactly
+// one event.
+func TestWrapper_DoubleWrapEmitsOneEventPerCall(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	m := map[string]*schema.Resource{"confluent_thing": r}
+
+	wrapResourcesMapForTelemetry(m, testWrapConfig(rec))
+	wrapResourcesMapForTelemetry(m, testWrapConfig(rec)) // second pass must be a no-op
+
+	_ = r.CreateContext(context.Background(), nil, nil)
+	if rec.count() != 1 {
+		t.Fatalf("double-wrapped Create emitted %d events, want exactly 1", rec.count())
+	}
+}
+
+// TestWrapper_ConcurrentRunIDsAndSequences drives ~20 independent resources'
+// entry points concurrently — modeling Terraform's parallel graph walk — and
+// asserts the run ID is stable and every sequence number is unique. Run with
+// -race to catch data races in the process-scoped run ID and sequence counter.
+func TestWrapper_ConcurrentRunIDsAndSequences(t *testing.T) {
+	rec := &recordingReporter{}
+	const numResources = 20
+
+	m := make(map[string]*schema.Resource, numResources)
+	for i := 0; i < numResources; i++ {
+		m[fmt.Sprintf("confluent_thing_%d", i)] = newTestResource()
+	}
+	wrapResourcesMapForTelemetry(m, testWrapConfig(rec))
+
+	// Collect every entry point to invoke; ~20 resources x 4 CRUD + 1 import.
+	type call func()
+	var calls []call
+	for _, r := range m {
+		r := r
+		calls = append(calls,
+			func() { r.CreateContext(context.Background(), nil, nil) },
+			func() { r.ReadContext(context.Background(), nil, nil) },
+			func() { r.UpdateContext(context.Background(), nil, nil) },
+			func() { r.DeleteContext(context.Background(), nil, nil) },
+			func() { r.Importer.StateContext(context.Background(), nil, nil) },
+		)
+	}
+
+	var wg sync.WaitGroup
+	for _, c := range calls {
+		wg.Add(1)
+		go func(c call) {
+			defer wg.Done()
+			c()
+		}(c)
+	}
+	wg.Wait()
+
+	events := rec.snapshot()
+	if len(events) != len(calls) {
+		t.Fatalf("emitted %d events, want %d (one per invocation)", len(events), len(calls))
+	}
+
+	runID := telemetry.RunID()
+	seen := make(map[int64]bool, len(events))
+	for _, u := range events {
+		if u.RunID != runID {
+			t.Errorf("event has RunID %q, want stable process run ID %q", u.RunID, runID)
+		}
+		if u.Sequence <= 0 {
+			t.Errorf("sequence %d is not positive", u.Sequence)
+		}
+		if seen[u.Sequence] {
+			t.Errorf("duplicate sequence number %d — counter is not race-free", u.Sequence)
+		}
+		seen[u.Sequence] = true
+	}
+	if len(seen) != len(events) {
+		t.Errorf("got %d distinct sequence numbers across %d events", len(seen), len(events))
+	}
+}
+
+// TestCollectChangedNames_NamesOnlyNeverMapKeys asserts the changed-attribute
+// computation can only ever emit statically declared attribute names — never a
+// user-controlled map key or value — even when the change detector claims a
+// nested map key changed. This is the provider-side guarantee that pairs with
+// the TFCA-B2 build-time allowlist.
+func TestCollectChangedNames_NamesOnlyNeverMapKeys(t *testing.T) {
+	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus scalars.
+	resourceSchema := map[string]*schema.Schema{
+		"config":        {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+		"topic_name":    {Type: schema.TypeString, Required: true},
+		"partitions":    {Type: schema.TypeInt, Optional: true},
+		"never_touched": {Type: schema.TypeString, Optional: true},
+	}
+
+	// A detector that reports EVERYTHING as changed, including a runtime map key
+	// that must never leak. The map key is never queried (the function only
+	// iterates schema keys), so it cannot appear in the output.
+	hasChange := func(name string) bool { return true }
+
+	got := collectChangedNames(resourceSchema, hasChange)
+
+	want := map[string]bool{"config": true, "topic_name": true, "partitions": true, "never_touched": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want the 4 declared names only", got)
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("emitted %q which is not a declared schema attribute name", name)
+		}
+		// Defense-in-depth: a leaked map key would contain a '.' address like
+		// "config.cleanup.policy". None of the declared names do.
+		if name == "config.cleanup.policy" || name == "cleanup.policy" {
+			t.Errorf("emitted a runtime map key %q — map contents must never leak", name)
+		}
+	}
+
+	// And when nothing changed, the result is an empty, non-nil slice.
+	none := collectChangedNames(resourceSchema, func(string) bool { return false })
+	if none == nil {
+		t.Errorf("collectChangedNames must return non-nil even when nothing changed")
+	}
+	if len(none) != 0 {
+		t.Errorf("expected no changed names, got %v", none)
+	}
+}
+
+// TestWrapper_ChangedAttributesFromRealResourceData exercises the full
+// changed-attributes path end to end with a genuine diff-bearing
+// *schema.ResourceData rather than a stubbed detector, proving that a
+// user-controlled map attribute contributes only its declared name to a Usage —
+// never its runtime keys. This is the empirical counterpart to the structural
+// TestCollectChangedNames_NamesOnlyNeverMapKeys.
+func TestWrapper_ChangedAttributesFromRealResourceData(t *testing.T) {
+	rec := &recordingReporter{}
+	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus a scalar.
+	r := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"config":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+			"topic_name": {Type: schema.TypeString, Optional: true},
+		},
+		CreateContext: func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics { return nil },
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_kafka_topic": r}, testWrapConfig(rec))
+
+	// A create-style ResourceData whose config map carries a user key
+	// ("cleanup.policy") that must never leak into telemetry.
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"config":     map[string]interface{}{"cleanup.policy": "compact"},
+		"topic_name": "orders",
+	})
+
+	_ = r.CreateContext(context.Background(), d, nil)
+
+	u := rec.snapshot()[0]
+	want := []string{"config", "topic_name"}
+	if !reflect.DeepEqual(u.ChangedAttributes, want) {
+		t.Fatalf("ChangedAttributes = %#v, want %v (declared top-level names only)", u.ChangedAttributes, want)
+	}
+	for _, name := range u.ChangedAttributes {
+		if strings.Contains(name, ".") {
+			t.Errorf("ChangedAttributes leaked a nested/map key: %q", name)
+		}
+	}
+}
+
+// TestChangedAttributeNames_NonCreateUpdateAreEmpty asserts read/delete/import
+// report an empty (non-nil) changed-attributes slice and never dereference a nil
+// ResourceData.
+func TestChangedAttributeNames_NonCreateUpdateAreEmpty(t *testing.T) {
+	resourceSchema := map[string]*schema.Schema{"name": {Type: schema.TypeString}}
+	for _, op := range []telemetry.Operation{telemetry.OperationRead, telemetry.OperationDelete, telemetry.OperationImport} {
+		got := changedAttributeNames(nil, resourceSchema, op)
+		if got == nil {
+			t.Errorf("op %s: changedAttributeNames returned nil, want empty non-nil slice", op)
+		}
+		if len(got) != 0 {
+			t.Errorf("op %s: expected empty changed attributes, got %v", op, got)
+		}
+	}
+	// Even Create/Update with a nil ResourceData must not panic.
+	if got := changedAttributeNames(nil, resourceSchema, telemetry.OperationCreate); len(got) != 0 {
+		t.Errorf("nil ResourceData on create should yield empty changed attributes, got %v", got)
+	}
+}


### PR DESCRIPTION
Release Notes
---------
No user-facing changes. With the no-op reporter shipped here the wrapper is behaviorally transparent, so this change is additive only.

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent. (N/A — no-op reporter makes this behaviorally transparent; the wrapped provider is exercised via the acceptance + unit suites, so no custom-binary run against Cloud was needed)
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A)
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. 
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR. (N/A)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only


## What & why

Implements **TFCA-B3** ([APIE-1566](https://confluentinc.atlassian.net/browse/APIE-1566)) — the **central CRUD + import wrapping mechanism** for the TF Provider Client Analytics initiative (INIT-17732).

A single pass in `provider.New` (a 14-line call to `wrapResourcesMapForTelemetry`, run once after `ResourcesMap` is fully built and before the provider is served) replaces every managed resource's `Create/Read/Update/DeleteContext` and `Importer.StateContext` with telemetry-emitting wrappers. Each wrapper builds a `telemetry.Usage` (run ID, sequence, timing, OS/arch, provider & Terraform version, resource type, operation, changed-attribute names, error flag) and hands it to a reporter. No individual `resource_*.go` file is touched.

**Why here:** the provider needs one place to observe every resource operation, and neither the Plugin SDK nor Terraform Core exposes a usage-telemetry hook, so a wrapping layer is required. Centralizing it in `provider.New` keeps all 64 managed resources covered with zero per-resource edits.

## Scope 

- **`wrapResourcesMapForTelemetry` call in `provider.New`** — the single, once-per-process entry point; `terraformVersion` is read lazily (via a closure) because Core sets `schema.Provider.TerraformVersion` during `ConfigureProvider`, after `New` returns but before any CRUD/import call runs.
- **Independent, nil-safe wrapping.** Each entry point is wrapped only when already non-nil, so the 8 resources with a nil `UpdateContext` keep it nil — the SDK decides update-legality by whether an update func is set, so turning nil into a no-op closure would both nil-panic and change that check. Import is wrapped separately (`wrapImportFunc`) because its signature differs.
- **Names-only changed attributes.** Computed from the resource's own top-level schema keys (`collectChangedNames`), so a `TypeMap` attribute contributes only its name and never its user-controlled keys or any value; the slice is always non-nil (serializes `[]`, not `null`). Only Create/Update carry a diff; Read/Delete/Import emit the empty slice.
- **Double-wrap guard in code** — a package-level `sync.Map` keyed by `*schema.Resource`, so composing the pass twice is a no-op rather than double-emitting. Enforced in code (not a comment) so it survives a refactor; resource pointers are unique per constructed provider, so providers never collide.
- **Synchronous reporting** after the inner call returns and before the wrapper returns — the SDK reads `ResourceData` immediately after CRUD returns, so nothing defers to a goroutine that touches `d`. Sequence and timer are taken at wrapper entry so order/duration are correct even for dropped reports.
- **No-op reporter seam.** Reporting goes to `noopTelemetryReporter` today; the bounded-worker transport (TFCA-B5) swaps in the real reporter and opt-out (TFCA-B6) gates it.

**Deliberately out of scope** (later tickets): the payload/timing/run-ID model this populates (TFCA-B1, `internal/provider/telemetry/`, already merged), the bounded-worker network transport (TFCA-B5), the opt-out / non-default-endpoint disable wiring (TFCA-B6), panic recovery around the wrapped call (TFCA-B4), and the build-time attribute-allowlist generator (TFCA-B2). Until B5/B6 land, the wrapper does no network or filesystem I/O and cannot fail, slow, or otherwise change an operation.

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Internal, additive change only. With the no-op reporter the wrapper does no I/O and cannot fail, slow, or alter any operation: return values pass through verbatim, panics propagate unchanged, and timeouts / `CustomizeDiff` / state upgraders are untouched — so there is no customer-facing behavior change and no expected blast radius. The real reporter (TFCA-B5) and opt-out (TFCA-B6) land in later PRs; only then can telemetry reporting have any runtime footprint, and it is designed to stay off the hot path.

## Testing

Backward compatibility is verified against the wrapped provider: **`TestAccEnvironment` passes unmodified**, **`InternalValidate` passes**, and the **full provider unit suite passes** with no regressions.

`internal/provider/telemetry_wrapper_test.go` covers every acceptance criterion:
- All **64 managed resources** wrapped, the 63 data sources excluded (count pinned so adding a resource is a deliberate change).
- Behavioral transparency on the happy path; exactly **one event per call**; error flag set when the inner call errors.
- Import wrapped separately, emits `IMPORT`.
- nil `UpdateContext` preserved — count-based against the real 8-resource set, plus a synthetic case (nil stays nil, other entry points stay intact).
- Double-wrap ⇒ one event per call.
- ~20 independent resources driven concurrently (**100 goroutines** = 20 × 4 CRUD + import) under `-race`: stable run ID, unique sequence numbers.
- Changed-attributes names-only both **structurally** (a fake detector that claims a map key changed) **and end-to-end** through a real diff-bearing `ResourceData`; non-Create/Update and nil `ResourceData` yield the empty slice without panicking.
- A build-guard test that fails if a future resource uses a deprecated (`Create`) / `*WithoutTimeout` CRUD entry point or the deprecated `Importer.State`, so nothing silently escapes telemetry.

All pass under `-race -count=2 -shuffle=on`. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APIE-1566]: https://confluentinc.atlassian.net/browse/APIE-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
