### PR TITLE
[APIE-1567] Panic recovery in the telemetry wrapper (TFCA-B4)

### DIFF
--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -35,9 +35,11 @@ import (
 // it to a reporter.
 //
 // The wrappers are also the provider's only panic recovery (TFCA-B4): a panic in
-// a wrapped CRUD or import call is recovered and converted to an error result, so
-// it no longer crashes the provider process, and is reported as a crash event
-// (Error=true, with a trimmed stack trace). Building and reporting the Usage runs
+// a wrapped CRUD or import call is recovered and converted to an error result
+// (whose detail carries the trimmed stack, so the operator can still diagnose it
+// just as they could from the pre-recovery crash), so it no longer crashes the
+// provider process, and is reported as a crash event (Error=true, with the same
+// trimmed stack trace). Building and reporting the Usage runs
 // under its own recover, separate from the one guarding the inner call, so a
 // panic while assembling or enqueuing a report — including after a *successful*
 // call — is contained too. Reporting stays synchronous and simply hands the Usage
@@ -150,7 +152,7 @@ func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Sche
 		// crash event, rather than letting it propagate.
 		rec, stack := runGuarded(func() { diags = inner(ctx, d, meta) })
 		if rec != nil {
-			diags = panicDiagnostics(resourceType, op, rec)
+			diags = panicDiagnostics(resourceType, op, rec, stack)
 		}
 
 		// Build and report the Usage under its own recover (reportSafely): the
@@ -181,7 +183,7 @@ func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schem
 		rec, stack := runGuarded(func() { imported, err = inner(ctx, d, meta) })
 		if rec != nil {
 			imported = nil
-			err = panicError(resourceType, telemetry.OperationImport, rec)
+			err = panicError(resourceType, telemetry.OperationImport, rec, stack)
 		}
 
 		reportSafely(cfg, func() telemetry.Usage {
@@ -236,18 +238,32 @@ func reportSafely(cfg telemetryWrapConfig, build func() telemetry.Usage) {
 }
 
 // panicDiagnostics converts a recovered panic into error diagnostics returned in
-// place of the wrapped CRUD call's result.
-func panicDiagnostics(resourceType string, op telemetry.Operation, rec interface{}) diag.Diagnostics {
+// place of the wrapped CRUD call's result. The stack is included in the Detail
+// (see panicDetail) so the operator keeps a diagnosable trace.
+func panicDiagnostics(resourceType string, op telemetry.Operation, rec interface{}, stack []string) diag.Diagnostics {
 	return diag.Diagnostics{{
 		Severity: diag.Error,
 		Summary:  fmt.Sprintf("the Confluent provider recovered from a panic during %s of %s", strings.ToLower(string(op)), resourceType),
-		Detail:   fmt.Sprintf("%v", rec),
+		Detail:   panicDetail(rec, stack),
 	}}
 }
 
 // panicError is the import-path equivalent of panicDiagnostics.
-func panicError(resourceType string, op telemetry.Operation, rec interface{}) error {
-	return fmt.Errorf("the Confluent provider recovered from a panic during %s of %s: %v", strings.ToLower(string(op)), resourceType, rec)
+func panicError(resourceType string, op telemetry.Operation, rec interface{}, stack []string) error {
+	return fmt.Errorf("the Confluent provider recovered from a panic during %s of %s: %s", strings.ToLower(string(op)), resourceType, panicDetail(rec, stack))
+}
+
+// panicDetail renders the recovered panic value with its trimmed stack for the
+// operator-visible error. Before this wrapper existed, an uncaught panic crashed
+// the provider and Terraform Core printed the full stack to the user; surfacing
+// the (already path-redacted) trimmed stack here keeps a recovered panic just as
+// diagnosable — and just as present in a bug report — without the crash, and
+// without relying on the telemetry reporter (a no-op until TFCA-B5).
+func panicDetail(rec interface{}, stack []string) string {
+	if len(stack) == 0 {
+		return fmt.Sprintf("%v", rec)
+	}
+	return fmt.Sprintf("%v\n\n%s", rec, strings.Join(stack, "\n"))
 }
 
 // maxStackFrames caps how many frames a crash payload carries, so a deep stack

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -34,18 +34,11 @@ import (
 // import entry points, once, with wrappers that build a telemetry.Usage and hand
 // it to a reporter.
 //
-// The wrappers are also the provider's only panic recovery (TFCA-B4): a panic in
-// a wrapped CRUD or import call is recovered and converted to an error result
-// (whose detail carries the trimmed stack, so the operator can still diagnose it
-// just as they could from the pre-recovery crash), so it no longer crashes the
-// provider process, and is reported as a crash event (Error=true, with the same
-// trimmed stack trace). Building and reporting the Usage runs
-// under its own recover, separate from the one guarding the inner call, so a
-// panic while assembling or enqueuing a report — including after a *successful*
-// call — is contained too. Reporting stays synchronous and simply hands the Usage
-// to the reporter (a no-op today); the bounded-worker transport that makes that
-// hand-off non-blocking (TFCA-B5) and the opt-out wiring (TFCA-B6) land
-// separately.
+// The wrappers are also the provider's only panic recovery: a panic in a wrapped
+// CRUD or import call is recovered and returned as an error (with the trimmed
+// stack in its detail) instead of crashing the process, and is reported as a
+// crash event. Building and reporting the Usage has its own recover, so a panic
+// while doing that is contained too.
 
 // telemetryReporter receives a populated Usage; Report should not block the caller.
 type telemetryReporter interface {
@@ -146,19 +139,15 @@ func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Sche
 		seq := telemetry.NextSequence()
 		timer := telemetry.StartTimer()
 
-		// Recover a panic from the wrapped CRUD call — the provider's only panic
-		// recovery. Without it a panic in any resource crashes the whole provider
-		// process. On panic we convert to error diagnostics and still report a
-		// crash event, rather than letting it propagate.
+		// Recover a panic from the CRUD call and return it as error diagnostics
+		// instead of letting it crash the process.
 		rec, stack := runGuarded(func() { diags = inner(ctx, d, meta) })
 		if rec != nil {
 			diags = panicDiagnostics(resourceType, op, rec, stack)
 		}
 
-		// Build and report the Usage under its own recover (reportSafely): the
-		// recover above only guards the inner call, so a panic while reflecting
-		// over ResourceData or formatting the payload here would otherwise escape
-		// and crash the very process this feature protects.
+		// Build and report the Usage under a separate recover, so a panic while
+		// building or sending it is also contained.
 		reportSafely(cfg, func() telemetry.Usage {
 			changed := []string{}
 			if rec == nil {
@@ -177,9 +166,7 @@ func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schem
 		seq := telemetry.NextSequence()
 		timer := telemetry.StartTimer()
 
-		// Recover a panic on the import path on the same terms as the CRUD path:
-		// convert it to an error, discard any partial result, and still report a
-		// crash event.
+		// Recover an import panic as an error, discarding any partial result.
 		rec, stack := runGuarded(func() { imported, err = inner(ctx, d, meta) })
 		if rec != nil {
 			imported = nil
@@ -193,8 +180,7 @@ func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schem
 	}
 }
 
-// buildUsage assembles a Usage from the process-scoped config and the
-// per-operation inputs. stack is non-empty only on the panic path, so a normal
+// buildUsage assembles a Usage. stack is set only on the panic path; a normal
 // operation omits stack_frames.
 func (c telemetryWrapConfig) buildUsage(resourceType string, op telemetry.Operation, seq int64, timer telemetry.Timer, changed []string, errored bool, stack []string) telemetry.Usage {
 	return telemetry.Usage{
@@ -214,10 +200,8 @@ func (c telemetryWrapConfig) buildUsage(resourceType string, op telemetry.Operat
 	}
 }
 
-// runGuarded runs fn, recovering any panic. It returns the recovered value (nil
-// if fn returned normally) and, on panic, a trimmed stack trace. The stack is
-// captured inside the recovering defer, while the panic is still unwinding, so it
-// reflects the panicking call site rather than just this recovery point.
+// runGuarded runs fn and recovers any panic, returning the recovered value (nil
+// if fn returned normally) and a trimmed stack trace captured at the panic site.
 func runGuarded(fn func()) (rec interface{}, stack []string) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -229,17 +213,15 @@ func runGuarded(fn func()) (rec interface{}, stack []string) {
 	return
 }
 
-// reportSafely builds and reports a Usage, recovering (and swallowing) any panic
-// from the build or the enqueue. Telemetry must never crash the process it is
-// observing, so a failure here is dropped, not propagated.
+// reportSafely builds and reports a Usage, swallowing any panic so telemetry can
+// never crash the process it observes.
 func reportSafely(cfg telemetryWrapConfig, build func() telemetry.Usage) {
 	defer func() { _ = recover() }()
 	cfg.report(build())
 }
 
-// panicDiagnostics converts a recovered panic into error diagnostics returned in
-// place of the wrapped CRUD call's result. The stack is included in the Detail
-// (see panicDetail) so the operator keeps a diagnosable trace.
+// panicDiagnostics converts a recovered panic into error diagnostics, with the
+// stack in the detail (see panicDetail).
 func panicDiagnostics(resourceType string, op telemetry.Operation, rec interface{}, stack []string) diag.Diagnostics {
 	return diag.Diagnostics{{
 		Severity: diag.Error,
@@ -253,12 +235,8 @@ func panicError(resourceType string, op telemetry.Operation, rec interface{}, st
 	return fmt.Errorf("the Confluent provider recovered from a panic during %s of %s: %s", strings.ToLower(string(op)), resourceType, panicDetail(rec, stack))
 }
 
-// panicDetail renders the recovered panic value with its trimmed stack for the
-// operator-visible error. Before this wrapper existed, an uncaught panic crashed
-// the provider and Terraform Core printed the full stack to the user; surfacing
-// the (already path-redacted) trimmed stack here keeps a recovered panic just as
-// diagnosable — and just as present in a bug report — without the crash, and
-// without relying on the telemetry reporter (a no-op until TFCA-B5).
+// panicDetail renders the panic value and its trimmed stack for the operator's
+// error, so a recovered panic stays as diagnosable as the crash it replaces.
 func panicDetail(rec interface{}, stack []string) string {
 	if len(stack) == 0 {
 		return fmt.Sprintf("%v", rec)
@@ -266,15 +244,12 @@ func panicDetail(rec interface{}, stack []string) string {
 	return fmt.Sprintf("%v\n\n%s", rec, strings.Join(stack, "\n"))
 }
 
-// maxStackFrames caps how many frames a crash payload carries, so a deep stack
-// can't bloat a report.
+// maxStackFrames caps how many frames a crash report carries.
 const maxStackFrames = 50
 
-// trimmedStackFrames captures the current goroutine's stack and reduces it to
-// file:line frames with local absolute paths stripped, mirroring the CLI's
-// panic-report redaction. It keeps only lines that reference a .go source
-// location and shortens each to its last two path segments, so no user's
-// absolute filesystem path (e.g. /Users/<name>/...) reaches the wire.
+// trimmedStackFrames captures the current stack and reduces it to file:line
+// frames, stripping absolute paths so no local path (e.g. /Users/<name>/...) is
+// exposed.
 func trimmedStackFrames() []string {
 	lines := strings.Split(string(debug.Stack()), "\n")
 	frames := make([]string, 0, len(lines))
@@ -283,10 +258,8 @@ func trimmedStackFrames() []string {
 		if !strings.Contains(loc, ".go:") {
 			continue
 		}
-		// A stack location line looks like "/abs/path/pkg/file.go:123 +0x1f".
-		// Drop the trailing " +0x.." program-counter offset specifically, rather
-		// than cutting at the first space, so a build path containing a space
-		// (e.g. "/Users/Jane Doe/...") is not truncated mid-path.
+		// Drop the trailing " +0x.." offset only (not everything after the first
+		// space), so a path containing a space is not truncated.
 		if off := strings.LastIndex(loc, " +0x"); off >= 0 {
 			loc = loc[:off]
 		}
@@ -299,13 +272,8 @@ func trimmedStackFrames() []string {
 }
 
 // shortenSourcePath reduces "/abs/path/pkg/file.go:123" to "pkg/file.go:123",
-// removing absolute local paths while keeping enough to locate the frame.
-//
-// Backslash separators are normalized to "/" first so the redaction fails
-// closed regardless of path style: Go emits "/"-separated paths in stack traces
-// even on Windows, but relying on that would let a hypothetical
-// "C:\Users\<name>\...\file.go" frame survive whole (leaking the username)
-// instead of being shortened.
+// dropping the absolute path while keeping enough to locate the frame. Backslashes
+// are normalized to "/" first so a Windows-style path is redacted the same way.
 func shortenSourcePath(loc string) string {
 	loc = strings.ReplaceAll(loc, "\\", "/")
 	segs := strings.Split(loc, "/")

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -300,7 +300,14 @@ func trimmedStackFrames() []string {
 
 // shortenSourcePath reduces "/abs/path/pkg/file.go:123" to "pkg/file.go:123",
 // removing absolute local paths while keeping enough to locate the frame.
+//
+// Backslash separators are normalized to "/" first so the redaction fails
+// closed regardless of path style: Go emits "/"-separated paths in stack traces
+// even on Windows, but relying on that would let a hypothetical
+// "C:\Users\<name>\...\file.go" frame survive whole (leaking the username)
+// instead of being shortened.
 func shortenSourcePath(loc string) string {
+	loc = strings.ReplaceAll(loc, "\\", "/")
 	segs := strings.Split(loc, "/")
 	if len(segs) > 2 {
 		segs = segs[len(segs)-2:]

--- a/internal/provider/telemetry_wrapper.go
+++ b/internal/provider/telemetry_wrapper.go
@@ -16,8 +16,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"runtime"
+	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"weak"
 
@@ -30,6 +33,17 @@ import (
 // Central client-analytics wrapping. Replaces every managed resource's CRUD and
 // import entry points, once, with wrappers that build a telemetry.Usage and hand
 // it to a reporter.
+//
+// The wrappers are also the provider's only panic recovery (TFCA-B4): a panic in
+// a wrapped CRUD or import call is recovered and converted to an error result, so
+// it no longer crashes the provider process, and is reported as a crash event
+// (Error=true, with a trimmed stack trace). Building and reporting the Usage runs
+// under its own recover, separate from the one guarding the inner call, so a
+// panic while assembling or enqueuing a report — including after a *successful*
+// call — is contained too. Reporting stays synchronous and simply hands the Usage
+// to the reporter (a no-op today); the bounded-worker transport that makes that
+// hand-off non-blocking (TFCA-B5) and the opt-out wiring (TFCA-B6) land
+// separately.
 
 // telemetryReporter receives a populated Usage; Report should not block the caller.
 type telemetryReporter interface {
@@ -126,25 +140,29 @@ func wrapResourceForTelemetry(resourceType string, r *schema.Resource, cfg telem
 // inner call and reports a Usage after it returns. Reporting is synchronous because
 // the SDK reads ResourceData as soon as the CRUD call returns.
 func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Schema, op telemetry.Operation, inner func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 		seq := telemetry.NextSequence()
 		timer := telemetry.StartTimer()
 
-		diags := inner(ctx, d, meta)
+		// Recover a panic from the wrapped CRUD call — the provider's only panic
+		// recovery. Without it a panic in any resource crashes the whole provider
+		// process. On panic we convert to error diagnostics and still report a
+		// crash event, rather than letting it propagate.
+		rec, stack := runGuarded(func() { diags = inner(ctx, d, meta) })
+		if rec != nil {
+			diags = panicDiagnostics(resourceType, op, rec)
+		}
 
-		cfg.report(telemetry.Usage{
-			RunID:             telemetry.RunID(),
-			Sequence:          seq,
-			StartedAt:         timer.StartTime(),
-			DurationMs:        timer.Elapsed().Milliseconds(),
-			OS:                runtime.GOOS,
-			Arch:              runtime.GOARCH,
-			ProviderVersion:   cfg.providerVersion,
-			TerraformVersion:  cfg.tfVersion(),
-			ResourceType:      resourceType,
-			Operation:         op,
-			ChangedAttributes: changedAttributeNames(d, resourceSchema, op),
-			Error:             diags.HasError(),
+		// Build and report the Usage under its own recover (reportSafely): the
+		// recover above only guards the inner call, so a panic while reflecting
+		// over ResourceData or formatting the payload here would otherwise escape
+		// and crash the very process this feature protects.
+		reportSafely(cfg, func() telemetry.Usage {
+			changed := []string{}
+			if rec == nil {
+				changed = changedAttributeNames(d, resourceSchema, op)
+			}
+			return cfg.buildUsage(resourceType, op, seq, timer, changed, rec != nil || diags.HasError(), stack)
 		})
 		return diags
 	}
@@ -153,28 +171,125 @@ func wrapContextFunc(resourceType string, resourceSchema map[string]*schema.Sche
 // wrapImportFunc wraps Importer.StateContext, which has a different signature and
 // carries no attribute diff, so ChangedAttributes is always the empty slice.
 func wrapImportFunc(resourceType string, resourceSchema map[string]*schema.Schema, inner schema.StateContextFunc, cfg telemetryWrapConfig) func(context.Context, *schema.ResourceData, interface{}) ([]*schema.ResourceData, error) {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) (imported []*schema.ResourceData, err error) {
 		seq := telemetry.NextSequence()
 		timer := telemetry.StartTimer()
 
-		imported, err := inner(ctx, d, meta)
+		// Recover a panic on the import path on the same terms as the CRUD path:
+		// convert it to an error, discard any partial result, and still report a
+		// crash event.
+		rec, stack := runGuarded(func() { imported, err = inner(ctx, d, meta) })
+		if rec != nil {
+			imported = nil
+			err = panicError(resourceType, telemetry.OperationImport, rec)
+		}
 
-		cfg.report(telemetry.Usage{
-			RunID:             telemetry.RunID(),
-			Sequence:          seq,
-			StartedAt:         timer.StartTime(),
-			DurationMs:        timer.Elapsed().Milliseconds(),
-			OS:                runtime.GOOS,
-			Arch:              runtime.GOARCH,
-			ProviderVersion:   cfg.providerVersion,
-			TerraformVersion:  cfg.tfVersion(),
-			ResourceType:      resourceType,
-			Operation:         telemetry.OperationImport,
-			ChangedAttributes: []string{},
-			Error:             err != nil,
+		reportSafely(cfg, func() telemetry.Usage {
+			return cfg.buildUsage(resourceType, telemetry.OperationImport, seq, timer, []string{}, rec != nil || err != nil, stack)
 		})
 		return imported, err
 	}
+}
+
+// buildUsage assembles a Usage from the process-scoped config and the
+// per-operation inputs. stack is non-empty only on the panic path, so a normal
+// operation omits stack_frames.
+func (c telemetryWrapConfig) buildUsage(resourceType string, op telemetry.Operation, seq int64, timer telemetry.Timer, changed []string, errored bool, stack []string) telemetry.Usage {
+	return telemetry.Usage{
+		RunID:             telemetry.RunID(),
+		Sequence:          seq,
+		StartedAt:         timer.StartTime(),
+		DurationMs:        timer.Elapsed().Milliseconds(),
+		OS:                runtime.GOOS,
+		Arch:              runtime.GOARCH,
+		ProviderVersion:   c.providerVersion,
+		TerraformVersion:  c.tfVersion(),
+		ResourceType:      resourceType,
+		Operation:         op,
+		ChangedAttributes: changed,
+		Error:             errored,
+		StackFrames:       stack,
+	}
+}
+
+// runGuarded runs fn, recovering any panic. It returns the recovered value (nil
+// if fn returned normally) and, on panic, a trimmed stack trace. The stack is
+// captured inside the recovering defer, while the panic is still unwinding, so it
+// reflects the panicking call site rather than just this recovery point.
+func runGuarded(fn func()) (rec interface{}, stack []string) {
+	defer func() {
+		if r := recover(); r != nil {
+			rec = r
+			stack = trimmedStackFrames()
+		}
+	}()
+	fn()
+	return
+}
+
+// reportSafely builds and reports a Usage, recovering (and swallowing) any panic
+// from the build or the enqueue. Telemetry must never crash the process it is
+// observing, so a failure here is dropped, not propagated.
+func reportSafely(cfg telemetryWrapConfig, build func() telemetry.Usage) {
+	defer func() { _ = recover() }()
+	cfg.report(build())
+}
+
+// panicDiagnostics converts a recovered panic into error diagnostics returned in
+// place of the wrapped CRUD call's result.
+func panicDiagnostics(resourceType string, op telemetry.Operation, rec interface{}) diag.Diagnostics {
+	return diag.Diagnostics{{
+		Severity: diag.Error,
+		Summary:  fmt.Sprintf("the Confluent provider recovered from a panic during %s of %s", strings.ToLower(string(op)), resourceType),
+		Detail:   fmt.Sprintf("%v", rec),
+	}}
+}
+
+// panicError is the import-path equivalent of panicDiagnostics.
+func panicError(resourceType string, op telemetry.Operation, rec interface{}) error {
+	return fmt.Errorf("the Confluent provider recovered from a panic during %s of %s: %v", strings.ToLower(string(op)), resourceType, rec)
+}
+
+// maxStackFrames caps how many frames a crash payload carries, so a deep stack
+// can't bloat a report.
+const maxStackFrames = 50
+
+// trimmedStackFrames captures the current goroutine's stack and reduces it to
+// file:line frames with local absolute paths stripped, mirroring the CLI's
+// panic-report redaction. It keeps only lines that reference a .go source
+// location and shortens each to its last two path segments, so no user's
+// absolute filesystem path (e.g. /Users/<name>/...) reaches the wire.
+func trimmedStackFrames() []string {
+	lines := strings.Split(string(debug.Stack()), "\n")
+	frames := make([]string, 0, len(lines))
+	for _, line := range lines {
+		loc := strings.TrimSpace(line)
+		if !strings.Contains(loc, ".go:") {
+			continue
+		}
+		// A stack location line looks like "/abs/path/pkg/file.go:123 +0x1f".
+		// Drop the trailing " +0x.." program-counter offset specifically, rather
+		// than cutting at the first space, so a build path containing a space
+		// (e.g. "/Users/Jane Doe/...") is not truncated mid-path.
+		if off := strings.LastIndex(loc, " +0x"); off >= 0 {
+			loc = loc[:off]
+		}
+		frames = append(frames, shortenSourcePath(loc))
+		if len(frames) >= maxStackFrames {
+			break
+		}
+	}
+	return frames
+}
+
+// shortenSourcePath reduces "/abs/path/pkg/file.go:123" to "pkg/file.go:123",
+// removing absolute local paths while keeping enough to locate the frame.
+func shortenSourcePath(loc string) string {
+	segs := strings.Split(loc, "/")
+	if len(segs) > 2 {
+		segs = segs[len(segs)-2:]
+	}
+	return strings.Join(segs, "/")
 }
 
 // changedAttributeNames returns the top-level schema attribute names that changed,

--- a/internal/provider/telemetry_wrapper_panic_test.go
+++ b/internal/provider/telemetry_wrapper_panic_test.go
@@ -334,3 +334,42 @@ func TestRunGuarded_ClassifiesReturnAndPanic(t *testing.T) {
 		t.Errorf("panic(nil) must still be classified as a panic (rec != nil)")
 	}
 }
+
+// TestWrapper_PanicErrorSurfacesStack asserts the operator-visible error from a
+// recovered panic carries the trimmed stack (CRUD diagnostics Detail and import
+// error). Before recovery, a panic crashed the provider and Terraform printed the
+// full stack; the stack must not vanish just because the telemetry reporter is a
+// no-op today. It also carries the panic value.
+func TestWrapper_PanicErrorSurfacesStack(t *testing.T) {
+	r := newTestResource()
+	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+		panic("kaboom-create")
+	}
+	r.Importer.StateContext = func(context.Context, *schema.ResourceData, interface{}) ([]*schema.ResourceData, error) {
+		panic("kaboom-import")
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(&recordingReporter{}))
+
+	diags := r.CreateContext(context.Background(), nil, nil)
+	if !diags.HasError() {
+		t.Fatalf("expected error diagnostics from a recovered panic, got %+v", diags)
+	}
+	detail := diags[0].Detail
+	if !strings.Contains(detail, "kaboom-create") {
+		t.Errorf("CRUD panic Detail should include the panic value, got %q", detail)
+	}
+	if !strings.Contains(detail, ".go:") {
+		t.Errorf("CRUD panic Detail should include a stack frame (file:line), got %q", detail)
+	}
+	if strings.Contains(detail, "/Users/") {
+		t.Errorf("CRUD panic Detail leaked an absolute local path: %q", detail)
+	}
+
+	_, err := r.Importer.StateContext(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected an error from a recovered import panic")
+	}
+	if !strings.Contains(err.Error(), "kaboom-import") || !strings.Contains(err.Error(), ".go:") {
+		t.Errorf("import panic error should include the panic value and a stack frame, got %v", err)
+	}
+}

--- a/internal/provider/telemetry_wrapper_panic_test.go
+++ b/internal/provider/telemetry_wrapper_panic_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/confluentinc/terraform-provider-confluent/internal/provider/telemetry"
+)
+
+// panicReporter panics on Report, simulating a fault in the report/enqueue path.
+type panicReporter struct{}
+
+func (panicReporter) Report(telemetry.Usage) { panic("reporter boom") }
+
+// TestWrapper_RecoversCrudPanic asserts a panic in a wrapped CRUD call is
+// converted to error diagnostics (not propagated), the process does not crash,
+// and exactly one crash event is reported with Error=true, no changed
+// attributes, and a stack trace.
+func TestWrapper_RecoversCrudPanic(t *testing.T) {
+	for _, tc := range []struct {
+		op    telemetry.Operation
+		apply func(r *schema.Resource, panicFn func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics)
+		call  func(r *schema.Resource) diag.Diagnostics
+	}{
+		{telemetry.OperationCreate,
+			func(r *schema.Resource, fn func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics) {
+				r.CreateContext = fn
+			},
+			func(r *schema.Resource) diag.Diagnostics { return r.CreateContext(context.Background(), nil, nil) }},
+		{telemetry.OperationRead,
+			func(r *schema.Resource, fn func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics) {
+				r.ReadContext = fn
+			},
+			func(r *schema.Resource) diag.Diagnostics { return r.ReadContext(context.Background(), nil, nil) }},
+		{telemetry.OperationUpdate,
+			func(r *schema.Resource, fn func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics) {
+				r.UpdateContext = fn
+			},
+			func(r *schema.Resource) diag.Diagnostics { return r.UpdateContext(context.Background(), nil, nil) }},
+		{telemetry.OperationDelete,
+			func(r *schema.Resource, fn func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics) {
+				r.DeleteContext = fn
+			},
+			func(r *schema.Resource) diag.Diagnostics { return r.DeleteContext(context.Background(), nil, nil) }},
+	} {
+		t.Run(string(tc.op), func(t *testing.T) {
+			rec := &recordingReporter{}
+			r := newTestResource()
+			tc.apply(r, func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+				panic("kaboom")
+			})
+			wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+			var diags diag.Diagnostics
+			func() {
+				defer func() {
+					if p := recover(); p != nil {
+						t.Fatalf("panic escaped the wrapper: %v", p)
+					}
+				}()
+				diags = tc.call(r)
+			}()
+
+			if !diags.HasError() {
+				t.Errorf("expected error diagnostics from a recovered panic, got %+v", diags)
+			}
+			if rec.count() != 1 {
+				t.Fatalf("expected exactly 1 crash event, got %d", rec.count())
+			}
+			u := rec.snapshot()[0]
+			if !u.Error {
+				t.Errorf("crash event must have Error=true")
+			}
+			if u.Operation != tc.op {
+				t.Errorf("Operation = %q, want %q", u.Operation, tc.op)
+			}
+			if len(u.StackFrames) == 0 {
+				t.Errorf("crash event must carry stack frames")
+			}
+			// On the panic path we must not reflect over a possibly-torn
+			// ResourceData, so no changed attributes are collected.
+			if u.ChangedAttributes == nil || len(u.ChangedAttributes) != 0 {
+				t.Errorf("crash event ChangedAttributes should be empty non-nil, got %#v", u.ChangedAttributes)
+			}
+		})
+	}
+}
+
+// TestWrapper_RecoversImportPanic asserts the import path recovers a panic,
+// returns an error with no partial result, and reports an IMPORT crash event.
+func TestWrapper_RecoversImportPanic(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	r.Importer.StateContext = func(context.Context, *schema.ResourceData, interface{}) ([]*schema.ResourceData, error) {
+		panic("import kaboom")
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+	var out []*schema.ResourceData
+	var err error
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("panic escaped the import wrapper: %v", p)
+			}
+		}()
+		out, err = r.Importer.StateContext(context.Background(), nil, nil)
+	}()
+
+	if err == nil {
+		t.Errorf("expected an error from a recovered import panic")
+	}
+	if out != nil {
+		t.Errorf("expected nil imported data on panic, got %v", out)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("expected exactly 1 crash event, got %d", rec.count())
+	}
+	u := rec.snapshot()[0]
+	if u.Operation != telemetry.OperationImport || !u.Error || len(u.StackFrames) == 0 {
+		t.Errorf("expected an IMPORT crash event with a stack, got %+v", u)
+	}
+}
+
+// TestWrapper_StackFramesAreRedacted asserts the emitted stack carries no
+// absolute local paths — only shortened file:line frames.
+func TestWrapper_StackFramesAreRedacted(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+		panic("kaboom")
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+	_ = r.CreateContext(context.Background(), nil, nil)
+
+	frames := rec.snapshot()[0].StackFrames
+	if len(frames) == 0 {
+		t.Fatal("expected stack frames")
+	}
+	for _, f := range frames {
+		if strings.HasPrefix(f, "/") {
+			t.Errorf("frame %q is an absolute path", f)
+		}
+		if strings.Contains(f, "/Users/") || strings.Contains(f, "\\Users\\") {
+			t.Errorf("frame %q leaks a local filesystem path", f)
+		}
+		if !strings.Contains(f, ".go:") {
+			t.Errorf("frame %q is not a file:line location", f)
+		}
+	}
+}
+
+// TestWrapper_StackFramesAreCapped asserts a deep stack is truncated to
+// maxStackFrames, so a runaway recursion can't bloat a crash payload.
+func TestWrapper_StackFramesAreCapped(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource()
+	var recurse func(int)
+	recurse = func(n int) {
+		if n == 0 {
+			panic("deep kaboom")
+		}
+		recurse(n - 1)
+	}
+	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+		recurse(maxStackFrames * 4) // far deeper than the cap
+		return nil
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+	_ = r.CreateContext(context.Background(), nil, nil)
+
+	frames := rec.snapshot()[0].StackFrames
+	if len(frames) == 0 {
+		t.Fatal("expected stack frames")
+	}
+	if len(frames) > maxStackFrames {
+		t.Errorf("stack has %d frames, want <= %d (cap not applied)", len(frames), maxStackFrames)
+	}
+}
+
+// TestWrapper_RecoversPanicInReportPath asserts a panic while reporting (here a
+// panicking reporter) after a *successful* CRUD call is contained and never
+// reaches the caller, and the underlying successful result is preserved.
+func TestWrapper_RecoversPanicInReportPath(t *testing.T) {
+	r := newTestResource() // CreateContext is a successful no-op
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(panicReporter{}))
+
+	var diags diag.Diagnostics
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("a panic in the report path escaped: %v", p)
+			}
+		}()
+		diags = r.CreateContext(context.Background(), nil, nil)
+	}()
+	if diags.HasError() {
+		t.Errorf("a successful CRUD call must not be turned into an error by a reporter panic: %+v", diags)
+	}
+}
+
+// TestWrapper_CrashReportPanicIsContained asserts the two recovers are
+// independent: when the wrapped call panics AND the reporter also panics while
+// reporting the crash, both are contained — the call still returns clean error
+// diagnostics and nothing escapes. This is the "endpoint stubbed to fail at
+// panic time" case; the bounded-timeout behavior for a *hung* endpoint is the
+// reporter's own (TFCA-B5's transport), which replaces the no-op reporter used
+// on this path today.
+func TestWrapper_CrashReportPanicIsContained(t *testing.T) {
+	r := newTestResource()
+	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+		panic("kaboom")
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(panicReporter{}))
+
+	var diags diag.Diagnostics
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("a panic escaped when both the call and the reporter panicked: %v", p)
+			}
+		}()
+		diags = r.CreateContext(context.Background(), nil, nil)
+	}()
+	if !diags.HasError() {
+		t.Errorf("expected error diagnostics from the recovered CRUD panic, got %+v", diags)
+	}
+}
+
+// TestWrapper_PanicSkipsChangedAttributeCollection asserts the crash path does
+// not reflect over ResourceData: even when a real, change-bearing ResourceData
+// is supplied to a panicking Create, the emitted crash event carries no changed
+// attributes. This exercises the rec==nil guard specifically — unlike the nil-d
+// cases above, changedAttributeNames on this d WOULD return ["config","topic_name"]
+// if the guard were removed, so the test fails if the guard regresses.
+func TestWrapper_PanicSkipsChangedAttributeCollection(t *testing.T) {
+	rec := &recordingReporter{}
+	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus a scalar.
+	r := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"config":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+			"topic_name": {Type: schema.TypeString, Optional: true},
+		},
+		CreateContext: func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+			panic("kaboom")
+		},
+	}
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_kafka_topic": r}, testWrapConfig(rec))
+
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"config":     map[string]interface{}{"cleanup.policy": "compact"},
+		"topic_name": "orders",
+	})
+
+	var diags diag.Diagnostics
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("panic escaped the wrapper: %v", p)
+			}
+		}()
+		diags = r.CreateContext(context.Background(), d, nil)
+	}()
+	if !diags.HasError() {
+		t.Errorf("expected error diagnostics from a recovered panic")
+	}
+	u := rec.snapshot()[0]
+	if u.ChangedAttributes == nil {
+		t.Errorf("ChangedAttributes must be non-nil so it serializes as [] not null")
+	}
+	if len(u.ChangedAttributes) != 0 {
+		t.Errorf("crash path must not collect changed attributes from ResourceData, got %#v", u.ChangedAttributes)
+	}
+}
+
+// TestReportSafely_ContainsPanics directly exercises reportSafely's recover: a
+// panic while BUILDING the payload and a panic while REPORTING are both
+// contained, so neither can crash the process the wrapper protects. The build
+// case is the payload-construction failure mode (e.g. reflecting over a torn
+// ResourceData) that the second recover exists for.
+func TestReportSafely_ContainsPanics(t *testing.T) {
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("reportSafely let a payload-build panic escape: %v", p)
+			}
+		}()
+		reportSafely(testWrapConfig(&recordingReporter{}), func() telemetry.Usage {
+			panic("build boom")
+		})
+	}()
+
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Fatalf("reportSafely let a reporter panic escape: %v", p)
+			}
+		}()
+		reportSafely(testWrapConfig(panicReporter{}), func() telemetry.Usage {
+			return telemetry.Usage{}
+		})
+	}()
+}
+
+// TestRunGuarded_ClassifiesReturnAndPanic asserts runGuarded distinguishes a
+// normal return from a panic, including the panic(nil) edge case (Go 1.21+ turns
+// it into a *runtime.PanicNilError, so it must still be classified as a panic).
+func TestRunGuarded_ClassifiesReturnAndPanic(t *testing.T) {
+	if rec, stack := runGuarded(func() {}); rec != nil || stack != nil {
+		t.Errorf("normal return: got rec=%v stack=%v, want nil/nil", rec, stack)
+	}
+	if rec, stack := runGuarded(func() { panic("boom") }); rec == nil || len(stack) == 0 {
+		t.Errorf("panic: got rec=%v stack len=%d, want non-nil rec and frames", rec, len(stack))
+	}
+	if rec, _ := runGuarded(func() { panic(nil) }); rec == nil {
+		t.Errorf("panic(nil) must still be classified as a panic (rec != nil)")
+	}
+}

