### PR TITLE
[APIE-1571] Test-mode gating for telemetry (TFCA-B8)

### DIFF
--- a/.semaphore/live-tests.yml
+++ b/.semaphore/live-tests.yml
@@ -19,6 +19,10 @@ global_job_config:
       - 'export "PATH=${GOPATH}/bin:${PATH}"'
       - 'mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"'
       - checkout
+      # Belt-and-suspenders for TFCA-B8: the provider already gates client
+      # analytics off in test mode (TF_ACC/TF_ACC_PROD), and again disable it
+      # here so live runs never emit telemetry even if that gate regresses.
+      - 'export "CONFLUENT_DISABLE_PROVIDER_ANALYTICS=1"'
 
 execution_time_limit:
   hours: 24

--- a/.semaphore/smoke-tests.yml
+++ b/.semaphore/smoke-tests.yml
@@ -19,6 +19,10 @@ global_job_config:
       - 'export "PATH=${GOPATH}/bin:${PATH}"'
       - 'mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"'
       - checkout
+      # Belt-and-suspenders for TFCA-B8: the provider already gates client
+      # analytics off in test mode (TF_ACC/TF_ACC_PROD), and again disable it
+      # here so smoke runs never emit telemetry even if that gate regresses.
+      - 'export "CONFLUENT_DISABLE_PROVIDER_ANALYTICS=1"'
 
 execution_time_limit:
   minutes: 30

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -809,7 +809,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	// opt-out from the env var and endpoint, and, when enabled, stand up the
 	// bounded-worker transport that the resource wrappers report through. Written
 	// once here, before the concurrent CRUD/import goroutines run.
-	publishTelemetryRuntime(ctx, endpoint, userAgent, cloudApiKey, cloudApiSecret, externalOAuthToken, stsOAuthToken)
+	publishTelemetryRuntime(ctx, endpoint, userAgent, cloudApiKey, cloudApiSecret, externalOAuthToken, stsOAuthToken, acceptanceTestMode || liveProductionTestMode)
 
 	return &client, nil
 }

