### PR TITLE
Fix OAuth and CAM authentication context handling

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -243,7 +243,7 @@ func (c *Client) certificateAuthorityV2ApiContext(ctx context.Context) context.C
 
 func (c *Client) camV1ApiContext(ctx context.Context) context.Context {
 	if c.cloudApiKey != "" && c.cloudApiSecret != "" {
-		return context.WithValue(context.Background(), camv1.ContextBasicAuth, camv1.BasicAuth{
+		return context.WithValue(ctx, camv1.ContextBasicAuth, camv1.BasicAuth{
 			UserName: c.cloudApiKey,
 			Password: c.cloudApiSecret,
 		})

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -749,7 +749,7 @@ func (c *KafkaRestClient) apiContext(ctx context.Context) context.Context {
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Kafka rest client: %v", err))
-			return ctx
+			return context.WithValue(ctx, kafkarestv3.ContextAccessToken, currToken.AccessToken)
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, kafkarestv3.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -772,7 +772,7 @@ func (c *SchemaRegistryRestClient) apiContext(ctx context.Context) context.Conte
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Schema Registry rest client: %v", err))
-			return ctx
+			return context.WithValue(ctx, schemaregistryv1.ContextAccessToken, currToken.AccessToken)
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, schemaregistryv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -795,7 +795,7 @@ func (c *SchemaRegistryRestClient) dataCatalogV1ApiContext(ctx context.Context) 
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Data Catalog rest client: %v", err))
-			return ctx
+			return context.WithValue(ctx, datacatalogv1.ContextAccessToken, currToken.AccessToken)
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, datacatalogv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -818,7 +818,7 @@ func (c *CatalogRestClient) dataCatalogV1ApiContext(ctx context.Context) context
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Stream Governance Cluster rest client: %v", err))
-			return ctx
+			return context.WithValue(ctx, datacatalogv1.ContextAccessToken, currToken.AccessToken)
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, datacatalogv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -840,7 +840,7 @@ func (c *FlinkRestClient) apiContext(ctx context.Context) context.Context {
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Flink rest client: %v", err))
-			return ctx
+			return context.WithValue(ctx, flinkgatewayv1.ContextAccessToken, currToken.AccessToken)
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, flinkgatewayv1.ContextAccessToken, c.externalAccessToken.AccessToken)

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -749,6 +749,7 @@ func (c *KafkaRestClient) apiContext(ctx context.Context) context.Context {
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Kafka rest client: %v", err))
+			return ctx
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, kafkarestv3.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -771,6 +772,7 @@ func (c *SchemaRegistryRestClient) apiContext(ctx context.Context) context.Conte
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Schema Registry rest client: %v", err))
+			return ctx
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, schemaregistryv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -793,6 +795,7 @@ func (c *SchemaRegistryRestClient) dataCatalogV1ApiContext(ctx context.Context) 
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Data Catalog rest client: %v", err))
+			return ctx
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, datacatalogv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -815,6 +818,7 @@ func (c *CatalogRestClient) dataCatalogV1ApiContext(ctx context.Context) context
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Stream Governance Cluster rest client: %v", err))
+			return ctx
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, datacatalogv1.ContextAccessToken, c.externalAccessToken.AccessToken)
@@ -836,6 +840,7 @@ func (c *FlinkRestClient) apiContext(ctx context.Context) context.Context {
 		token, err := fetchExternalOAuthToken(ctx, currToken.TokenUrl, currToken.ClientId, currToken.ClientSecret, currToken.Scope, currToken.IdentityPoolId, currToken, currToken.HTTPClient)
 		if err != nil {
 			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Flink rest client: %v", err))
+			return ctx
 		}
 		c.externalAccessToken = token
 		return context.WithValue(ctx, flinkgatewayv1.ContextAccessToken, c.externalAccessToken.AccessToken)

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -149,9 +149,9 @@ func (c *Client) connectCustomPluginV1ApiContext(ctx context.Context) context.Co
 func (c *Client) ccpmV1ApiContext(ctx context.Context) context.Context {
 	if c.oauthToken != nil && c.stsToken != nil {
 		if err := c.fetchOrOverrideSTSOAuthTokenFromApiContext(ctx); err != nil {
-			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Custom Code Logging client: %v", err))
+			tflog.Error(ctx, fmt.Sprintf("Failed to get OAuth token for Custom Connect Plugin Management client: %v", err))
 		}
-		return context.WithValue(ctx, connectcustompluginv1.ContextAccessToken, c.stsToken.AccessToken)
+		return context.WithValue(ctx, ccpmv1.ContextAccessToken, c.stsToken.AccessToken)
 	}
 
 	if c.cloudApiKey != "" && c.cloudApiSecret != "" {
@@ -161,7 +161,7 @@ func (c *Client) ccpmV1ApiContext(ctx context.Context) context.Context {
 		})
 	}
 
-	tflog.Warn(ctx, "Could not find Cloud API Key or OAuth Token for Custom Code Logging client")
+	tflog.Warn(ctx, "Could not find Cloud API Key or OAuth Token for Custom Connect Plugin Management client")
 	return ctx
 }
 

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -81,6 +81,67 @@ func TestCCPMV1ApiContextUsesCCPMOAuthContextKey(t *testing.T) {
 	}
 }
 
+func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context, *OAuthToken) (context.Context, *OAuthToken)
+	}{
+		{
+			name: "Kafka",
+			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
+				c := &KafkaRestClient{externalAccessToken: token}
+				return c.apiContext(ctx), c.externalAccessToken
+			},
+		},
+		{
+			name: "Schema Registry",
+			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
+				c := &SchemaRegistryRestClient{externalAccessToken: token}
+				return c.apiContext(ctx), c.externalAccessToken
+			},
+		},
+		{
+			name: "Schema Registry Data Catalog",
+			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
+				c := &SchemaRegistryRestClient{externalAccessToken: token}
+				return c.dataCatalogV1ApiContext(ctx), c.externalAccessToken
+			},
+		},
+		{
+			name: "Catalog",
+			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
+				c := &CatalogRestClient{externalAccessToken: token}
+				return c.dataCatalogV1ApiContext(ctx), c.externalAccessToken
+			},
+		},
+		{
+			name: "Flink",
+			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
+				c := &FlinkRestClient{externalAccessToken: token}
+				return c.apiContext(ctx), c.externalAccessToken
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := &OAuthToken{
+				TokenUrl:   "https://example.com/oauth/token",
+				ValidUntil: time.Now().Add(-time.Hour),
+			}
+			ctx := context.WithValue(context.Background(), struct{}{}, "test-value")
+
+			gotContext, gotToken := tt.call(ctx, token)
+			if gotContext != ctx {
+				t.Fatal("expected the original context after OAuth refresh failure")
+			}
+			if gotToken != token {
+				t.Fatal("expected the expired token to remain cached after OAuth refresh failure")
+			}
+		})
+	}
+}
+
 func TestExtractOrgIdFromResourceName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	apikeysv2 "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
