### PR TITLE
Nit fix for doc and comment

### DIFF
--- a/internal/provider/telemetry/run.go
+++ b/internal/provider/telemetry/run.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Confluent Inc. All Rights Reserved.
+// Copyright 2026 Confluent Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/provider/telemetry/telemetry.go
+++ b/internal/provider/telemetry/telemetry.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Confluent Inc. All Rights Reserved.
+// Copyright 2026 Confluent Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ func NewConfig(disabled bool) Config {
 }
 
 // Timer captures the start of an operation so the wrapper can record the
-// Usage.StartTime and Usage.Duration, timed from wrapper entry to just before
+// Usage.StartedAt and Usage.DurationMs, timed from wrapper entry to just before
 // the wrapped function returns.
 type Timer struct {
 	start time.Time

--- a/internal/provider/telemetry/telemetry_test.go
+++ b/internal/provider/telemetry/telemetry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Confluent Inc. All Rights Reserved.
+// Copyright 2026 Confluent Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Release Notes
---------
No user-facing changes; comment/header only.

## What & why

Two small corrections in the `internal/provider/telemetry/` package (added in #1176), neither of which was reachable to fix from the stacked B3 PR (#1190) once it was rebased off this package:

1. **Doc-comment fix** — the `Timer` doc comment referenced `Usage.StartTime` and `Usage.Duration`, but the `Usage` struct fields are `StartedAt` and `DurationMs` (there is no `Usage.StartTime`/`Usage.Duration`). This is the wrong-identifier comment flagged in review. Corrected to the real field names.
2. **Copyright year** — `run.go`, `telemetry.go`, and `telemetry_test.go` carried a stale `Copyright 2021` inherited from the file used as a template. Per the repo convention (header year = file creation year; files added in 2026 use 2026), set them to `2026`.

No code or behavior change.

Blast Radius
----
None. Comment/header-only change; the package's code and tests are untouched.

## Testing

`gofmt`, `go build ./internal/provider/telemetry/`, and `go test ./internal/provider/telemetry/ -race` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
