### PR TITLE
[APIE-1570] Scope telemetry auth to the top-level Cloud identity (TFCA-B7)

### DIFF
--- a/internal/provider/telemetry_auth_scope_test.go
+++ b/internal/provider/telemetry_auth_scope_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
+)
+
+// TestTelemetryDisabledWithoutTopLevelIdentity covers TFCA-B7: a provider
+// configured with no top-level Cloud identity (e.g. only resource-scoped Kafka
+// credentials, which are never passed here) reports nothing — the runtime is
+// disabled with no transport, so zero telemetry calls are made. Reporting with
+// no identity is a no-op, never an error.
+func TestTelemetryDisabledWithoutTopLevelIdentity(t *testing.T) {
+	restorePublishedTelemetry(t)
+	t.Setenv(disableProviderAnalyticsEnvVar, "")
+
+	// Default endpoint (would otherwise enable), but no cloud key and no OAuth/STS
+	// token — mirroring a Kafka-only provider configuration.
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "", "", nil, nil)
+
+	rt := publishedTelemetry.Load()
+	if rt == nil {
+		t.Fatal("expected a published runtime")
+	}
+	if !rt.config.Disabled {
+		t.Errorf("runtime must be disabled when no top-level Cloud identity is configured")
+	}
+	if rt.reporter != nil {
+		t.Errorf("no transport should be built without a top-level identity, got %T", rt.reporter)
+	}
+
+	// With no transport, the late-binding reporter is a no-op: it must not panic
+	// and makes zero calls (there is nothing to send through).
+	publishedTelemetryReporter{}.Report(telemetry.Usage{ResourceType: "confluent_kafka_topic", Operation: telemetry.OperationCreate})
+}
+
+// TestTelemetryEnabledWithTopLevelIdentity is the positive control: a top-level
+// Cloud API key on the default endpoint yields an enabled runtime.
+func TestTelemetryEnabledWithTopLevelIdentity(t *testing.T) {
+	restorePublishedTelemetry(t)
+	t.Setenv(disableProviderAnalyticsEnvVar, "")
+
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "cloud-key", "cloud-secret", nil, nil)
+	rt := publishedTelemetry.Load()
+	if rt == nil || rt.config.Disabled || rt.reporter == nil {
+		t.Fatalf("expected an enabled runtime with a top-level identity, got %+v", rt)
+	}
+	if c, ok := rt.reporter.(interface{ Close() }); ok {
+		c.Close()
+	}
+}

--- a/internal/provider/telemetry_runtime.go
+++ b/internal/provider/telemetry_runtime.go
@@ -93,9 +93,12 @@ func telemetryOptOut(endpoint string) bool {
 }
 
 // telemetryAuthFunc builds the per-request auth decorator from the provider's
-// top-level Cloud identity, preferring a bearer token (OAuth/STS) over the Cloud
-// API key. It returns nil when no top-level identity is configured; TFCA-B7
-// turns that case into a disabled runtime.
+// top-level Cloud identity ONLY — the Cloud API key/secret or the OAuth/STS
+// bearer token — preferring a bearer token when present. It deliberately never
+// reads resource-scoped credentials (Kafka/Schema Registry/Flink/Tableflow API
+// keys): analytics is attributed to the org-level identity, not a data-plane
+// key. It returns nil when no top-level identity is configured, which
+// publishTelemetryRuntime treats as a disabled runtime (TFCA-B7).
 func telemetryAuthFunc(cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, sts *STSToken) func(context.Context) context.Context {
 	switch {
 	case sts != nil && sts.AccessToken != "":
@@ -113,10 +116,14 @@ func telemetryAuthFunc(cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, st
 // when enabled, and publishes the runtime for the CRUD goroutines. Called once,
 // at the end of provider configuration.
 func publishTelemetryRuntime(ctx context.Context, endpoint, userAgent, cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, sts *STSToken) {
-	disabled := telemetryOptOut(endpoint)
+	// Auth scoping (TFCA-B7): reporting uses only the top-level Cloud identity. If
+	// none is configured (for example a provider set up with only resource-scoped
+	// Kafka credentials), authFunc is nil and reporting is a no-op — not an error.
+	authFunc := telemetryAuthFunc(cloudAPIKey, cloudAPISecret, oauth, sts)
+	disabled := telemetryOptOut(endpoint) || authFunc == nil
 	rt := &telemetryRuntime{config: telemetry.NewConfig(disabled)}
 	if !disabled {
-		poster := telemetry.NewSDKPoster(endpoint, &http.Client{}, userAgent, telemetryAuthFunc(cloudAPIKey, cloudAPISecret, oauth, sts))
+		poster := telemetry.NewSDKPoster(endpoint, &http.Client{}, userAgent, authFunc)
 		rt.reporter = telemetry.NewTransport(poster, ctx)
 	}
 	publishedTelemetry.Store(rt)


### PR DESCRIPTION
## What
Implements **TFCA-B7** ([APIE-1570](https://confluentinc.atlassian.net/browse/APIE-1570)) — **auth scoping** to the top-level Cloud identity.

Telemetry authenticates with the provider's top-level Cloud API key/secret or an OAuth/STS bearer token **only** — `telemetryAuthFunc` structurally cannot read resource-scoped credentials (Kafka/Schema Registry/Flink/Tableflow keys). When no top-level identity is configured (e.g. a Kafka-only provider), reporting is disabled (no transport built) — a no-op, not an error, so such a config makes **zero** telemetry calls.

> ⚠️ **Stacked PR.** Base = `APIE-1569` (B6). Merge B5 → B4 → B6 first.

## Tests
No-identity → disabled runtime, nil reporter, zero calls (with a positive control proving the same inputs + a Cloud key enable it); auth precedence STS > OAuth > key > nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APIE-1570]: https://confluentinc.atlassian.net/browse/APIE-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