+	camv1 "github.com/confluentinc/ccloud-sdk-go-v2/cam/v1"
 	ccpmv1 "github.com/confluentinc/ccloud-sdk-go-v2/ccpm/v1"
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 	networkingdnsforwarderv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-dnsforwarder/v1"
@@ -139,6 +140,31 @@ func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testin
 				t.Fatal("expected the expired token to remain cached after OAuth refresh failure")
 			}
 		})
+	}
+}
+
+func TestCamV1ApiContextPreservesCallerContext(t *testing.T) {
+	type contextKey string
+
+	key := contextKey("test-key")
+	baseContext := context.WithValue(context.Background(), key, "test-value")
+	ctx, cancel := context.WithCancel(baseContext)
+	cancel()
+
+	c := &Client{cloudApiKey: "test-key", cloudApiSecret: "test-secret"}
+	gotContext := c.camV1ApiContext(ctx)
+
+	if got := gotContext.Value(key); got != "test-value" {
+		t.Fatalf("CAM context value = %v, want test-value", got)
+	}
+	select {
+	case <-gotContext.Done():
+	default:
+		t.Fatal("expected CAM context to remain cancelled")
+	}
+	auth, ok := gotContext.Value(camv1.ContextBasicAuth).(camv1.BasicAuth)
+	if !ok || auth.UserName != "test-key" || auth.Password != "test-secret" {
+		t.Fatalf("CAM basic auth = %#v, want test credentials", auth)
 	}
 }
 

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -31,6 +31,8 @@ import (
 	apikeysv2 "github.com/confluentinc/ccloud-sdk-go-v2/apikeys/v2"
 	camv1 "github.com/confluentinc/ccloud-sdk-go-v2/cam/v1"
 	ccpmv1 "github.com/confluentinc/ccloud-sdk-go-v2/ccpm/v1"
+	datacatalogv1 "github.com/confluentinc/ccloud-sdk-go-v2/data-catalog/v1"
+	flinkgatewayv1 "github.com/confluentinc/ccloud-sdk-go-v2/flink-gateway/v1"
 	kafkarestv3 "github.com/confluentinc/ccloud-sdk-go-v2/kafkarest/v3"
 	networkingdnsforwarderv1 "github.com/confluentinc/ccloud-sdk-go-v2/networking-dnsforwarder/v1"
 	schemaregistryv1 "github.com/confluentinc/ccloud-sdk-go-v2/schema-registry/v1"
@@ -82,16 +84,20 @@ func TestCCPMV1ApiContextUsesCCPMOAuthContextKey(t *testing.T) {
 	}
 }
 
