### PR TITLE
#minor Prepare for 2.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.86.0 (September 10th, 2026)
+## 2.86.0 (September 10th, 2026) 
 
 [Full Changelog](https://github.com/confluentinc/terraform-provider-confluent/compare/v2.85.0...v2.86.0)
 


### PR DESCRIPTION
Dummy PR: adds a trailing space to `CHANGELOG.md` to prepare a release-prep commit for 2.86.0. No functional changes.