### PR TITLE
FF-12186: Document that CRNs must be URL encoded and that urlencode() can be used for crn_pattern

### DIFF
--- a/docs/resources/confluent_role_binding.md
+++ b/docs/resources/confluent_role_binding.md
@@ -117,6 +117,22 @@ resource "confluent_role_binding" "subject-with-abc-prefix-example-rb" {
   crn_pattern = "${data.confluent_schema_registry_cluster.example.resource_name}/subject=abc*"
 }
 
+resource "confluent_role_binding" "subject-with-special-characters-example-rb" {
+  principal = "User:${confluent_service_account.test.id}"
+  role_name = "DeveloperRead"
+  // A subject name that contains special characters, like "/", must be URL encoded.
+  // This results in ".../subject=grxevents%2Fprivate%2Fbilling".
+  crn_pattern = "${data.confluent_schema_registry_cluster.example.resource_name}/subject=${urlencode("grxevents/private/billing")}"
+}
+
+resource "confluent_role_binding" "subject-with-special-characters-prefix-example-rb" {
+  principal = "User:${confluent_service_account.test.id}"
+  role_name = "DeveloperRead"
+  // Note that the trailing "*" wildcard is intentionally kept outside of urlencode().
+  // This results in ".../subject=grxevents%2Fprivate%2Fbilling*".
+  crn_pattern = "${data.confluent_schema_registry_cluster.example.resource_name}/subject=${urlencode("grxevents/private/billing")}*"
+}
+
 resource "confluent_role_binding" "kek-example-rb" {
   principal   = "User:${confluent_service_account.test.id}"
   role_name   = "DeveloperRead"
@@ -142,6 +158,9 @@ The following arguments are supported:
 - `principal` - (Required String) A principal User to bind the role to, for example, "User:u-111aaa" for binding to a user "u-111aaa", or "User:sa-111aaa" for binding to a service account "sa-111aaa".
 - `role_name` - (Required String) A name of the role to bind to the principal. See [Confluent Cloud RBAC Roles](https://docs.confluent.io/cloud/current/access-management/access-control/cloud-rbac.html#ccloud-rbac-roles) for a full list of supported role names.
 - `crn_pattern` - (Required String) A [Confluent Resource Name (CRN)](https://docs.confluent.io/cloud/current/api.html#section/Identifiers-and-URLs/Confluent-Resource-Names-(CRNs)) that specifies the scope and resource patterns necessary for the role to bind.
+
+-> **Note:** A CRN is a URI, so a resource name that contains special characters must be URL encoded. For example, a Schema Registry subject named `grxevents/private/billing` must appear in `crn_pattern` as `subject=grxevents%2Fprivate%2Fbilling`. You can use Terraform's [`urlencode()`](https://developer.hashicorp.com/terraform/language/functions/urlencode) function instead of encoding the name yourself, which is particularly useful when the resource name comes from a variable or another resource rather than a hardcoded string, see [this example](#example-of-using-urlencode) for more details.
+
 - `disable_wait_for_ready` - (Optional Boolean) An optional flag to disable wait-for-readiness on create. Must be unset when importing. Defaults to `false`.
 
 !> **Warning:** When `disable_wait_for_ready = true` is used, Terraform skips waiting for role bindings to fully propagate. This can lead to a situation where Terraform attempts to create resources before the service account has the necessary permissions—resulting in HTTP 403 Forbidden errors.
@@ -217,3 +236,33 @@ resource "confluent_kafka_topic" "orders" {
   }
 }
 ```
+
+## Example of using urlencode
+
+A CRN is a URI, so a resource name that contains special characters must be URL encoded in `crn_pattern`. Terraform's [`urlencode()`](https://developer.hashicorp.com/terraform/language/functions/urlencode) function performs the encoding for you, so you do not have to hardcode the encoded form. This is particularly useful when the resource name is defined through a variable or another resource rather than a hardcoded string.
+
+For example, to bind the `DeveloperRead` role to a Schema Registry subject named `grxevents/private/billing`:
+
+```terraform
+resource "confluent_role_binding" "subject-with-special-characters" {
+  principal   = "User:${confluent_service_account.test.id}"
+  role_name   = "DeveloperRead"
+  crn_pattern = "${data.confluent_schema_registry_cluster.example.resource_name}/subject=${urlencode("grxevents/private/billing")}"
+}
+```
+
+The preceding configuration sets `crn_pattern` to `crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/schema-registry=lsrc-abc123/subject=grxevents%2Fprivate%2Fbilling`.
+
+To bind the role to every subject that starts with `grxevents/private/billing` instead, append the `*` wildcard after the encoded subject name:
+
+```terraform
+resource "confluent_role_binding" "subject-with-special-characters-prefix" {
+  principal   = "User:${confluent_service_account.test.id}"
+  role_name   = "DeveloperRead"
+  crn_pattern = "${data.confluent_schema_registry_cluster.example.resource_name}/subject=${urlencode("grxevents/private/billing")}*"
+}
+```
+
+!> **Warning:** Apply `urlencode()` to the resource name only, and keep the trailing `*` wildcard outside of the function. `urlencode()` percent encodes `*` as `%2A`, so `urlencode("grxevents/private/billing*")` returns `grxevents%2Fprivate%2Fbilling%2A`, where `*` is a literal character of the subject name instead of a wildcard. A percent encoded `*` may also cause Terraform to display a permanent difference for `crn_pattern` and plan a replacement on every run, see [#285](https://github.com/confluentinc/terraform-provider-confluent/issues/285) for more details.
+
+-> **Note:** `urlencode()` encodes a space as `+` rather than as `%20`. If a resource name contains spaces, and you need the `%20` form, you can use `replace(urlencode("my subject"), "+", "%20")` instead.


### PR DESCRIPTION
Release Notes
---------

NA

Checklist
---------
- [ ] I can successfully build and use a custom Terraform provider binary for Confluent.
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both.
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below.
- [ ] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality.
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality.
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing.
- [ ] I have included rate limit/load testing results.
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [x] I have updated the corresponding documentation and include relevant examples for this PR.
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in:
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only

-> **Note:** This is a documentation-only PR: no provider code, schema, or behavior changes, so the build/testing/feature-enablement items above do not apply. The Terraform snippets that were added are validated in the `Test & Review` section below.

What
----

The Confluent Cloud API uses URL encoding in CRNs so that resource names can contain special characters, for example, a Schema Registry subject with slashes in its name. Today users have to translate the resource name into its URL encoded form by hand, which is not very user friendly with the Terraform Provider, where the CRN is often assembled from variables or other resources rather than hardcoded.

Terraform ships a [`urlencode()`](https://developer.hashicorp.com/terraform/language/functions/urlencode) function that can do this for users on the fly, so this PR documents it in `docs/resources/confluent_role_binding.md`:

* Added a note under the `crn_pattern` argument stating that a CRN is a URI, so a resource name that contains special characters must be URL encoded, with `subject=grxevents%2Fprivate%2Fbilling` as an example, and pointing at `urlencode()`.
* Added two examples to the `Example Usage` section (an exact subject name and a prefix pattern), matching the existing `subject=foo` / `subject=abc*` examples in that section.
* Added an `Example of using urlencode` section with the resulting CRN spelled out, following the existing `Example of using time_sleep` section convention in this file.

One important caveat that came up while writing this: `urlencode()` percent encodes `*` as `%2A`, so applying it to the whole pattern does **not** produce the intended CRN:

```
urlencode("grxevents/private/billing*")  => "grxevents%2Fprivate%2Fbilling%2A"   # "*" is now a literal character
urlencode("grxevents/private/billing")   => "grxevents%2Fprivate%2Fbilling"      # append "*" outside the function
```

So the docs deliberately apply `urlencode()` to the resource name only and keep the trailing `*` wildcard outside of it, and a `!> Warning` block calls this out. This is also what [#285](https://github.com/confluentinc/terraform-provider-confluent/issues/285) ran into: a `%2A` in `crn_pattern` shows up as a permanent difference and forces a replacement on every run.

Note that the other half of FF-12186 — noting the URL encoding requirement with examples in the **Confluent Cloud API docs** — is not covered by this PR, since those docs do not live in this repo. The CRN section of the API docs currently does not mention encoding or wildcards at all.

Blast Radius
----

None. This PR only changes Markdown under `docs/`, so there is no impact on any customer configuration: no provider code, schema, resource, data source, or behavior is touched. The worst case is a documentation inaccuracy for Confluent Cloud customers who read the `confluent_role_binding` resource docs.

Test & Review
-------------

https://registry.terraform.io/tools/doc-preview:
<img width="334" height="612" alt="image" src="https://github.com/user-attachments/assets/77bb8b43-6896-4fc8-9986-36718e559433" />


Documentation-only change, so there is nothing to build or apply. Every claim added to the docs was verified against Terraform v1.15.8 rather than assumed:

```
$ terraform console
> urlencode("grxevents/private/billing")
"grxevents%2Fprivate%2Fbilling"

> urlencode("grxevents/private/billing*")
"grxevents%2Fprivate%2Fbilling%2A"

> "subject=${urlencode("grxevents/private/billing")}*"
"subject=grxevents%2Fprivate%2Fbilling*"

> replace(urlencode("my subject"), "+", "%20")
"my%20subject"
```

The exact CRN quoted in the new section was also evaluated end to end:

```
> "crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/schema-registry=lsrc-abc123/subject=${urlencode("grxevents/private/billing")}"
"crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/schema-registry=lsrc-abc123/subject=grxevents%2Fprivate%2Fbilling"
```

All four new `terraform` snippets were extracted into a `.tf` file and confirmed to parse and to be canonically formatted:

```
$ terraform fmt -check -diff fmtcheck/
FMT CLEAN (no changes needed)
```

Reviewer note: the `-> **Note:**` inserted between the `crn_pattern` and `disable_wait_for_ready` bullets intentionally splits the argument list, which is the existing convention in this repo, see `docs/resources/confluent_kafka_topic.md` for the same pattern.