--- a/internal/provider/telemetry_wrapper_panic_test.go
+++ b/internal/provider/telemetry_wrapper_panic_test.go
@@ -400,19 +400,27 @@ func TestWrapper_HappyPathHasNoStackFrames(t *testing.T) {
 // TestShortenSourcePath locks the stack-frame redaction contract deterministically
 // (TestWrapper_StackFramesAreRedacted only checks a live host stack): an absolute
 // path is reduced to its last two segments so the username directory is stripped,
-// and a path already short enough is left untouched.
+// a path already short enough is left untouched, and — failing closed —
+// backslash-separated paths are redacted the same way rather than surviving whole.
 func TestShortenSourcePath(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"/Users/cqin/go/src/x/internal/provider/resource_x.go:123", "provider/resource_x.go:123"},
 		{"/home/jenkins/go/pkg/mod/github.com/foo/bar/baz.go:9", "bar/baz.go:9"},
 		{"provider/resource_x.go:1", "provider/resource_x.go:1"},
 		{"file.go:1", "file.go:1"},
+		{`C:\Users\jane\proj\pkg\main.go:10`, "pkg/main.go:10"}, // fail closed: username stripped
 	} {
-		if got := shortenSourcePath(tc.in); got != tc.want {
+		got := shortenSourcePath(tc.in)
+		if got != tc.want {
 			t.Errorf("shortenSourcePath(%q) = %q, want %q", tc.in, got, tc.want)
 		}
-		if strings.Contains(shortenSourcePath(tc.in), "/Users/") || strings.Contains(shortenSourcePath(tc.in), "/home/") {
-			t.Errorf("shortenSourcePath(%q) leaked a home/user path segment", tc.in)
+		// Structural, separator-agnostic guarantee: at most two segments survive,
+		// so no deep path (and thus no username directory) can leak.
+		if strings.Count(got, "/") > 1 {
+			t.Errorf("shortenSourcePath(%q) = %q kept >2 segments; redaction did not shorten", tc.in, got)
+		}
+		if strings.Contains(got, "Users") || strings.Contains(got, "jane") || strings.Contains(got, "cqin") {
+			t.Errorf("shortenSourcePath(%q) = %q leaked a user path segment", tc.in, got)
 		}
 	}
 }

--- a/internal/provider/telemetry_wrapper_panic_test.go
+++ b/internal/provider/telemetry_wrapper_panic_test.go
@@ -373,3 +373,46 @@ func TestWrapper_PanicErrorSurfacesStack(t *testing.T) {
 		t.Errorf("import panic error should include the panic value and a stack frame, got %v", err)
 	}
 }
