### PR TITLE
Fix release pipeline wedging on an already-pushed version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ TEST?=./...
 NAME        := terraform-provider-confluent
 # Build variables
 BUILD_DIR   := bin
-VERSION     ?= $(shell git tag --sort=-creatordate | grep -v ".*deleted" | head -n 1)
+# Newest release tag, read from origin (not the local clone): CI only fetches tags reachable from the
+# built branch, so a tag already pushed onto an off-branch commit stays invisible locally, gets
+# recomputed, then fails to push as "already exists" and wedges the release. sort -V picks the max;
+# the $$-anchored match keeps only bare vX.Y.Z, skipping "-deleted" and peeled "^{}" refs.
+VERSION     ?= $(shell git ls-remote --tags origin 2>/dev/null | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -n 1)
 # Go variables
 GOENV         := GO111MODULE=on
 GOCMD         := $(GOENV) go

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,17 @@ TEST?=./...
 NAME        := terraform-provider-confluent
 # Build variables
 BUILD_DIR   := bin
-# Newest release tag, read from origin (not the local clone): CI only fetches tags reachable from the
-# built branch, so a tag already pushed onto an off-branch commit stays invisible locally, gets
-# recomputed, then fails to push as "already exists" and wedges the release. sort -V picks the max;
-# the $$-anchored match keeps only bare vX.Y.Z, skipping "-deleted" and peeled "^{}" refs.
+# The release path (release-ci) runs only under CI, the only place the next version is pushed as a
+# tag. There, read the newest tag from origin, not the local clone: CI fetches only tags reachable
+# from the built branch, so a tag already pushed onto an off-branch commit is invisible locally, gets
+# recomputed, and fails to push as "already exists", wedging the release. Off CI keep the local-tag
+# lookup: VERSION is expanded at parse time (via CLEAN_VERSION :=), so an unconditional ls-remote
+# would hit the network on every make target. sort -V = max; $$-anchor skips "-deleted"/peeled refs.
+ifeq ($(CI),true)
 VERSION     ?= $(shell git ls-remote --tags origin 2>/dev/null | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -n 1)
+else
+VERSION     ?= $(shell git tag --sort=-creatordate | grep -v ".*deleted" | head -n 1)
+endif
 # Go variables
 GOENV         := GO111MODULE=on
 GOCMD         := $(GOENV) go


### PR DESCRIPTION
## Problem

Every push to `master` runs `make release-ci` → `tag-release`, which creates and pushes the next version tag. The next version is derived in the `Makefile` from:

```make
VERSION ?= $(shell git tag --sort=-creatordate | grep -v ".*deleted" | head -n 1)
```

`git tag` here lists only the tags present in the CI checkout, and CI fetches only tags reachable from the built branch. If a previous release pushed a tag onto a commit that never landed on `master` — e.g. the follow-up `git push origin master` in `tag-release` lost a race to a concurrent merge and was swallowed by `|| true` — that tag becomes invisible to later builds. They recompute the **same** version, and `git push origin <tag>` is rejected as `already exists`, so **every subsequent `master` build fails at `tag-release`** until a `#minor` release happens to leapfrog the stranded patch number.

This actually happened: an orphaned `v2.85.1` tag (a patch bump commit that never reached `master`, never published to the registry or as a GitHub release) wedged every `master` build for ~2 weeks. It only cleared when `v2.86.0` was released and jumped past it.

## Fix

Compute the newest tag from `git ls-remote --tags origin` instead of the local checkout, so the bump is based on what actually exists on the remote. An already-pushed tag now advances the version instead of colliding with it.

```make
VERSION ?= $(shell git ls-remote --tags origin 2>/dev/null | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -n 1)
```

- `sort -V | tail -n 1` selects the highest semver rather than newest-by-creation-date — equivalent in the happy path, and more correct when tags land out of creation order.
- The `$$` end-anchor keeps only bare `vX.Y.Z`, so `-deleted` tags (the repo's soft-delete convention) and peeled `^{}` refs are skipped — preserving the old `grep -v ".*deleted"` behavior.

## Verification

- Ran the extracted pipeline against `origin`: resolves to `v2.86.0` (current remote max), so the next patch build computes `v2.86.1` — no collision.
- No behavior change in the normal case: on an up-to-date checkout the remote max equals the local max.
- I could not run `make` locally (project requires gmake, not installed here), so this validates the shell command directly; `$$` is standard make escaping for a literal `$`.

## Out of scope

- The root of the *orphaning* — `git push origin $(MASTER_BRANCH) || true` in `tag-release` silently swallowing a failed master push — is left as-is. This PR stops that from wedging the pipeline regardless of whether the master push lands.
- Cleaning up the leftover `v2.85.1` / `v2.85.1-deleted` orphan tags can be a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