--- a/internal/provider/telemetry_auth_scope_test.go
+++ b/internal/provider/telemetry_auth_scope_test.go
@@ -31,7 +31,7 @@ func TestTelemetryDisabledWithoutTopLevelIdentity(t *testing.T) {
 
 	// Default endpoint (would otherwise enable), but no cloud key and no OAuth/STS
 	// token — mirroring a Kafka-only provider configuration.
-	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "", "", nil, nil)
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "", "", nil, nil, false)
 
 	rt := publishedTelemetry.Load()
 	if rt == nil {
@@ -55,7 +55,7 @@ func TestTelemetryEnabledWithTopLevelIdentity(t *testing.T) {
 	restorePublishedTelemetry(t)
 	t.Setenv(disableProviderAnalyticsEnvVar, "")
 
-	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "cloud-key", "cloud-secret", nil, nil)
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "cloud-key", "cloud-secret", nil, nil, false)
 	rt := publishedTelemetry.Load()
 	if rt == nil || rt.config.Disabled || rt.reporter == nil {
 		t.Fatalf("expected an enabled runtime with a top-level identity, got %+v", rt)

--- a/internal/provider/telemetry_integration_test.go
+++ b/internal/provider/telemetry_integration_test.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
+)
+
+// capturingPoster is a telemetry.Poster that forwards each delivered Usage to a
+// channel, so a test can observe what actually reached the transport's sender.
+type capturingPoster struct {
+	got chan telemetry.Usage
+}
+
+func (c capturingPoster) Post(_ context.Context, u telemetry.Usage) error {
+	c.got <- u
+	return nil
+}
+
+// TestTelemetryEnabledPathEmitsEndToEnd exercises the whole enabled chain that no
+// per-component test composes: a resource from New()'s real, wrapped ResourcesMap
+// -> the reporter captured at New() (publishedTelemetryReporter) -> an enabled
+// published runtime -> the real bounded-worker Transport -> a poster that
+// receives the Usage.
+//
+// It is the regression guard for the New() wiring line itself: if
+// `reporter: publishedTelemetryReporter{}` were ever reverted to a no-op, or the
+// published-runtime lookup broke, no other test would fail — this one would time
+// out. Invoking Read with a nil meta panics inside the real resource; the B4
+// recovery converts that to a reported crash event, which is exactly the Usage we
+// assert arrives (proving the chain end to end without any network).
+func TestTelemetryEnabledPathEmitsEndToEnd(t *testing.T) {
+	restorePublishedTelemetry(t)
+
+	poster := capturingPoster{got: make(chan telemetry.Usage, 4)}
+	transport := telemetry.NewTransport(poster, context.Background())
+	defer transport.Close()
+
+	// Publish an ENABLED runtime backed by the real Transport (no endpoint/network
+	// involved — the poster is a local capture).
+	publishedTelemetry.Store(&telemetryRuntime{
+		config:   telemetry.NewConfig(false),
+		reporter: transport,
+	})
+
+	// Drive a real, New()-wrapped resource. This asserts the New() wiring, not a
+	// synthetic fixture.
+	p := New(testVersion, "")()
+	r, ok := p.ResourcesMap["confluent_environment"]
+	if !ok || r.ReadContext == nil {
+		t.Fatal("confluent_environment with a ReadContext is required for this test")
+	}
+	_ = r.ReadContext(context.Background(), nil, nil)
+
+	select {
+	case u := <-poster.got:
+		if u.ResourceType != "confluent_environment" {
+			t.Errorf("ResourceType = %q, want confluent_environment", u.ResourceType)
+		}
+		if u.Operation != telemetry.OperationRead {
+			t.Errorf("Operation = %q, want READ", u.Operation)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no telemetry reached the poster: the New()->published reporter->transport->poster chain is broken")
+	}
+}

--- a/internal/provider/telemetry_runtime.go
+++ b/internal/provider/telemetry_runtime.go
@@ -115,12 +115,15 @@ func telemetryAuthFunc(cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, st
 // publishTelemetryRuntime computes the opt-out decision, builds the transport
 // when enabled, and publishes the runtime for the CRUD goroutines. Called once,
 // at the end of provider configuration.
-func publishTelemetryRuntime(ctx context.Context, endpoint, userAgent, cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, sts *STSToken) {
+func publishTelemetryRuntime(ctx context.Context, endpoint, userAgent, cloudAPIKey, cloudAPISecret string, oauth *OAuthToken, sts *STSToken, testMode bool) {
 	// Auth scoping (TFCA-B7): reporting uses only the top-level Cloud identity. If
 	// none is configured (for example a provider set up with only resource-scoped
 	// Kafka credentials), authFunc is nil and reporting is a no-op — not an error.
 	authFunc := telemetryAuthFunc(cloudAPIKey, cloudAPISecret, oauth, sts)
-	disabled := telemetryOptOut(endpoint) || authFunc == nil
+	// Test-mode gating (TFCA-B8): never report during acceptance or live-production
+	// test runs, so an unexpected outbound call can't make those suites slow or
+	// flaky (cf. hashicorp/terraform-plugin-sdk#640).
+	disabled := testMode || telemetryOptOut(endpoint) || authFunc == nil
 	rt := &telemetryRuntime{config: telemetry.NewConfig(disabled)}
 	if !disabled {
 		poster := telemetry.NewSDKPoster(endpoint, &http.Client{}, userAgent, authFunc)

--- a/internal/provider/telemetry_runtime_test.go
+++ b/internal/provider/telemetry_runtime_test.go
@@ -107,7 +107,7 @@ func TestPublishTelemetryRuntime(t *testing.T) {
 	t.Run("non-default endpoint publishes a disabled runtime", func(t *testing.T) {
 		restorePublishedTelemetry(t)
 		t.Setenv(disableProviderAnalyticsEnvVar, "")
-		publishTelemetryRuntime(t.Context(), "https://mock.local", "ua", "key", "secret", nil, nil)
+		publishTelemetryRuntime(t.Context(), "https://mock.local", "ua", "key", "secret", nil, nil, false)
 		rt := publishedTelemetry.Load()
 		if rt == nil || !rt.config.Disabled || rt.reporter != nil {
 			t.Fatalf("expected a disabled runtime with no reporter, got %+v", rt)
@@ -117,7 +117,7 @@ func TestPublishTelemetryRuntime(t *testing.T) {
 	t.Run("env var publishes a disabled runtime", func(t *testing.T) {
 		restorePublishedTelemetry(t)
 		t.Setenv(disableProviderAnalyticsEnvVar, "1")
-		publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil)
+		publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil, false)
 		rt := publishedTelemetry.Load()
 		if rt == nil || !rt.config.Disabled || rt.reporter != nil {
 			t.Fatalf("expected a disabled runtime, got %+v", rt)
@@ -127,7 +127,7 @@ func TestPublishTelemetryRuntime(t *testing.T) {
 	t.Run("default endpoint with a cloud key publishes an enabled transport", func(t *testing.T) {
 		restorePublishedTelemetry(t)
 		t.Setenv(disableProviderAnalyticsEnvVar, "")
-		publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil)
+		publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil, false)
 		rt := publishedTelemetry.Load()
 		if rt == nil || rt.config.Disabled {
 			t.Fatalf("expected an enabled runtime, got %+v", rt)

--- a/internal/provider/telemetry_test_mode_test.go
+++ b/internal/provider/telemetry_test_mode_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/walkerus/go-wiremock"
+)
+
+const telemetryTestModeScenario = "telemetryTestModeScenarioName"
+
+// TestTelemetryDisabledInTestMode isolates the TFCA-B8 gate: even on the default
+// endpoint and with a top-level identity (a config that would otherwise report),
+// test mode disables reporting so no transport is built.
+func TestTelemetryDisabledInTestMode(t *testing.T) {
+	restorePublishedTelemetry(t)
+	t.Setenv(disableProviderAnalyticsEnvVar, "")
+
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil, true /* testMode */)
+	rt := publishedTelemetry.Load()
+	if rt == nil || !rt.config.Disabled || rt.reporter != nil {
+		t.Fatalf("test mode must disable telemetry with no transport, got %+v", rt)
+	}
+
+	// Control: the same inputs with testMode=false do enable it (proving the only
+	// difference is the gate). Close the transport it stands up.
+	publishTelemetryRuntime(t.Context(), defaultCloudEndpoint, "ua", "key", "secret", nil, nil, false)
+	rt = publishedTelemetry.Load()
+	if rt == nil || rt.config.Disabled || rt.reporter == nil {
+		t.Fatalf("expected telemetry enabled when not in test mode, got %+v", rt)
+	}
+	if c, ok := rt.reporter.(interface{ Close() }); ok {
+		c.Close()
+	}
+}
+
+// TestAccTelemetryDisabledDuringAcceptanceTests is the acceptance-level assertion
+// for TFCA-B8: during a testacc run (TF_ACC=1), a full resource lifecycle emits
+// zero telemetry calls, verified with checkStubCount against a stubbed
+// terraform-usage endpoint.
+func TestAccTelemetryDisabledDuringAcceptanceTests(t *testing.T) {
+	ctx := context.Background()
+
+	wiremockContainer, err := setupWiremock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wiremockContainer.Terminate(ctx)
+
+	mockServerUrl := wiremockContainer.URI
+	wiremockClient := wiremock.NewClient(mockServerUrl)
+	// nolint:errcheck
+	defer wiremockClient.Reset()
+	// nolint:errcheck
+	defer wiremockClient.ResetAllScenarios()
+
+	// A stub for the telemetry endpoint. If anything reported, this counter would
+	// be non-zero; the test asserts it stays at zero.
+	telemetryStub := wiremock.Post(wiremock.URLPathEqualTo("/terraform-usage/v1/usages")).
+		WillReturn("", contentTypeJSONHeader, http.StatusOK)
+	_ = wiremockClient.StubFor(telemetryStub)
+
+	// A minimal create -> destroy environment lifecycle, so real CRUD runs.
+	createEnvResponse, _ := os.ReadFile("../testdata/environment/create_env.json")
+	createEnvStub := wiremock.Post(wiremock.URLPathEqualTo("/org/v2/environments")).
+		InScenario(telemetryTestModeScenario).
+		WhenScenarioStateIs(wiremock.ScenarioStateStarted).
+		WillSetStateTo(scenarioStateEnvHasBeenCreated).
+		WillReturn(string(createEnvResponse), contentTypeJSONHeader, http.StatusCreated)
+	_ = wiremockClient.StubFor(createEnvStub)
+
+	readCreatedEnvResponse, _ := os.ReadFile("../testdata/environment/read_created_env.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/org/v2/environments/env-1jrymj")).
+		InScenario(telemetryTestModeScenario).
+		WhenScenarioStateIs(scenarioStateEnvHasBeenCreated).
+		WillReturn(string(readCreatedEnvResponse), contentTypeJSONHeader, http.StatusOK))
+
+	deleteEnvStub := wiremock.Delete(wiremock.URLPathEqualTo("/org/v2/environments/env-1jrymj")).
+		InScenario(telemetryTestModeScenario).
+		WhenScenarioStateIs(scenarioStateEnvHasBeenCreated).
+		WillSetStateTo(scenarioStateEnvHasBeenDeleted).
+		WillReturn("", contentTypeJSONHeader, http.StatusNoContent)
+	_ = wiremockClient.StubFor(deleteEnvStub)
+
+	readDeletedEnvResponse, _ := os.ReadFile("../testdata/environment/read_deleted_env.json")
+	_ = wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/org/v2/environments/env-1jrymj")).
+		InScenario(telemetryTestModeScenario).
+		WhenScenarioStateIs(scenarioStateEnvHasBeenDeleted).
+		WillReturn(string(readDeletedEnvResponse), contentTypeJSONHeader, http.StatusNotFound))
+
+	environmentResourceLabel := "telemetry_test_env"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				// display_name must match the value in the create/read fixtures, else
+			// the post-apply plan is non-empty and the step fails.
+			Config: testAccCheckEnvironmentConfig(mockServerUrl, environmentResourceLabel, "test_env_display_name", "ESSENTIALS"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(fmt.Sprintf("confluent_environment.%s", environmentResourceLabel)),
+				),
+			},
+		},
+	})
+
+	// Sanity: the lifecycle really ran (create happened once)...
+	checkStubCount(t, wiremockClient, createEnvStub, "POST /org/v2/environments", expectedCountOne)
+	// ...and yet zero telemetry was emitted during the acceptance run.
+	checkStubCount(t, wiremockClient, telemetryStub, "POST /terraform-usage/v1/usages", expectedCountZero)
+}

--- a/internal/provider/telemetry_test_mode_test.go
+++ b/internal/provider/telemetry_test_mode_test.go
@@ -52,11 +52,16 @@ func TestTelemetryDisabledInTestMode(t *testing.T) {
 	}
 }
 
-// TestAccTelemetryDisabledDuringAcceptanceTests is the acceptance-level assertion
-// for TFCA-B8: during a testacc run (TF_ACC=1), a full resource lifecycle emits
-// zero telemetry calls, verified with checkStubCount against a stubbed
-// terraform-usage endpoint.
+// TestAccTelemetryDisabledDuringAcceptanceTests is an end-to-end "no telemetry
+// escapes during a testacc run" guard: a full resource lifecycle under TF_ACC
+// emits zero telemetry calls, verified with checkStubCount against a stubbed
+// terraform-usage endpoint (with a non-zero create-stub count proving the
+// lifecycle really ran). It does NOT isolate the test-mode gate specifically —
+// an acceptance run structurally uses a non-default (mock) endpoint, which also
+// disables reporting — so the gate is isolated by the unit test
+// TestTelemetryDisabledInTestMode; this test guards the composed outcome.
 func TestAccTelemetryDisabledDuringAcceptanceTests(t *testing.T) {
+	restorePublishedTelemetry(t)
 	ctx := context.Background()
 
 	wiremockContainer, err := setupWiremock(ctx)
@@ -114,8 +119,8 @@ func TestAccTelemetryDisabledDuringAcceptanceTests(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// display_name must match the value in the create/read fixtures, else
-			// the post-apply plan is non-empty and the step fails.
-			Config: testAccCheckEnvironmentConfig(mockServerUrl, environmentResourceLabel, "test_env_display_name", "ESSENTIALS"),
+				// the post-apply plan is non-empty and the step fails.
+				Config: testAccCheckEnvironmentConfig(mockServerUrl, environmentResourceLabel, "test_env_display_name", "ESSENTIALS"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentExists(fmt.Sprintf("confluent_environment.%s", environmentResourceLabel)),
 				),


### PR DESCRIPTION
## What
Implements **TFCA-B8** ([APIE-1571](https://confluentinc.atlassian.net/browse/APIE-1571)) — **test-mode gating**, the final piece of the provider-side telemetry stack.

Reporting is gated off whenever `isAcceptanceTestMode`/`isLiveProductionTestMode` are set (`TF_ACC`/`TF_ACC_PROD`): `publishTelemetryRuntime` takes a `testMode` flag that short-circuits to disabled, so an unexpected outbound call can't make acceptance/live suites slow or flaky (cf. hashicorp/terraform-plugin-sdk#640). The live/smoke Semaphore jobs also export `CONFLUENT_DISABLE_PROVIDER_ANALYTICS` as belt-and-suspenders.

Also adds the one test that composes the **enabled** end-to-end chain (`New()`-wrapped resource → `publishedTelemetryReporter` → real `Transport` → poster receives the `Usage`) — the seam nothing else asserted, so a revert of the `New()` wiring to a no-op reporter would now be caught.

> ⚠️ **Stacked PR (top of the stack).** Base = `APIE-1570` (B7). Merge B5 → B4 → B6 → B7 first; when this and the rest land, the provider-side telemetry feature (Epic B MVP) is complete.

## Tests
Unit test isolates the gate (default endpoint + real identity — which would otherwise report — stays disabled under `testMode`, enabled otherwise); acceptance test runs a full environment lifecycle under `TF_ACC` and asserts via `checkStubCount` that a stubbed terraform-usage endpoint got **zero** requests (with a non-zero create-stub sanity control); the enabled-path composition test. Green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APIE-1571]: https://confluentinc.atlassian.net/browse/APIE-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