+
+// TestWrapper_HappyPathHasNoStackFrames locks the backward-compat invariant that
+// a successful operation never enters the panic-only path: the emitted Usage
+// carries no stack frames (so stack_frames stays omitted on the wire), and the
+// operator error machinery (panicDetail/trimmedStackFrames) runs only on a real
+// panic. Guards against a future change that populated a stack on success.
+func TestWrapper_HappyPathHasNoStackFrames(t *testing.T) {
+	rec := &recordingReporter{}
+	r := newTestResource() // all CRUD/import entry points are successful no-ops
+	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(rec))
+
+	_ = r.CreateContext(context.Background(), nil, nil)
+	_, _ = r.Importer.StateContext(context.Background(), nil, nil)
+
+	for _, u := range rec.snapshot() {
+		if u.StackFrames != nil {
+			t.Errorf("op %s: happy path must not carry stack frames, got %#v", u.Operation, u.StackFrames)
+		}
+		if u.Error {
+			t.Errorf("op %s: happy path must not be flagged as an error", u.Operation)
+		}
+	}
+}
+
+// TestShortenSourcePath locks the stack-frame redaction contract deterministically
+// (TestWrapper_StackFramesAreRedacted only checks a live host stack): an absolute
+// path is reduced to its last two segments so the username directory is stripped,
+// and a path already short enough is left untouched.
+func TestShortenSourcePath(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/Users/cqin/go/src/x/internal/provider/resource_x.go:123", "provider/resource_x.go:123"},
+		{"/home/jenkins/go/pkg/mod/github.com/foo/bar/baz.go:9", "bar/baz.go:9"},
+		{"provider/resource_x.go:1", "provider/resource_x.go:1"},
+		{"file.go:1", "file.go:1"},
+	} {
+		if got := shortenSourcePath(tc.in); got != tc.want {
+			t.Errorf("shortenSourcePath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		if strings.Contains(shortenSourcePath(tc.in), "/Users/") || strings.Contains(shortenSourcePath(tc.in), "/home/") {
+			t.Errorf("shortenSourcePath(%q) leaked a home/user path segment", tc.in)
+		}
+	}
+}

--- a/internal/provider/telemetry_wrapper_panic_test.go
+++ b/internal/provider/telemetry_wrapper_panic_test.go
@@ -30,10 +30,8 @@ type panicReporter struct{}
 
 func (panicReporter) Report(telemetry.Usage) { panic("reporter boom") }
 
-// TestWrapper_RecoversCrudPanic asserts a panic in a wrapped CRUD call is
-// converted to error diagnostics (not propagated), the process does not crash,
-// and exactly one crash event is reported with Error=true, no changed
-// attributes, and a stack trace.
+// TestWrapper_RecoversCrudPanic asserts a CRUD panic becomes error diagnostics
+// (no crash) and reports one crash event with Error=true and a stack trace.
 func TestWrapper_RecoversCrudPanic(t *testing.T) {
 	for _, tc := range []struct {
 		op    telemetry.Operation
@@ -196,9 +194,8 @@ func TestWrapper_StackFramesAreCapped(t *testing.T) {
 	}
 }
 
-// TestWrapper_RecoversPanicInReportPath asserts a panic while reporting (here a
-// panicking reporter) after a *successful* CRUD call is contained and never
-// reaches the caller, and the underlying successful result is preserved.
+// TestWrapper_RecoversPanicInReportPath asserts a panic in the reporter after a
+// successful call is contained, preserving the successful result.
 func TestWrapper_RecoversPanicInReportPath(t *testing.T) {
 	r := newTestResource() // CreateContext is a successful no-op
 	wrapResourcesMapForTelemetry(map[string]*schema.Resource{"confluent_thing": r}, testWrapConfig(panicReporter{}))
@@ -218,12 +215,8 @@ func TestWrapper_RecoversPanicInReportPath(t *testing.T) {
 }
 
 // TestWrapper_CrashReportPanicIsContained asserts the two recovers are
-// independent: when the wrapped call panics AND the reporter also panics while
-// reporting the crash, both are contained — the call still returns clean error
-// diagnostics and nothing escapes. This is the "endpoint stubbed to fail at
-// panic time" case; the bounded-timeout behavior for a *hung* endpoint is the
-// reporter's own (TFCA-B5's transport), which replaces the no-op reporter used
-// on this path today.
+// independent: when both the wrapped call and the reporter panic, both are
+// contained and the call still returns clean error diagnostics.
 func TestWrapper_CrashReportPanicIsContained(t *testing.T) {
 	r := newTestResource()
 	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
@@ -245,12 +238,9 @@ func TestWrapper_CrashReportPanicIsContained(t *testing.T) {
 	}
 }
 
-// TestWrapper_PanicSkipsChangedAttributeCollection asserts the crash path does
-// not reflect over ResourceData: even when a real, change-bearing ResourceData
-// is supplied to a panicking Create, the emitted crash event carries no changed
-// attributes. This exercises the rec==nil guard specifically — unlike the nil-d
-// cases above, changedAttributeNames on this d WOULD return ["config","topic_name"]
-// if the guard were removed, so the test fails if the guard regresses.
+// TestWrapper_PanicSkipsChangedAttributeCollection asserts the crash path collects
+// no changed attributes even when a real, change-bearing ResourceData is supplied
+// to a panicking Create, so it never reflects over a possibly-torn ResourceData.
 func TestWrapper_PanicSkipsChangedAttributeCollection(t *testing.T) {
 	rec := &recordingReporter{}
 	// Schema modeled on confluent_kafka_topic: a TypeMap "config" plus a scalar.
@@ -291,11 +281,8 @@ func TestWrapper_PanicSkipsChangedAttributeCollection(t *testing.T) {
 	}
 }
 
-// TestReportSafely_ContainsPanics directly exercises reportSafely's recover: a
-// panic while BUILDING the payload and a panic while REPORTING are both
-// contained, so neither can crash the process the wrapper protects. The build
-// case is the payload-construction failure mode (e.g. reflecting over a torn
-// ResourceData) that the second recover exists for.
+// TestReportSafely_ContainsPanics asserts reportSafely contains a panic from
+// either building the payload or reporting it.
 func TestReportSafely_ContainsPanics(t *testing.T) {
 	func() {
 		defer func() {
@@ -321,8 +308,7 @@ func TestReportSafely_ContainsPanics(t *testing.T) {
 }
 
 // TestRunGuarded_ClassifiesReturnAndPanic asserts runGuarded distinguishes a
-// normal return from a panic, including the panic(nil) edge case (Go 1.21+ turns
-// it into a *runtime.PanicNilError, so it must still be classified as a panic).
+// normal return from a panic, including panic(nil) (still a panic on Go 1.21+).
 func TestRunGuarded_ClassifiesReturnAndPanic(t *testing.T) {
 	if rec, stack := runGuarded(func() {}); rec != nil || stack != nil {
 		t.Errorf("normal return: got rec=%v stack=%v, want nil/nil", rec, stack)
@@ -336,10 +322,8 @@ func TestRunGuarded_ClassifiesReturnAndPanic(t *testing.T) {
 }
 
 // TestWrapper_PanicErrorSurfacesStack asserts the operator-visible error from a
-// recovered panic carries the trimmed stack (CRUD diagnostics Detail and import
-// error). Before recovery, a panic crashed the provider and Terraform printed the
-// full stack; the stack must not vanish just because the telemetry reporter is a
-// no-op today. It also carries the panic value.
+// recovered panic carries the panic value and the trimmed stack, on both the CRUD
+// diagnostics detail and the import error.
 func TestWrapper_PanicErrorSurfacesStack(t *testing.T) {
 	r := newTestResource()
 	r.CreateContext = func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
@@ -374,11 +358,8 @@ func TestWrapper_PanicErrorSurfacesStack(t *testing.T) {
 	}
 }
 
-// TestWrapper_HappyPathHasNoStackFrames locks the backward-compat invariant that
-// a successful operation never enters the panic-only path: the emitted Usage
-// carries no stack frames (so stack_frames stays omitted on the wire), and the
-// operator error machinery (panicDetail/trimmedStackFrames) runs only on a real
-// panic. Guards against a future change that populated a stack on success.
+// TestWrapper_HappyPathHasNoStackFrames asserts a successful operation emits a
+// Usage with no stack frames, so the panic-only path never runs on success.
 func TestWrapper_HappyPathHasNoStackFrames(t *testing.T) {
 	rec := &recordingReporter{}
 	r := newTestResource() // all CRUD/import entry points are successful no-ops
@@ -397,11 +378,9 @@ func TestWrapper_HappyPathHasNoStackFrames(t *testing.T) {
 	}
 }
 
-// TestShortenSourcePath locks the stack-frame redaction contract deterministically
-// (TestWrapper_StackFramesAreRedacted only checks a live host stack): an absolute
-// path is reduced to its last two segments so the username directory is stripped,
-// a path already short enough is left untouched, and — failing closed —
-// backslash-separated paths are redacted the same way rather than surviving whole.
+// TestShortenSourcePath asserts the redaction contract: an absolute path is reduced
+// to its last two segments (stripping the username), a short path is untouched, and
+// a backslash path is redacted the same way.
 func TestShortenSourcePath(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"/Users/cqin/go/src/x/internal/provider/resource_x.go:123", "provider/resource_x.go:123"},


### PR DESCRIPTION
Release Notes
---------
No change to normal operation. On the rare path where a resource's Create/Read/Update/Delete/Import **panics**, the provider now recovers it and returns a Terraform error for that resource instead of crashing the entire provider process (and with it the whole `terraform` invocation). That error carries a trimmed, path-redacted stack trace, so a recovered panic stays as diagnosable to the operator as the crash it replaces. 

Telemetry reporting remains a no-op until the transport logic land, so this change is currently behaviorally transparent.

Checklist
---------
- [x] I can successfully build and use a custom Terraform provider binary for Confluent. 
- [ ] I have verified my PR with real Confluent Cloud resources in a pre-prod or production environment, or both. (N/A)
- [ ] I have attached manual Terraform verification results or screenshots in the `Test & Review` section below. (N/A)
- [x] I have included appropriate Terraform acceptance or unit tests for any new resource, data source, or functionality. 
- [ ] I have included appropriate Terraform live testing for any new resource, data source, or functionality. (N/A)
- [ ] I have included a testing thread with main.tf file in #terraform-provider-development-testing. (N/A)
- [ ] I have included rate limit/load testing results. (N/A)
- [x] I confirm that this PR introduces no breaking changes or backward compatibility issues.
- [ ] I have updated the corresponding documentation and include relevant examples for this PR. (N/A)
- [x] I have indicated the potential customer impact if something goes wrong in the `Blast Radius` section below.
- [ ] I have put checkmarks below confirming that the feature associated with this PR is enabled in: (N/A)
  - [ ] Confluent Cloud prod
  - [ ] Confluent Cloud stag
  - [ ] Check this box if the feature is enabled for certain organizations only


## What & why

Implements **TFCA-B4** ([APIE-1567](https://confluentinc.atlassian.net/browse/APIE-1567)) — **panic recovery** in the telemetry CRUD/import wrapper, for the TF Provider Client Analytics initiative (INIT-17732). This is the provider's **only** `recover()`: there are zero `recover` calls anywhere under `internal/provider/` today, so an uncaught panic in any resource function currently crashes the whole provider process.

The wrapper introduced by TFCA-B3 now recovers a panic from any wrapped `Create/Read/Update/Delete` or `Importer.StateContext`, converts it to an error result (never propagated), and reports it as a crash event (`Error: true`, with a trimmed stack trace) through the **same reporter seam** as ordinary telemetry — no separate crash path.

## Scope

- **Two independent recovers.**
  - `runGuarded` wraps the inner CRUD/import call. On panic it captures the recovered value plus a trimmed stack, and the wrapper substitutes an error result (`panicDiagnostics` for CRUD, `panicError` for import) in place of the inner return. Named return values let the recovered path override what the caller sees.
  - `reportSafely` wraps the payload build **and** the report/enqueue in its own `recover`. The first recover only guards the inner call, so a panic while reflecting over `ResourceData` or formatting the payload — including **after a successful call** — would otherwise escape and crash the very process this feature protects. A telemetry failure is dropped, never propagated.
- **No `ResourceData` access after a panic.** On the crash path, changed-attribute collection is skipped (`ChangedAttributes` is the empty, non-nil slice), so a torn `ResourceData` is never reflected over.
- **The operator keeps the stack.** The error returned in place of a panic carries the trimmed stack in its detail (`panicDetail`), so a recovered panic is as diagnosable as the pre-change crash (which printed the full stack) — and without relying on the telemetry reporter, which is a no-op until B5. The frames are the same path-redacted ones sent to telemetry, so no absolute local path is surfaced.
- **Stack redaction mirrors the CLI.** `trimmedStackFrames` keeps only `.go:` source locations (so the `funcName(0x…)` argument-register lines are dropped entirely), strips the trailing ` +0x…` PC offset (so a build path containing a space is not truncated), and shortens each frame to its last two path segments — normalizing `\` to `/` first so the redaction **fails closed** regardless of path style — so no absolute local path (e.g. `/Users/<name>/…`) reaches either the operator error or the wire. Capped at `maxStackFrames` (50) so a deep stack can't bloat a report.
- **Happy path unchanged.** `buildUsage` centralizes the `Usage` construction the success paths already did; with `stack == nil` it emits an identical payload (`stack_frames` is `omitempty`). Return values, timing, sequence, and the one-event-per-call contract are all preserved.

Because the reporter is still a no-op here, the crash-report path does no I/O and cannot hang; the "returns within the per-report timeout against a **hung** backend" guarantee is a property of transport and would verified end-to-end once transport is a wired reporter. 

Blast Radius
----
<!--
The Blast Radius section should include information on what will be the customer(s) impact if something goes wrong or unexpectedly, 
adding this section will trigger the PR author to think about the impact from product perspective, examples can be:
- Confluent Cloud customers who are using confluent kafka topic any subcommand will be blocked.
- Confluent Cloud customers who are using confluent kafka topic list commands will be blocked.
- Confluent Platform customers who are using --schema flag will be impacted.
- All customers who are using SSO to login will be impacted.
-->
Internal, additive change with no reporting footprint (the reporter is still a no-op). On the normal path the wrapper is behaviorally transparent: return values, diagnostics, timing, and state handling are unchanged. 

The only behavior change is on the **panic** path, and it is strictly a resilience improvement: a resource operation that panics now surfaces as a Terraform error for that resource instead of crashing the provider process (and the whole run). Worst case if the recovery logic itself misbehaved: a panic that previously crashed the process is turned into an error diagnostic — still safer than the pre-change crash.

## Testing

Backward compatibility is verified against the wrapped provider:
- **`TestAccEnvironment` passes** under the acceptance (mock-server) harness — a full create/read/update/delete/import cycle through the wrapped provider, confirming the panic-recovery wrapper is transparent on the happy path (the same check B3 used).
- **`TestProvider_InternalValidate` passes** — the wrapped provider schema is still valid.
- The existing happy-path wrapper tests (transparency, one-event-per-call, error flag, import, double-wrap, concurrent run IDs/sequences, names-only changed attributes) pass **unmodified**, confirming the success path is unchanged.

`internal/provider/telemetry_wrapper_panic_test.go` covers the acceptance criteria:
- **Recovers a CRUD panic** in each of Create/Read/Update/Delete → error diagnostics, process intact, exactly **one** crash event with `Error=true`, correct operation, a stack trace, and empty (non-nil) `ChangedAttributes` (no `ResourceData` access after a panic).
- **Recovers an import panic** → error returned, nil imported data, one `IMPORT` crash event with a stack.
- **Report-path panic contained** on a *successful* call (a panicking reporter) → the successful result is preserved, nothing escapes.
- **Both recovers together**: the wrapped call panics *and* the reporter panics while reporting the crash → still returns clean error diagnostics, nothing escapes (the "endpoint fails at panic time" case).
- **Stack redaction** asserted on the emitted payload: no absolute / `/Users/` paths, every frame a `file:line` `.go:` location.
- **Stack cap**: a deeply recursive panic yields `<= maxStackFrames` frames.
- **Operator-facing error carries the stack**: the CRUD diagnostic detail and the import error both include the panic value and a `.go:` frame, with no absolute/`/Users/` path.
- **Happy path carries no stack**: a successful CRUD/import emits a `Usage` with `nil` `StackFrames` and `Error=false`, so the panic-only path never runs on success.
- **Redaction contract** (`shortenSourcePath`): asserted deterministically on synthetic inputs — an absolute path is reduced to its last two segments (username directory stripped), a short path is untouched, and a backslash path fails closed the same way.

All green under `-race`. No new dependencies; no change to `go.mod`/`go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APIE-1567]: https://confluentinc.atlassian.net/browse/APIE-1567