-func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testing.T) {
+func TestRestClientApiContextUsesCachedOAuthTokenOnRefreshError(t *testing.T) {
 	tests := []struct {
-		name string
-		call func(context.Context, *OAuthToken) (context.Context, *OAuthToken)
+		name        string
+		call        func(context.Context, *OAuthToken) (context.Context, *OAuthToken)
+		accessToken func(context.Context) interface{}
 	}{
 		{
 			name: "Kafka",
 			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
 				c := &KafkaRestClient{externalAccessToken: token}
 				return c.apiContext(ctx), c.externalAccessToken
+			},
+			accessToken: func(ctx context.Context) interface{} {
+				return ctx.Value(kafkarestv3.ContextAccessToken)
 			},
 		},
 		{
@@ -100,12 +106,18 @@ func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testin
 				c := &SchemaRegistryRestClient{externalAccessToken: token}
 				return c.apiContext(ctx), c.externalAccessToken
 			},
+			accessToken: func(ctx context.Context) interface{} {
+				return ctx.Value(schemaregistryv1.ContextAccessToken)
+			},
 		},
 		{
 			name: "Schema Registry Data Catalog",
 			call: func(ctx context.Context, token *OAuthToken) (context.Context, *OAuthToken) {
 				c := &SchemaRegistryRestClient{externalAccessToken: token}
 				return c.dataCatalogV1ApiContext(ctx), c.externalAccessToken
+			},
+			accessToken: func(ctx context.Context) interface{} {
+				return ctx.Value(datacatalogv1.ContextAccessToken)
 			},
 		},
 		{
@@ -114,6 +126,9 @@ func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testin
 				c := &CatalogRestClient{externalAccessToken: token}
 				return c.dataCatalogV1ApiContext(ctx), c.externalAccessToken
 			},
+			accessToken: func(ctx context.Context) interface{} {
+				return ctx.Value(datacatalogv1.ContextAccessToken)
+			},
 		},
 		{
 			name: "Flink",
@@ -121,23 +136,27 @@ func TestRestClientApiContextReturnsOriginalContextOnOAuthRefreshError(t *testin
 				c := &FlinkRestClient{externalAccessToken: token}
 				return c.apiContext(ctx), c.externalAccessToken
 			},
+			accessToken: func(ctx context.Context) interface{} {
+				return ctx.Value(flinkgatewayv1.ContextAccessToken)
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := &OAuthToken{
-				TokenUrl:   "https://example.com/oauth/token",
-				ValidUntil: time.Now().Add(-time.Hour),
+				AccessToken: "existing-access-token",
+				TokenUrl:    "https://example.com/oauth/token",
+				ValidUntil:  time.Now().Add(-time.Hour),
 			}
 			ctx := context.WithValue(context.Background(), struct{}{}, "test-value")
 
 			gotContext, gotToken := tt.call(ctx, token)
-			if gotContext != ctx {
-				t.Fatal("expected the original context after OAuth refresh failure")
+			if got := tt.accessToken(gotContext); got != token.AccessToken {
+				t.Fatalf("context access token = %v, want %q", got, token.AccessToken)
 			}
 			if gotToken != token {
-				t.Fatal("expected the expired token to remain cached after OAuth refresh failure")
+				t.Fatal("expected the cached token to remain after OAuth refresh failure")
 			}
 		})
 	}

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -63,6 +63,24 @@ func TestKafkaAclResourceStateUpgradeV0(t *testing.T) {
 	}
 }
 
+func TestCCPMV1ApiContextUsesCCPMOAuthContextKey(t *testing.T) {
+	const expectedAccessToken = "test-access-token"
+
+	c := &Client{
+		oauthToken: &OAuthToken{},
+		stsToken: &STSToken{
+			AccessToken: expectedAccessToken,
+			ValidUntil:  time.Now().Add(time.Hour),
+		},
+	}
+
+	ctx := c.ccpmV1ApiContext(context.Background())
+	accessToken, ok := ctx.Value(ccpmv1.ContextAccessToken).(string)
+	if !ok || accessToken != expectedAccessToken {
+		t.Fatalf("CCPM context access token = %q, want %q", accessToken, expectedAccessToken)
+	}
+}
+
 func TestExtractOrgIdFromResourceName(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
Release Notes
---------

Bug Fixes
- **CCPM OAuth:** Use the CCPM SDK context key so bearer tokens are sent correctly.
- **External OAuth refresh:** Avoid a provider panic when token refresh fails for Kafka, Schema Registry, Data Catalog, and Flink REST clients.
- **CAM auth:** Preserve the caller context when adding CAM basic authentication.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR. No docs or examples are needed for these internal authentication fixes.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

What
----
These are three small authentication correctness fixes.

- The CCPM helper used the access-token key from a different SDK package.
- REST helpers replaced the cached external token with nil after a refresh error.
- CAM auth started from `context.Background()` and dropped caller values and cancellation.

Successful authentication paths are unchanged.

Blast Radius
----
- OAuth users of custom connect plugin management could make requests without a bearer token.
- OAuth users of Kafka, Schema Registry, Data Catalog, or Flink REST APIs could see a provider panic when a token refresh failed. The provider now returns the API error path instead.
- CAM calls now keep Terraform cancellation, deadlines, and context values.

References
----------
None.

Test & Review
-------------
- Added unit coverage for the CCPM SDK context key.
- Added coverage for refresh failures across all five REST helpers.
- Added coverage for CAM context values, cancellation, and credentials.
- `go test ./... -run '^Test' -skip '^TestAcc' -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
